### PR TITLE
fix gemini api response error

### DIFF
--- a/src/main/java/com/kairos/infrastructure/graph/KnowledgeGraphStoreAdapter.java
+++ b/src/main/java/com/kairos/infrastructure/graph/KnowledgeGraphStoreAdapter.java
@@ -54,7 +54,7 @@ public class KnowledgeGraphStoreAdapter implements KnowledgeGraphStore {
     @Transactional
     public void saveAllForChunk(UUID chunkId, List<KnowledgeTriple> triples) {
         if (chunkId == null) {
-            log.error("Cannot save triples because chunkId is null.");
+            log.error("Attempted to save triples with null chunkId. This indicates a bug in the calling flow.");
             return;
         }
 
@@ -77,7 +77,7 @@ public class KnowledgeGraphStoreAdapter implements KnowledgeGraphStore {
 
     private void ensurePassageNode(UUID chunkId) {
         if (chunkId == null) {
-            log.error("Cannot ensure PassageNode because chunkId is null.");
+            log.error("Defensive check failed: chunkId is null in ensurePassageNode.");
             return;
         }
 

--- a/src/main/java/com/kairos/infrastructure/graph/KnowledgeGraphStoreAdapter.java
+++ b/src/main/java/com/kairos/infrastructure/graph/KnowledgeGraphStoreAdapter.java
@@ -53,6 +53,11 @@ public class KnowledgeGraphStoreAdapter implements KnowledgeGraphStore {
     @Override
     @Transactional
     public void saveAllForChunk(UUID chunkId, List<KnowledgeTriple> triples) {
+        if (chunkId == null) {
+            log.error("Cannot save triples because chunkId is null.");
+            return;
+        }
+
         if (triples == null || triples.isEmpty()) {
             log.warn("No triples to save for chunkId: {}", chunkId);
             return;
@@ -71,6 +76,11 @@ public class KnowledgeGraphStoreAdapter implements KnowledgeGraphStore {
     }
 
     private void ensurePassageNode(UUID chunkId) {
+        if (chunkId == null) {
+            log.error("Cannot ensure PassageNode because chunkId is null.");
+            return;
+        }
+
         if (!passageRepository.existsById(chunkId)) {
             log.debug("Creating new PassageNode for chunk: {}", chunkId);
             passageRepository.save(PassageNode.forChunk(chunkId));

--- a/src/test/java/com/kairos/infrastructure/graph/KnowledgeGraphStoreAdapterTest.java
+++ b/src/test/java/com/kairos/infrastructure/graph/KnowledgeGraphStoreAdapterTest.java
@@ -99,6 +99,14 @@ class KnowledgeGraphStoreAdapterTest {
         verify(passageRepository, never()).existsById(any());
     }
 
+    @Test
+    @DisplayName("saveAllForChunk — does nothing when chunkId is null")
+    void saveAllForChunk_nullChunkId_noInteractions() {
+        adapter.saveAllForChunk(null, List.of(triple("a", "REL", "b", UUID.randomUUID())));
+
+        verifyNoInteractions(phraseRepository, passageRepository);
+    }
+
     // -------------------------------------------------------------------------
     // save (batch with chunkId inside triple)
     // -------------------------------------------------------------------------


### PR DESCRIPTION
This pull request adds defensive checks to ensure that a `null` `chunkId` is handled gracefully in the `KnowledgeGraphStoreAdapter`, preventing possible bugs or unintended behavior. Additionally, a new unit test verifies that the method does nothing when `chunkId` is `null`.

Defensive programming improvements:

* Added a check in `saveAllForChunk` to log an error and return early if `chunkId` is `null`, preventing further processing with invalid input.
* Added a similar check in `ensurePassageNode` to log an error and exit if `chunkId` is `null`, avoiding repository operations with invalid IDs.

Testing improvements:

* Added a unit test to verify that `saveAllForChunk` does nothing and interacts with no repositories when `chunkId` is `null`.