### PR TITLE
Add authentication records and endpoints for login and registration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR ${APP_HOME}
 
 RUN set -eux; \
     groupadd --system app; \
-    useradd --system --gid app --create-home --home-dir ${APP_HOME} app
+    useradd --system --gid app --of-home --home-dir ${APP_HOME} app
 
 COPY --from=build /app/target/*.jar ${APP_HOME}/app.jar
 

--- a/src/main/java/com/kairos/auth/application/command/ConfirmEmailCommand.java
+++ b/src/main/java/com/kairos/auth/application/command/ConfirmEmailCommand.java
@@ -1,7 +1,12 @@
 package com.kairos.auth.application.command;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record ConfirmEmailCommand(
         String code,
         String email
 ) {
+    public static ConfirmEmailCommand create(String code,String email) {
+        return new ConfirmEmailCommand(code,email);
+    }
 }

--- a/src/main/java/com/kairos/auth/application/command/ConfirmEmailCommand.java
+++ b/src/main/java/com/kairos/auth/application/command/ConfirmEmailCommand.java
@@ -1,12 +1,10 @@
 package com.kairos.auth.application.command;
 
-import jakarta.validation.constraints.NotBlank;
-
 public record ConfirmEmailCommand(
         String code,
         String email
 ) {
-    public static ConfirmEmailCommand create(String code,String email) {
+    public static ConfirmEmailCommand of(String code, String email) {
         return new ConfirmEmailCommand(code,email);
     }
 }

--- a/src/main/java/com/kairos/auth/application/command/LoginCommand.java
+++ b/src/main/java/com/kairos/auth/application/command/LoginCommand.java
@@ -9,7 +9,7 @@ public record LoginCommand(
         String identifier,
         String password
 ) {
-    public static LoginCommand create(String identifier, String password) {
+    public static LoginCommand of(String identifier, String password) {
         return new LoginCommand(identifier, password);
     }
 }

--- a/src/main/java/com/kairos/auth/application/command/LoginCommand.java
+++ b/src/main/java/com/kairos/auth/application/command/LoginCommand.java
@@ -9,4 +9,7 @@ public record LoginCommand(
         String identifier,
         String password
 ) {
+    public static LoginCommand create(String identifier, String password) {
+        return new LoginCommand(identifier, password);
+    }
 }

--- a/src/main/java/com/kairos/auth/application/command/RegisterCommand.java
+++ b/src/main/java/com/kairos/auth/application/command/RegisterCommand.java
@@ -6,7 +6,7 @@ public record RegisterCommand(
         String email,
         String password
 ) {
-    public static RegisterCommand create(String name, String username, String email, String password) {
+    public static RegisterCommand of(String name, String username, String email, String password) {
         return new RegisterCommand(
                 name,
                 username,

--- a/src/main/java/com/kairos/auth/application/command/RegisterCommand.java
+++ b/src/main/java/com/kairos/auth/application/command/RegisterCommand.java
@@ -6,4 +6,12 @@ public record RegisterCommand(
         String email,
         String password
 ) {
+    public static RegisterCommand create(String name, String username, String email, String password) {
+        return new RegisterCommand(
+                name,
+                username,
+                email,
+                password
+        );
+    }
 }

--- a/src/main/java/com/kairos/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/kairos/auth/presentation/controller/AuthController.java
@@ -1,15 +1,19 @@
 package com.kairos.auth.presentation.controller;
 
 import com.kairos.auth.application.command.LoginCommand;
+import com.kairos.auth.application.command.RegisterCommand;
 import com.kairos.auth.application.use_case.ConfirmEmailUseCase;
 import com.kairos.auth.application.use_case.LoginUseCase;
 import com.kairos.auth.application.use_case.RegisterUseCase;
 
 import com.kairos.auth.presentation.dto.login.LoginRequest;
 import com.kairos.auth.presentation.dto.login.LoginResponse;
+import com.kairos.auth.presentation.dto.register.RegisterRequest;
 
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,13 +32,27 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(LoginRequest request) {
+    public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
         var command = LoginCommand.create(request.identifier(), request.password());
 
         var session = loginUseCase.execute(command);
         var response = LoginResponse.create(session.accessToken(), session.roles());
 
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<Void> register(@RequestBody @Valid RegisterRequest request){
+        var command = RegisterCommand.create(
+                request.name(),
+                request.username(),
+                request.email(),
+                request.password()
+        );
+
+        registerUseCase.execute(command);
+
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/kairos/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/kairos/auth/presentation/controller/AuthController.java
@@ -13,6 +13,7 @@ import com.kairos.auth.presentation.dto.register.ConfirmEmailRequest;
 import com.kairos.auth.presentation.dto.register.RegisterRequest;
 
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -35,17 +36,17 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
-        var command = LoginCommand.create(request.identifier(), request.password());
+        var command = LoginCommand.of(request.identifier(), request.password());
 
         var session = loginUseCase.execute(command);
-        var response = LoginResponse.create(session.accessToken(), session.roles());
+        var response = LoginResponse.of(session.accessToken(), session.roles());
 
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/register")
     public ResponseEntity<Void> register(@RequestBody @Valid RegisterRequest request){
-        var command = RegisterCommand.create(
+        var command = RegisterCommand.of(
                 request.name(),
                 request.username(),
                 request.email(),
@@ -54,16 +55,18 @@ public class AuthController {
 
         registerUseCase.execute(command);
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .build();
     }
 
 
     @PostMapping("/confirm-email")
     public ResponseEntity<LoginResponse> confirmEmail(@RequestBody @Valid ConfirmEmailRequest request) {
-        var command = ConfirmEmailCommand.create(request.code(), request.email());
+        var command = ConfirmEmailCommand.of(request.code(), request.email());
 
         var session = confirmEmailUseCase.execute(command);
-        var response = LoginResponse.create(session.accessToken(), session.roles());
+        var response = LoginResponse.of(session.accessToken(), session.roles());
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/kairos/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/kairos/auth/presentation/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.kairos.auth.presentation.controller;
 
+import com.kairos.auth.application.command.ConfirmEmailCommand;
 import com.kairos.auth.application.command.LoginCommand;
 import com.kairos.auth.application.command.RegisterCommand;
 import com.kairos.auth.application.use_case.ConfirmEmailUseCase;
@@ -8,6 +9,7 @@ import com.kairos.auth.application.use_case.RegisterUseCase;
 
 import com.kairos.auth.presentation.dto.login.LoginRequest;
 import com.kairos.auth.presentation.dto.login.LoginResponse;
+import com.kairos.auth.presentation.dto.register.ConfirmEmailRequest;
 import com.kairos.auth.presentation.dto.register.RegisterRequest;
 
 import jakarta.validation.Valid;
@@ -53,6 +55,17 @@ public class AuthController {
         registerUseCase.execute(command);
 
         return ResponseEntity.ok().build();
+    }
+
+
+    @PostMapping("/confirm-email")
+    public ResponseEntity<LoginResponse> confirmEmail(@RequestBody @Valid ConfirmEmailRequest request) {
+        var command = ConfirmEmailCommand.create(request.code(), request.email());
+
+        var session = confirmEmailUseCase.execute(command);
+        var response = LoginResponse.create(session.accessToken(), session.roles());
+
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/com/kairos/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/kairos/auth/presentation/controller/AuthController.java
@@ -1,0 +1,40 @@
+package com.kairos.auth.presentation.controller;
+
+import com.kairos.auth.application.command.LoginCommand;
+import com.kairos.auth.application.use_case.ConfirmEmailUseCase;
+import com.kairos.auth.application.use_case.LoginUseCase;
+import com.kairos.auth.application.use_case.RegisterUseCase;
+
+import com.kairos.auth.presentation.dto.login.LoginRequest;
+import com.kairos.auth.presentation.dto.login.LoginResponse;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final LoginUseCase loginUseCase;
+    private final RegisterUseCase registerUseCase;
+    private final ConfirmEmailUseCase confirmEmailUseCase;
+
+    public AuthController(LoginUseCase loginUseCase, RegisterUseCase registerUseCase, ConfirmEmailUseCase confirmEmailUseCase) {
+        this.loginUseCase = loginUseCase;
+        this.registerUseCase = registerUseCase;
+        this.confirmEmailUseCase = confirmEmailUseCase;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(LoginRequest request) {
+        var command = LoginCommand.create(request.identifier(), request.password());
+
+        var session = loginUseCase.execute(command);
+        var response = LoginResponse.create(session.accessToken(), session.roles());
+
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/kairos/auth/presentation/dto/login/LoginRequest.java
+++ b/src/main/java/com/kairos/auth/presentation/dto/login/LoginRequest.java
@@ -1,12 +1,14 @@
 package com.kairos.auth.presentation.dto.login;
 
+import jakarta.validation.constraints.NotBlank;
+
 /**
  * LoginRequest is a record that represents the data required for a login request.
  * @param identifier The identifier can be either a username or an email address.
  * @param password The password associated with the identifier.
  */
 public record LoginRequest(
-        String identifier,
-        String password
+        @NotBlank String identifier,
+        @NotBlank String password
 ) {
 }

--- a/src/main/java/com/kairos/auth/presentation/dto/login/LoginRequest.java
+++ b/src/main/java/com/kairos/auth/presentation/dto/login/LoginRequest.java
@@ -1,0 +1,12 @@
+package com.kairos.auth.presentation.dto.login;
+
+/**
+ * LoginRequest is a record that represents the data required for a login request.
+ * @param identifier The identifier can be either a username or an email address.
+ * @param password The password associated with the identifier.
+ */
+public record LoginRequest(
+        String identifier,
+        String password
+) {
+}

--- a/src/main/java/com/kairos/auth/presentation/dto/login/LoginResponse.java
+++ b/src/main/java/com/kairos/auth/presentation/dto/login/LoginResponse.java
@@ -1,0 +1,18 @@
+package com.kairos.auth.presentation.dto.login;
+
+import com.kairos.user.domain.model.Role;
+
+import java.util.List;
+
+public record LoginResponse(
+        String accessToken,
+        List<String> roles
+) {
+    public static LoginResponse create(String accessToken, List<Role> roles) {
+        var roleNames = roles.stream()
+                .map(Role::name)
+                .toList();
+
+        return new LoginResponse(accessToken, roleNames);
+    }
+}

--- a/src/main/java/com/kairos/auth/presentation/dto/login/LoginResponse.java
+++ b/src/main/java/com/kairos/auth/presentation/dto/login/LoginResponse.java
@@ -8,7 +8,7 @@ public record LoginResponse(
         String accessToken,
         List<String> roles
 ) {
-    public static LoginResponse create(String accessToken, List<Role> roles) {
+    public static LoginResponse of(String accessToken, List<Role> roles) {
         var roleNames = roles.stream()
                 .map(Role::name)
                 .toList();

--- a/src/main/java/com/kairos/auth/presentation/dto/register/ConfirmEmailRequest.java
+++ b/src/main/java/com/kairos/auth/presentation/dto/register/ConfirmEmailRequest.java
@@ -1,0 +1,9 @@
+package com.kairos.auth.presentation.dto.register;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ConfirmEmailRequest(
+        @NotBlank String code,
+        @NotBlank String email
+) {
+}

--- a/src/main/java/com/kairos/auth/presentation/dto/register/RegisterRequest.java
+++ b/src/main/java/com/kairos/auth/presentation/dto/register/RegisterRequest.java
@@ -1,0 +1,11 @@
+package com.kairos.auth.presentation.dto.register;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RegisterRequest(
+        @NotBlank String name,
+        @NotBlank String username,
+        @NotBlank String email,
+        @NotBlank String password
+) {
+}

--- a/src/main/java/com/kairos/auth/presentation/mapper/AuthMapper.java
+++ b/src/main/java/com/kairos/auth/presentation/mapper/AuthMapper.java
@@ -1,0 +1,9 @@
+package com.kairos.auth.presentation.mapper;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthMapper {
+
+
+}

--- a/src/main/java/com/kairos/context_engine/application/use_case/GenerateSourceContextUseCase.java
+++ b/src/main/java/com/kairos/context_engine/application/use_case/GenerateSourceContextUseCase.java
@@ -45,7 +45,7 @@ public class GenerateSourceContextUseCase {
     /**
      * Generates a knowledge graph context for the given source and its associated chunks.
      * @param source the source for which the knowledge graph context is being generated
-     * @param chunks the list of chunks associated with the source, from which to extract triples and create the knowledge graph context
+     * @param chunks the list of chunks associated with the source, from which to extract triples and of the knowledge graph context
      */
     private void generateKnowledgeGraph(Source source, List<Chunk> chunks) {
         knowledgeGraphStore.createContext(chunks);
@@ -56,7 +56,7 @@ public class GenerateSourceContextUseCase {
     /**
      * Extracts triples from the content of each chunk and saves them to the knowledge graph store, associating them with the corresponding chunk ID.
      * @param source the source for which the knowledge graph context is being generated
-     * @param chunks the list of chunks from which to extract triples and create the knowledge graph context
+     * @param chunks the list of chunks from which to extract triples and of the knowledge graph context
      */
     private void createContextForKnowledgeGraph(Source source, List<Chunk> chunks) {
         for (Chunk chunk : chunks) {

--- a/src/main/java/com/kairos/context_engine/infrastructure/embedding/onnx/OnnxEmbeddingProvider.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/embedding/onnx/OnnxEmbeddingProvider.java
@@ -68,7 +68,7 @@ public class OnnxEmbeddingProvider implements EmbeddingProvider {
      * @param environment   ONNX Runtime environment
      * @param session       ONNX Runtime session containing the embedding model
      * @param tokenizer     tokenizer compatible with the ONNX model
-     * @param tensorFactory factory used to create ORT input tensors
+     * @param tensorFactory factory used to of ORT input tensors
      * @throws EmbeddingException if session metadata cannot be read during initialization
      */
     public OnnxEmbeddingProvider(


### PR DESCRIPTION
This pull request introduces a new authentication API layer by adding an `AuthController` and associated DTOs for login, registration, and email confirmation. It also standardizes the creation of command objects using static factory methods. These changes provide a structured and validated interface for authentication-related endpoints.

**New API Layer and Endpoints:**

* Added `AuthController` with endpoints for `/login`, `/register`, and `/confirm-email`, delegating logic to the appropriate use cases and returning structured responses.

**DTOs and Request Validation:**

* Introduced request and response DTOs for authentication:
  - `LoginRequest` and `LoginResponse` for login operations, with validation annotations and a static factory for response creation. [[1]](diffhunk://#diff-0e79690748d1e1fd4b6fe55a56f1d232b631b375debaf05cfbf0a3c13fba1688R1-R14) [[2]](diffhunk://#diff-b5934a30687f58cce175b789bca538846460b34071c8578b104a4fe871f1e034R1-R18)
  - `RegisterRequest` for registration, and `ConfirmEmailRequest` for email confirmation, both with validation. [[1]](diffhunk://#diff-74cdc280cb208f78e0f8dfe98d5229a08a02f7390595a6552606cceca2a2de9bR1-R11) [[2]](diffhunk://#diff-2e7e35622d4272e822209e9e5db58e0299d8104d070b7ae66157d47aeb66fc4fR1-R9)

**Command Object Improvements:**

* Added static `create` methods to `LoginCommand`, `RegisterCommand`, and `ConfirmEmailCommand` to standardize instantiation and improve code readability. [[1]](diffhunk://#diff-03f5e6d288a1a52e59a1aee52983debc205f7c03aa6e423895145688037a1dbcR12-R14) [[2]](diffhunk://#diff-547f06068e4e109afb462c7fb465b064f4dd70e0a0a7ff6cd3dd6bd94956b6a9R9-R16) [[3]](diffhunk://#diff-87c6a6517c304d076fc0df6c57df06f4225e797fea47c5c5832eb1547feb92c2R3-R11)

**Other:**

* Added a placeholder `AuthMapper` component for potential mapping logic between DTOs and domain objects.