### PR TITLE
Refactor knowledge graph model for HippoRAG foundation

### DIFF
--- a/src/main/java/com/kairos/context_engine/application/use_case/GenerateSourceContextUseCase.java
+++ b/src/main/java/com/kairos/context_engine/application/use_case/GenerateSourceContextUseCase.java
@@ -5,6 +5,7 @@ import com.kairos.context_engine.domain.model.content.TripleExtracted;
 import com.kairos.context_engine.domain.port.embedding.EmbeddingProvider;
 import com.kairos.context_engine.domain.model.content.Chunk;
 import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.Passage;
 import com.kairos.context_engine.domain.model.content.Source;
 import com.kairos.context_engine.domain.model.Triple;
 import com.kairos.context_engine.domain.port.extraction.TripleExtractor;
@@ -51,8 +52,8 @@ public class GenerateSourceContextUseCase {
      * @param chunks the list of chunks associated with the source, from which to extract triples and of the knowledge graph context
      */
     private void generateKnowledgeGraph(Source source, List<Chunk> chunks) {
-        knowledgeGraphStore.createContext(chunks);
-        createContextForKnowledgeGraph(source,chunks);
+        knowledgeGraphStore.createContext(chunks); // TODO: this is a bad abstraction. First we to create a series of passages nodes and this will be the foundation of context.
+        createContextForKnowledgeGraph(source,chunks); // TODO: this is a causal bad abstraction. This parte will create the relationships and structure of the foundation create before.
     }
 
 
@@ -64,13 +65,14 @@ public class GenerateSourceContextUseCase {
     private void createContextForKnowledgeGraph(Source source, List<Chunk> chunks) {
         for (Chunk chunk : chunks) {
             List<Triple> triples = tripleExtractor.extract(chunk.getContent());
+            Passage passage = Passage.fromChunkId(chunk.getId());
 
             List<TripleExtracted> extractedTriples = triples.stream()
                     .map(triple -> this.createEmbeddingTriple(triple, chunk))
                     .toList();
 
             List<KnowledgeTriple> knowledgeTriples = triples.stream()
-                    .map(triple -> KnowledgeTriple.create(triple, chunk.getId()))
+                    .map(triple -> KnowledgeTriple.create(triple, passage))
                     .toList();
 
             tripleRepository.saveAll(extractedTriples);

--- a/src/main/java/com/kairos/context_engine/application/use_case/GenerateSourceContextUseCase.java
+++ b/src/main/java/com/kairos/context_engine/application/use_case/GenerateSourceContextUseCase.java
@@ -4,7 +4,7 @@ import com.kairos.context_engine.application.command.GenerateSourceContextComman
 import com.kairos.context_engine.domain.model.content.TripleExtracted;
 import com.kairos.context_engine.domain.port.embedding.EmbeddingProvider;
 import com.kairos.context_engine.domain.model.content.Chunk;
-import com.kairos.context_engine.domain.model.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 import com.kairos.context_engine.domain.model.content.Source;
 import com.kairos.context_engine.domain.model.Triple;
 import com.kairos.context_engine.domain.port.extraction.TripleExtractor;
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/kairos/context_engine/application/use_case/SearchSourceUseCase.java
+++ b/src/main/java/com/kairos/context_engine/application/use_case/SearchSourceUseCase.java
@@ -4,7 +4,7 @@ import com.kairos.context_engine.application.query.SearchSourceQuery;
 import com.kairos.context_engine.domain.port.embedding.EmbeddingProvider;
 import com.kairos.context_engine.domain.port.graph.KnowledgeGraphSearch;
 import com.kairos.context_engine.domain.model.content.Chunk;
-import com.kairos.context_engine.domain.model.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 import com.kairos.context_engine.domain.model.SearchResult;
 import com.kairos.context_engine.domain.port.semantic.SemanticSearch;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/kairos/context_engine/application/use_case/SearchSourceUseCase.java
+++ b/src/main/java/com/kairos/context_engine/application/use_case/SearchSourceUseCase.java
@@ -56,7 +56,7 @@ public class SearchSourceUseCase {
         List<KnowledgeTriple> triples = knowledgeGraphSearch.expandKnowledge(semanticAnchors);
 
         List<UUID> orderedChunkIds = triples.stream()
-                .map(KnowledgeTriple::chunkId)
+                .map(triple -> triple.passage().chunkId())
                 .distinct()
                 .toList();
 

--- a/src/main/java/com/kairos/context_engine/application/use_case/SearchSourceUseCase.java
+++ b/src/main/java/com/kairos/context_engine/application/use_case/SearchSourceUseCase.java
@@ -69,7 +69,7 @@ public class SearchSourceUseCase {
      * Hydrates the chunk payloads from the semantic store and enforces the relevance ranking
      * established by the knowledge graph expansion phase.
      *
-     * @param orderedChunkIds a list of UUIDs strictly ordered by graph centrality/relevance.
+     * @param orderedChunkIds a list of UUIDs strictly ordered by graph relevance.
      * @return a list of fully hydrated {@link Chunk} objects preserving the input order.
      */
     private List<Chunk> fetchAndSortExpandedContext(List<UUID> orderedChunkIds) {

--- a/src/main/java/com/kairos/context_engine/domain/model/SearchResult.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/SearchResult.java
@@ -1,6 +1,7 @@
 package com.kairos.context_engine.domain.model;
 
 import com.kairos.context_engine.domain.model.content.Chunk;
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 
 import java.util.List;
 

--- a/src/main/java/com/kairos/context_engine/domain/model/Triple.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/Triple.java
@@ -6,4 +6,7 @@ public record Triple(
         String object,
         double weight
 ) {
+    public Triple(String subject, String predicate, String object) {
+        this(subject, predicate, object, 1.0);
+    }
 }

--- a/src/main/java/com/kairos/context_engine/domain/model/Triple.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/Triple.java
@@ -3,6 +3,7 @@ package com.kairos.context_engine.domain.model;
 public record Triple(
         String subject,
         String predicate,
-        String object
+        String object,
+        double weight
 ) {
 }

--- a/src/main/java/com/kairos/context_engine/domain/model/knowledge/Concept.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/knowledge/Concept.java
@@ -3,6 +3,14 @@ package com.kairos.context_engine.domain.model.knowledge;
 public record Concept(
         String name
 ) {
+    public Concept {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Concept name cannot be null or blank");
+        }
+
+        name = name.trim();
+    }
+
     public static Concept create(String name) {
         return new Concept(name);
     }

--- a/src/main/java/com/kairos/context_engine/domain/model/knowledge/Concept.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/knowledge/Concept.java
@@ -1,11 +1,9 @@
 package com.kairos.context_engine.domain.model.knowledge;
 
 public record Concept(
-        String name,
-        double centrality,
-        int degree
+        String name
 ) {
     public static Concept create(String name) {
-        return new Concept(name, 0, 0);
+        return new Concept(name);
     }
 }

--- a/src/main/java/com/kairos/context_engine/domain/model/knowledge/Concept.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/knowledge/Concept.java
@@ -1,4 +1,4 @@
-package com.kairos.context_engine.domain.model;
+package com.kairos.context_engine.domain.model.knowledge;
 
 public record Concept(
         String name,

--- a/src/main/java/com/kairos/context_engine/domain/model/knowledge/KnowledgeTriple.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/knowledge/KnowledgeTriple.java
@@ -2,31 +2,29 @@ package com.kairos.context_engine.domain.model.knowledge;
 
 import com.kairos.context_engine.domain.model.Triple;
 
-import java.util.UUID;
-
 public record KnowledgeTriple(
         Concept subject,
         String predicate,
         Concept object,
-        UUID chunkId,
+        Passage passage,
         double weight
 ) {
-    public static KnowledgeTriple create(Triple triple, UUID chunkId) {
+    public static KnowledgeTriple create(Triple triple, Passage passage) {
         return new KnowledgeTriple(
                 Concept.create(triple.subject()),
                 triple.predicate(),
                 Concept.create(triple.object()),
-                chunkId,
+                passage,
                 triple.weight()
         );
     }
 
-    public static KnowledgeTriple create(String subject, String predicate, String object, UUID chunkId, double weight) {
+    public static KnowledgeTriple create(String subject, String predicate, String object, Passage passage, double weight) {
         return new KnowledgeTriple(
                 Concept.create(subject),
                 predicate,
                 Concept.create(object),
-                chunkId,
+                passage,
                 weight
         );
     }

--- a/src/main/java/com/kairos/context_engine/domain/model/knowledge/KnowledgeTriple.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/knowledge/KnowledgeTriple.java
@@ -1,4 +1,6 @@
-package com.kairos.context_engine.domain.model;
+package com.kairos.context_engine.domain.model.knowledge;
+
+import com.kairos.context_engine.domain.model.Triple;
 
 import java.util.UUID;
 
@@ -6,23 +8,26 @@ public record KnowledgeTriple(
         Concept subject,
         String predicate,
         Concept object,
-        UUID chunkId
+        UUID chunkId,
+        double weight
 ) {
     public static KnowledgeTriple create(Triple triple, UUID chunkId) {
         return new KnowledgeTriple(
                 Concept.create(triple.subject()),
                 triple.predicate(),
                 Concept.create(triple.object()),
-                chunkId
+                chunkId,
+                triple.weight()
         );
     }
 
-    public static KnowledgeTriple create(String subject, String predicate, String object, UUID chunkId) {
+    public static KnowledgeTriple create(String subject, String predicate, String object, UUID chunkId, double weight) {
         return new KnowledgeTriple(
                 Concept.create(subject),
                 predicate,
                 Concept.create(object),
-                chunkId
+                chunkId,
+                weight
         );
     }
 }

--- a/src/main/java/com/kairos/context_engine/domain/model/knowledge/Passage.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/knowledge/Passage.java
@@ -1,0 +1,17 @@
+package com.kairos.context_engine.domain.model.knowledge;
+
+import java.util.UUID;
+
+public record Passage(
+        UUID chunkId
+) {
+    public Passage {
+        if (chunkId == null) {
+            throw new IllegalArgumentException("Passage chunkId cannot be null");
+        }
+    }
+
+    public static Passage fromChunkId(UUID chunkId) {
+        return new Passage(chunkId);
+    }
+}

--- a/src/main/java/com/kairos/context_engine/domain/port/graph/KnowledgeGraphSearch.java
+++ b/src/main/java/com/kairos/context_engine/domain/port/graph/KnowledgeGraphSearch.java
@@ -1,7 +1,7 @@
 package com.kairos.context_engine.domain.port.graph;
 
 import com.kairos.context_engine.domain.model.content.Chunk;
-import com.kairos.context_engine.domain.model.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 
 import java.util.List;
 

--- a/src/main/java/com/kairos/context_engine/domain/port/graph/KnowledgeGraphStore.java
+++ b/src/main/java/com/kairos/context_engine/domain/port/graph/KnowledgeGraphStore.java
@@ -1,7 +1,7 @@
 package com.kairos.context_engine.domain.port.graph;
 
 import com.kairos.context_engine.domain.model.content.Chunk;
-import com.kairos.context_engine.domain.model.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 
 import java.util.List;
 import java.util.UUID;

--- a/src/main/java/com/kairos/context_engine/infrastructure/ai/gemini/GeminiResponseParser.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/ai/gemini/GeminiResponseParser.java
@@ -72,7 +72,7 @@ public class GeminiResponseParser {
             String subject = text(item, "subject");
             String predicate = text(item, "predicate");
             String object = text(item, "object");
-            double weight = Double.parseDouble(Objects.requireNonNull(text(item, "weight")));
+            double weight = weight(item);
 
             if (subject != null && predicate != null && object != null) {
                 triples.add(new Triple(subject, predicate, object, weight));
@@ -85,6 +85,11 @@ public class GeminiResponseParser {
     private String text(JsonNode node, String field) {
         JsonNode value = node.get(field);
         return value != null && !value.isNull() ? value.asString() : null;
+    }
+
+    private double weight(JsonNode node) {
+        String value = text(node, "weight");
+        return value == null || value.isBlank() ? 1.0 : Double.parseDouble(value);
     }
 
     private String sanitize(String text) {
@@ -156,11 +161,9 @@ public class GeminiResponseParser {
             String subject = unescapeJson(matcher.group("subject"));
             String predicate = unescapeJson(matcher.group("predicate"));
             String object = unescapeJson(matcher.group("object"));
-            unescapeJson(matcher.group("weight"));
-            double weight = Double.parseDouble(unescapeJson(matcher.group("weight")));
 
             if (!subject.isBlank() && !predicate.isBlank() && !object.isBlank()) {
-                triples.add(new Triple(subject, predicate, object, weight));
+                triples.add(new Triple(subject, predicate, object));
             }
         }
 

--- a/src/main/java/com/kairos/context_engine/infrastructure/ai/gemini/GeminiResponseParser.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/ai/gemini/GeminiResponseParser.java
@@ -72,9 +72,10 @@ public class GeminiResponseParser {
             String subject = text(item, "subject");
             String predicate = text(item, "predicate");
             String object = text(item, "object");
+            double weight = Double.parseDouble(Objects.requireNonNull(text(item, "weight")));
 
             if (subject != null && predicate != null && object != null) {
-                triples.add(new Triple(subject, predicate, object));
+                triples.add(new Triple(subject, predicate, object, weight));
             }
         }
 
@@ -155,9 +156,11 @@ public class GeminiResponseParser {
             String subject = unescapeJson(matcher.group("subject"));
             String predicate = unescapeJson(matcher.group("predicate"));
             String object = unescapeJson(matcher.group("object"));
+            unescapeJson(matcher.group("weight"));
+            double weight = Double.parseDouble(unescapeJson(matcher.group("weight")));
 
             if (!subject.isBlank() && !predicate.isBlank() && !object.isBlank()) {
-                triples.add(new Triple(subject, predicate, object));
+                triples.add(new Triple(subject, predicate, object, weight));
             }
         }
 

--- a/src/main/java/com/kairos/context_engine/infrastructure/extraction/GeminiTripleExtractorAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/extraction/GeminiTripleExtractorAdapter.java
@@ -79,7 +79,8 @@ public class GeminiTripleExtractorAdapter implements TripleExtractor {
                     {
                       "subject": "string",
                       "predicate": "STRING",
-                      "object": "string"
+                      "object": "string",
+                      "weight": number
                     }
                   ]
                 }

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphGdsExecutor.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphGdsExecutor.java
@@ -50,7 +50,8 @@ public class KnowledgeGraphGdsExecutor {
                 r.predicate     AS predicate,
                 target.name     AS object,
                 passage.chunkId AS chunkId,
-                passageScore    AS score
+                passageScore    AS score,
+                coalesce(r.weight, 1.0) AS weight
             ORDER BY passageScore DESC
             """;
 
@@ -122,7 +123,8 @@ public class KnowledgeGraphGdsExecutor {
                             nullableString(record.get("predicate")),
                             nullableString(record.get("object")),
                             nullableString(record.get("chunkId")),
-                            record.get("score").isNull() ? 0d : record.get("score").asDouble()
+                            record.get("score").isNull() ? 0d : record.get("score").asDouble(),
+                            record.get("weight").isNull() ? 1d : record.get("weight").asDouble()
                     ))
             );
         }
@@ -137,6 +139,7 @@ public class KnowledgeGraphGdsExecutor {
             String predicate,
             String object,
             String chunkId,
-            double score
+            double score,
+            double weight
     ) implements GraphExpansionResult {}
 }

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphMutationExecutor.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphMutationExecutor.java
@@ -15,19 +15,21 @@ public class KnowledgeGraphMutationExecutor {
             MERGE (p:Passage {chunkId: $chunkId})
             MERGE (s:PhraseNode {name: $subjectName})
             MERGE (o:PhraseNode {name: $objectName})
-            MERGE (s)-[:TRIPLE {predicate: $predicate, chunk_id: $chunkId}]->(o)
+            MERGE (s)-[r:TRIPLE {predicate: $predicate, chunk_id: $chunkId}]->(o)
+            SET r.weight = $weight
             MERGE (p)-[:CONTAINS]->(s)
             MERGE (p)-[:CONTAINS]->(o)
             """;
 
     private final Driver neo4jDriver;
 
-    public void mergeTriple(String subjectName, String objectName, String predicate, UUID chunkId) {
+    public void mergeTriple(String subjectName, String objectName, String predicate, UUID chunkId, double weight) {
         runWrite(MERGE_TRIPLE_FOR_CHUNK, Map.of(
                 "chunkId", chunkId.toString(),
                 "subjectName", subjectName,
                 "objectName", objectName,
-                "predicate", predicate
+                "predicate", predicate,
+                "weight", weight
         ));
     }
 

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapter.java
@@ -63,6 +63,7 @@ public class KnowledgeGraphSearchAdapter implements KnowledgeGraphSearch {
      * @param semanticAnchors chunks selected as PPR seed sources; must not be {@code null}
      * @return knowledge triples ranked by passage score; never {@code null}
      */
+    // This will be modified in future to support HippoRAG, with score to implement PPR.
     @Override
     public List<KnowledgeTriple> expandKnowledge(List<Chunk> semanticAnchors) {
         if (semanticAnchors == null || semanticAnchors.isEmpty()) {
@@ -107,7 +108,8 @@ public class KnowledgeGraphSearchAdapter implements KnowledgeGraphSearch {
                             result.subject(),
                             result.predicate(),
                             result.object(),
-                            UUID.fromString(result.chunkId())
+                            UUID.fromString(result.chunkId()),
+                            result.score() // simulate weight with score
                     ))
                     .toList();
 

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapter.java
@@ -2,7 +2,7 @@ package com.kairos.context_engine.infrastructure.graph;
 
 import com.kairos.context_engine.domain.port.graph.KnowledgeGraphSearch;
 import com.kairos.context_engine.domain.model.content.Chunk;
-import com.kairos.context_engine.domain.model.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapter.java
@@ -3,6 +3,7 @@ package com.kairos.context_engine.infrastructure.graph;
 import com.kairos.context_engine.domain.port.graph.KnowledgeGraphSearch;
 import com.kairos.context_engine.domain.model.content.Chunk;
 import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.Passage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -108,7 +109,7 @@ public class KnowledgeGraphSearchAdapter implements KnowledgeGraphSearch {
                             result.subject(),
                             result.predicate(),
                             result.object(),
-                            UUID.fromString(result.chunkId()),
+                            Passage.fromChunkId(UUID.fromString(result.chunkId())),
                             result.score() // simulate weight with score
                     ))
                     .toList();

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapter.java
@@ -20,7 +20,7 @@ import java.util.UUID;
  * <ol>
  *   <li>{@code projectPhraseGraph} — creates a named in-memory GDS projection.</li>
  *   <li>{@code runPPRExpansion} — executes Personalized PageRank seeded from the
- *       anchor passages and returns the top-scored knowledge triples.</li>
+ *       anchor passages and returns knowledge triples from the top-scored passages.</li>
  *   <li>{@code dropProjectedGraph} — releases the in-memory projection.</li>
  * </ol>
  *
@@ -64,7 +64,6 @@ public class KnowledgeGraphSearchAdapter implements KnowledgeGraphSearch {
      * @param semanticAnchors chunks selected as PPR seed sources; must not be {@code null}
      * @return knowledge triples ranked by passage score; never {@code null}
      */
-    // This will be modified in future to support HippoRAG, with score to implement PPR.
     @Override
     public List<KnowledgeTriple> expandKnowledge(List<Chunk> semanticAnchors) {
         if (semanticAnchors == null || semanticAnchors.isEmpty()) {
@@ -105,12 +104,20 @@ public class KnowledgeGraphSearchAdapter implements KnowledgeGraphSearch {
                         }
                         return true;
                     })
+                    .filter(result -> {
+                        if (result.subject() == null || result.predicate() == null || result.object() == null) {
+                            log.warn("Skipping incomplete graph expansion row | chunkId='{}' subject='{}' predicate='{}' object='{}'",
+                                    result.chunkId(), result.subject(), result.predicate(), result.object());
+                            return false;
+                        }
+                        return true;
+                    })
                     .map(result -> KnowledgeTriple.create(
                             result.subject(),
                             result.predicate(),
                             result.object(),
                             Passage.fromChunkId(UUID.fromString(result.chunkId())),
-                            result.score() // simulate weight with score
+                            result.weight()
                     ))
                     .toList();
 

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapter.java
@@ -1,7 +1,7 @@
 package com.kairos.context_engine.infrastructure.graph;
 
 import com.kairos.context_engine.domain.model.content.Chunk;
-import com.kairos.context_engine.domain.model.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 import com.kairos.context_engine.domain.port.graph.KnowledgeGraphStore;
 import com.kairos.context_engine.infrastructure.graph.entity.PassageNode;
 import com.kairos.context_engine.infrastructure.graph.repository.Neo4jPassageNodeRepository;

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapter.java
@@ -33,7 +33,7 @@ public class KnowledgeGraphStoreAdapter implements KnowledgeGraphStore {
         Set<UUID> ensuredChunks = new java.util.HashSet<>();
 
         for (KnowledgeTriple triple : triples) {
-            UUID chunkId = triple.chunkId();
+            UUID chunkId = triple.passage() == null ? null : triple.passage().chunkId();
 
             if (chunkId == null) {
                 log.error("Triple for subject '{}' has no chunkId. Skipping.", triple.subject().name());

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapter.java
@@ -88,6 +88,6 @@ public class KnowledgeGraphStoreAdapter implements KnowledgeGraphStore {
     }
 
     private void mergeTriple(KnowledgeTriple triple, UUID chunkId) {
-        mutationExecutor.mergeTriple(triple.subject().name(), triple.object().name(), triple.predicate(), chunkId);
+        mutationExecutor.mergeTriple(triple.subject().name(), triple.object().name(), triple.predicate(), chunkId, triple.weight());
     }
 }

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/entity/PhraseNode.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/entity/PhraseNode.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.neo4j.core.schema.Id;
 import org.springframework.data.neo4j.core.schema.Node;
-import org.springframework.data.neo4j.core.schema.Property;
 import org.springframework.data.neo4j.core.schema.Relationship;
 
 import java.util.ArrayList;
@@ -21,12 +20,6 @@ public class PhraseNode {
 
     @Id
     private String name;
-
-    @Property("centrality")
-    private double centrality;
-
-    @Property("degree")
-    private int degree;
 
     @Relationship(type = "TRIPLE", direction = Relationship.Direction.OUTGOING)
     private List<TripleRelationship> triples = new ArrayList<>();

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/repository/Neo4jPassageNodeRepository.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/repository/Neo4jPassageNodeRepository.java
@@ -150,7 +150,8 @@ public interface Neo4jPassageNodeRepository extends Neo4jRepository<PassageNode,
                 r.predicate     AS predicate,
                 target.name     AS object,
                 passage.chunkId AS chunkId,
-                passageScore    AS score
+                passageScore    AS score,
+                coalesce(r.weight, 1.0) AS weight
             ORDER BY passageScore DESC
             """)
     List<GraphExpansionResult> runPPRExpansion(

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/repository/Neo4jPhraseNodeRepository.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/repository/Neo4jPhraseNodeRepository.java
@@ -19,11 +19,13 @@ public interface Neo4jPhraseNodeRepository extends Neo4jRepository<PhraseNode, S
             MERGE (s:PhraseNode {name: $subjectName})
             MERGE (o:PhraseNode {name: $objectName})
             MERGE (s)-[r:TRIPLE {predicate: $predicate, chunk_id: $chunkId}]->(o)
+            SET r.weight = $weight
             """)
     void mergeTriple(
             @Param("subjectName") String subjectName,
             @Param("objectName")  String objectName,
             @Param("predicate")   String predicate,
-            @Param("chunkId")     UUID chunkId
+            @Param("chunkId")     UUID chunkId,
+            @Param("weight")      double weight
     );
 }

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/repository/projection/GraphExpansionResult.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/repository/projection/GraphExpansionResult.java
@@ -3,7 +3,8 @@ package com.kairos.context_engine.infrastructure.graph.repository.projection;
 /**
  * Projection for HippoRAG PPR graph expansion results.
  * Score reflects the Personalized PageRank value accumulated
- * by the passage containing the subject node.
+ * by the passage containing the subject node. Weight is the
+ * structural confidence stored on the TRIPLE relationship.
  */
 public interface GraphExpansionResult {
     String subject();
@@ -11,4 +12,5 @@ public interface GraphExpansionResult {
     String object();
     String chunkId();
     double score();
+    double weight();
 }

--- a/src/main/java/com/kairos/context_engine/presentation/dto/response/ContextResponse.java
+++ b/src/main/java/com/kairos/context_engine/presentation/dto/response/ContextResponse.java
@@ -1,7 +1,7 @@
 package com.kairos.context_engine.presentation.dto.response;
 
 import com.kairos.context_engine.domain.model.content.Chunk;
-import com.kairos.context_engine.domain.model.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 
 import java.util.List;
 

--- a/src/main/java/com/kairos/context_engine/presentation/dto/response/KnowledgeTripleResponse.java
+++ b/src/main/java/com/kairos/context_engine/presentation/dto/response/KnowledgeTripleResponse.java
@@ -1,6 +1,6 @@
 package com.kairos.context_engine.presentation.dto.response;
 
-import com.kairos.context_engine.domain.model.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 
 import java.util.UUID;
 

--- a/src/main/java/com/kairos/context_engine/presentation/dto/response/KnowledgeTripleResponse.java
+++ b/src/main/java/com/kairos/context_engine/presentation/dto/response/KnowledgeTripleResponse.java
@@ -16,7 +16,7 @@ public record KnowledgeTripleResponse(
                 triple.subject().name(),
                 triple.predicate(),
                 triple.object().name(),
-                triple.chunkId()
+                triple.passage().chunkId()
         );
     }
 

--- a/src/test/java/com/kairos/context_engine/domain/model/knowledge/ConceptTest.java
+++ b/src/test/java/com/kairos/context_engine/domain/model/knowledge/ConceptTest.java
@@ -1,0 +1,23 @@
+package com.kairos.context_engine.domain.model.knowledge;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ConceptTest {
+
+    @Test
+    void create_shouldTrimConceptName() {
+        Concept concept = Concept.create("  Backpropagation  ");
+
+        assertThat(concept.name()).isEqualTo("Backpropagation");
+    }
+
+    @Test
+    void create_shouldRejectBlankName() {
+        assertThatThrownBy(() -> Concept.create("  "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Concept name cannot be null or blank");
+    }
+}

--- a/src/test/java/com/kairos/context_engine/domain/model/knowledge/KnowledgeTripleTest.java
+++ b/src/test/java/com/kairos/context_engine/domain/model/knowledge/KnowledgeTripleTest.java
@@ -1,0 +1,42 @@
+package com.kairos.context_engine.domain.model.knowledge;
+
+import com.kairos.context_engine.domain.model.Triple;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KnowledgeTripleTest {
+
+    @Test
+    void createFromTriple_shouldKeepStructuralFieldsAndPassage() {
+        Passage passage = Passage.fromChunkId(UUID.randomUUID());
+        Triple extractedTriple = new Triple("Subject", "RELATES_TO", "Object", 0.42);
+
+        KnowledgeTriple knowledgeTriple = KnowledgeTriple.create(extractedTriple, passage);
+
+        assertThat(knowledgeTriple.subject()).isEqualTo(new Concept("Subject"));
+        assertThat(knowledgeTriple.predicate()).isEqualTo("RELATES_TO");
+        assertThat(knowledgeTriple.object()).isEqualTo(new Concept("Object"));
+        assertThat(knowledgeTriple.passage()).isEqualTo(passage);
+        assertThat(knowledgeTriple.weight()).isEqualTo(0.42);
+    }
+
+    @Test
+    void createFromFields_shouldNotRequireGraphMetricsOnConcepts() {
+        Passage passage = Passage.fromChunkId(UUID.randomUUID());
+
+        KnowledgeTriple knowledgeTriple = KnowledgeTriple.create(
+                "Concept A",
+                "CONNECTS_TO",
+                "Concept B",
+                passage,
+                1.0
+        );
+
+        assertThat(knowledgeTriple.subject().name()).isEqualTo("Concept A");
+        assertThat(knowledgeTriple.object().name()).isEqualTo("Concept B");
+        assertThat(knowledgeTriple.weight()).isEqualTo(1.0);
+    }
+}

--- a/src/test/java/com/kairos/context_engine/domain/model/knowledge/PassageTest.java
+++ b/src/test/java/com/kairos/context_engine/domain/model/knowledge/PassageTest.java
@@ -1,0 +1,27 @@
+package com.kairos.context_engine.domain.model.knowledge;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PassageTest {
+
+    @Test
+    void fromChunkId_shouldKeepStableChunkReference() {
+        UUID chunkId = UUID.randomUUID();
+
+        Passage passage = Passage.fromChunkId(chunkId);
+
+        assertThat(passage.chunkId()).isEqualTo(chunkId);
+    }
+
+    @Test
+    void fromChunkId_shouldRejectNullChunkId() {
+        assertThatThrownBy(() -> Passage.fromChunkId(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Passage chunkId cannot be null");
+    }
+}

--- a/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphGdsExecutorTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphGdsExecutorTest.java
@@ -78,6 +78,7 @@ class KnowledgeGraphGdsExecutorTest {
         when(record.get("object")).thenReturn(Values.value("object"));
         when(record.get("chunkId")).thenReturn(Values.value("550e8400-e29b-41d4-a716-446655440000"));
         when(record.get("score")).thenReturn(Values.value(0.85d));
+        when(record.get("weight")).thenReturn(Values.value(0.42d));
 
         doAnswer(invocation -> {
             java.util.function.Function<Record, GraphExpansionResult> mapper = invocation.getArgument(0);
@@ -98,6 +99,7 @@ class KnowledgeGraphGdsExecutorTest {
         assertThat(rows.getFirst().object()).isEqualTo("object");
         assertThat(rows.getFirst().chunkId()).isEqualTo("550e8400-e29b-41d4-a716-446655440000");
         assertThat(rows.getFirst().score()).isEqualTo(0.85d);
+        assertThat(rows.getFirst().weight()).isEqualTo(0.42d);
     }
 
     @Test

--- a/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphMutationExecutorTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphMutationExecutorTest.java
@@ -56,7 +56,7 @@ class KnowledgeGraphMutationExecutorTest {
 
         when(transactionContext.run(anyString(), anyMap())).thenReturn(result);
 
-        executor.mergeTriple("Subject", "Object", "RELATES_TO", chunkId);
+        executor.mergeTriple("Subject", "Object", "RELATES_TO", chunkId, 0.75);
 
         verify(neo4jDriver).session();
         verify(session).executeWrite(any(TransactionCallback.class));
@@ -78,7 +78,7 @@ class KnowledgeGraphMutationExecutorTest {
 
         when(transactionContext.run(anyString(), anyMap())).thenReturn(result);
 
-        executor.mergeTriple("Subject", "Object", "RELATES_TO", chunkId);
+        executor.mergeTriple("Subject", "Object", "RELATES_TO", chunkId, 0.75);
 
         verify(transactionContext).run(queryCaptor.capture(), paramsCaptor.capture());
 
@@ -86,7 +86,8 @@ class KnowledgeGraphMutationExecutorTest {
         assertThat(capturedQuery).contains("MERGE (p:Passage {chunkId: $chunkId})");
         assertThat(capturedQuery).contains("MERGE (s:PhraseNode {name: $subjectName})");
         assertThat(capturedQuery).contains("MERGE (o:PhraseNode {name: $objectName})");
-        assertThat(capturedQuery).contains("MERGE (s)-[:TRIPLE {predicate: $predicate, chunk_id: $chunkId}]->(o)");
+        assertThat(capturedQuery).contains("MERGE (s)-[r:TRIPLE {predicate: $predicate, chunk_id: $chunkId}]->(o)");
+        assertThat(capturedQuery).contains("SET r.weight = $weight");
         assertThat(capturedQuery).contains("MERGE (p)-[:CONTAINS]->(s)");
         assertThat(capturedQuery).contains("MERGE (p)-[:CONTAINS]->(o)");
 
@@ -95,7 +96,8 @@ class KnowledgeGraphMutationExecutorTest {
                 .containsEntry("chunkId", chunkId.toString())
                 .containsEntry("subjectName", "Subject")
                 .containsEntry("objectName", "Object")
-                .containsEntry("predicate", "RELATES_TO");
+                .containsEntry("predicate", "RELATES_TO")
+                .containsEntry("weight", 0.75);
     }
 
     @Test
@@ -110,7 +112,7 @@ class KnowledgeGraphMutationExecutorTest {
 
         when(transactionContext.run(anyString(), anyMap())).thenReturn(result);
 
-        executor.mergeTriple("Subject", "Object", "RELATES_TO", chunkId);
+        executor.mergeTriple("Subject", "Object", "RELATES_TO", chunkId, 0.75);
 
         verify(result).consume();
     }
@@ -129,7 +131,7 @@ class KnowledgeGraphMutationExecutorTest {
 
         when(transactionContext.run(anyString(), anyMap())).thenReturn(result);
 
-        executor.mergeTriple("Subject", "Object", "RELATES_TO", chunkId);
+        executor.mergeTriple("Subject", "Object", "RELATES_TO", chunkId, 0.75);
 
         verify(transactionContext).run(anyString(), paramsCaptor.capture());
 
@@ -143,7 +145,7 @@ class KnowledgeGraphMutationExecutorTest {
 
         when(session.executeWrite(any())).thenThrow(new RuntimeException("Neo4j connection failure"));
 
-        assertThatThrownBy(() -> executor.mergeTriple("Subject", "Object", "RELATES_TO", chunkId))
+        assertThatThrownBy(() -> executor.mergeTriple("Subject", "Object", "RELATES_TO", chunkId, 0.75))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("Neo4j connection failure");
 
@@ -164,7 +166,7 @@ class KnowledgeGraphMutationExecutorTest {
 
         when(transactionContext.run(anyString(), anyMap())).thenReturn(result);
 
-        executor.mergeTriple("Company", "Product", "PRODUCES", chunkId);
+        executor.mergeTriple("Company", "Product", "PRODUCES", chunkId, 0.75);
 
         verify(transactionContext).run(anyString(), paramsCaptor.capture());
 
@@ -185,7 +187,7 @@ class KnowledgeGraphMutationExecutorTest {
 
         when(transactionContext.run(anyString(), anyMap())).thenReturn(result);
 
-        executor.mergeTriple("Entity", "Entity", "SELF_REFERENCES", chunkId);
+        executor.mergeTriple("Entity", "Entity", "SELF_REFERENCES", chunkId, 0.75);
 
         verify(transactionContext).run(anyString(), paramsCaptor.capture());
 

--- a/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapterTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapterTest.java
@@ -2,6 +2,7 @@ package com.kairos.context_engine.infrastructure.graph;
 
 import com.kairos.context_engine.domain.model.content.Chunk;
 import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.Passage;
 import com.kairos.context_engine.infrastructure.graph.repository.projection.GraphExpansionResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -179,7 +180,7 @@ class KnowledgeGraphSearchAdapterTest {
             assertThat(triple.subject().name()).isEqualTo("Paris");
             assertThat(triple.predicate()).isEqualTo("CAPITAL_OF");
             assertThat(triple.object().name()).isEqualTo("France");
-            assertThat(triple.chunkId()).isEqualTo(chunkId);
+            assertThat(triple.passage()).isEqualTo(Passage.fromChunkId(chunkId));
         }
 
         @Test
@@ -194,8 +195,8 @@ class KnowledgeGraphSearchAdapterTest {
             List<KnowledgeTriple> triples = adapter.expandKnowledge(List.of(chunk()));
 
             assertThat(triples).hasSize(2);
-            assertThat(triples.get(0).chunkId()).isEqualTo(chunkId1);
-            assertThat(triples.get(1).chunkId()).isEqualTo(chunkId2);
+            assertThat(triples.get(0).passage().chunkId()).isEqualTo(chunkId1);
+            assertThat(triples.get(1).passage().chunkId()).isEqualTo(chunkId2);
         }
 
         @Test
@@ -230,7 +231,7 @@ class KnowledgeGraphSearchAdapterTest {
             assertThat(result)
                     .hasSize(1)
                     .first()
-                    .satisfies(t -> assertThat(t.chunkId()).isEqualTo(validId));
+                    .satisfies(t -> assertThat(t.passage().chunkId()).isEqualTo(validId));
         }
 
         @Test

--- a/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapterTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapterTest.java
@@ -1,7 +1,7 @@
 package com.kairos.context_engine.infrastructure.graph;
 
 import com.kairos.context_engine.domain.model.content.Chunk;
-import com.kairos.context_engine.domain.model.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 import com.kairos.context_engine.infrastructure.graph.repository.projection.GraphExpansionResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapterTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapterTest.java
@@ -184,6 +184,20 @@ class KnowledgeGraphSearchAdapterTest {
         }
 
         @Test
+        @DisplayName("maps structural relationship weight without using PPR score as triple weight")
+        void singleRow_usesRelationshipWeightNotPprScore() {
+            UUID chunkId = UUID.randomUUID();
+            GraphExpansionResult row = expansionRowWithScore("Paris", "CAPITAL_OF", "France", chunkId.toString(), 0.85, 0.42);
+            stubSuccessfulExpansion(List.of(row));
+
+            List<KnowledgeTriple> triples = adapter.expandKnowledge(List.of(chunkWithId(chunkId)));
+
+            assertThat(triples)
+                    .singleElement()
+                    .satisfies(triple -> assertThat(triple.weight()).isEqualTo(0.42));
+        }
+
+        @Test
         @DisplayName("maps multiple rows preserving order returned by the repository")
         void multipleRows_allMappedInOrder() {
             UUID chunkId1 = UUID.randomUUID();
@@ -240,6 +254,18 @@ class KnowledgeGraphSearchAdapterTest {
             stubSuccessfulExpansion(List.of(
                     expansionRow("X", "rel", "Y", null),
                     expansionRow("A", "rel", "B", null)));
+
+            List<KnowledgeTriple> result = adapter.expandKnowledge(List.of(chunk()));
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("filters out rows without a complete triple")
+        void incompleteTripleRows_returnEmpty() {
+            UUID chunkId = UUID.randomUUID();
+            stubSuccessfulExpansion(List.of(
+                    expansionRow(null, null, null, chunkId.toString())));
 
             List<KnowledgeTriple> result = adapter.expandKnowledge(List.of(chunk()));
 
@@ -392,11 +418,42 @@ class KnowledgeGraphSearchAdapterTest {
      */
     private GraphExpansionResult expansionRow(String subject, String predicate,
                                               String object, String chunkId) {
-        GraphExpansionResult row = mock(GraphExpansionResult.class);
-        when(row.subject()).thenReturn(subject);
-        when(row.predicate()).thenReturn(predicate);
-        when(row.object()).thenReturn(object);
-        when(row.chunkId()).thenReturn(chunkId);
-        return row;
+        return expansionRowWithScore(subject, predicate, object, chunkId, 0.0, 1.0);
+    }
+
+    private GraphExpansionResult expansionRowWithScore(String subject, String predicate,
+                                                       String object, String chunkId,
+                                                       double score, double weight) {
+        return new GraphExpansionResult() {
+            @Override
+            public String subject() {
+                return subject;
+            }
+
+            @Override
+            public String predicate() {
+                return predicate;
+            }
+
+            @Override
+            public String object() {
+                return object;
+            }
+
+            @Override
+            public String chunkId() {
+                return chunkId;
+            }
+
+            @Override
+            public double score() {
+                return score;
+            }
+
+            @Override
+            public double weight() {
+                return weight;
+            }
+        };
     }
 }

--- a/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapterTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapterTest.java
@@ -1,9 +1,7 @@
 package com.kairos.context_engine.infrastructure.graph;
 
-import com.kairos.context_engine.domain.model.Concept;
-import com.kairos.context_engine.domain.model.KnowledgeTriple;
-import com.kairos.context_engine.infrastructure.graph.KnowledgeGraphMutationExecutor;
-import com.kairos.context_engine.infrastructure.graph.KnowledgeGraphStoreAdapter;
+import com.kairos.context_engine.domain.model.knowledge.Concept;
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapterTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapterTest.java
@@ -2,6 +2,7 @@ package com.kairos.context_engine.infrastructure.graph;
 
 import com.kairos.context_engine.domain.model.knowledge.Concept;
 import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.Passage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -116,7 +117,8 @@ class KnowledgeGraphStoreAdapterTest {
                 new Concept("subject", 0, 0),
                 "REL",
                 new Concept("object", 0, 0),
-                null
+                null,
+                1.0
         );
 
         adapter.save(List.of(invalidTriple));
@@ -145,7 +147,8 @@ class KnowledgeGraphStoreAdapterTest {
                 new Concept(subject, 0, 0),
                 predicate,
                 new Concept(object, 0, 0),
-                chunkId
+                Passage.fromChunkId(chunkId),
+                1.0
         );
     }
 }

--- a/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapterTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapterTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -37,7 +38,7 @@ class KnowledgeGraphStoreAdapterTest {
 
         adapter.saveAllForChunk(chunkId, List.of(triple));
 
-        verify(mutationExecutor).mergeTriple("backpropagation", "chain rule", "USES", chunkId);
+        verify(mutationExecutor).mergeTriple("backpropagation", "chain rule", "USES", chunkId, 1.0);
     }
 
     @Test
@@ -48,7 +49,18 @@ class KnowledgeGraphStoreAdapterTest {
 
         adapter.saveAllForChunk(chunkId, List.of(triple));
 
-        verify(mutationExecutor).mergeTriple("a", "b", "REL", chunkId);
+        verify(mutationExecutor).mergeTriple("a", "b", "REL", chunkId, 1.0);
+    }
+
+    @Test
+    @DisplayName("saveAllForChunk should forward structural triple weight")
+    void saveAllForChunk_shouldForwardStructuralTripleWeight() {
+        UUID chunkId = UUID.randomUUID();
+        KnowledgeTriple triple = triple("a", "REL", "b", chunkId, 0.42);
+
+        adapter.saveAllForChunk(chunkId, List.of(triple));
+
+        verify(mutationExecutor).mergeTriple("a", "b", "REL", chunkId, 0.42);
     }
 
     @Test
@@ -62,7 +74,7 @@ class KnowledgeGraphStoreAdapterTest {
 
         adapter.saveAllForChunk(chunkId, triples);
 
-        verify(mutationExecutor, times(2)).mergeTriple(anyString(), anyString(), anyString(), eq(chunkId));
+        verify(mutationExecutor, times(2)).mergeTriple(anyString(), anyString(), anyString(), eq(chunkId), anyDouble());
     }
 
     @Test
@@ -107,7 +119,7 @@ class KnowledgeGraphStoreAdapterTest {
 
         adapter.save(triples);
 
-        verify(mutationExecutor, times(3)).mergeTriple(anyString(), anyString(), anyString(), any(UUID.class));
+        verify(mutationExecutor, times(3)).mergeTriple(anyString(), anyString(), anyString(), any(UUID.class), anyDouble());
     }
 
     @Test
@@ -143,12 +155,16 @@ class KnowledgeGraphStoreAdapterTest {
     }
 
     private KnowledgeTriple triple(String subject, String predicate, String object, UUID chunkId) {
+        return triple(subject, predicate, object, chunkId, 1.0);
+    }
+
+    private KnowledgeTriple triple(String subject, String predicate, String object, UUID chunkId, double weight) {
         return new KnowledgeTriple(
                 new Concept(subject),
                 predicate,
                 new Concept(object),
                 Passage.fromChunkId(chunkId),
-                1.0
+                weight
         );
     }
 }

--- a/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapterTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapterTest.java
@@ -114,9 +114,9 @@ class KnowledgeGraphStoreAdapterTest {
     @DisplayName("save should skip triples with null chunkId")
     void save_shouldSkipTriplesWithNullChunkId() {
         KnowledgeTriple invalidTriple = new KnowledgeTriple(
-                new Concept("subject", 0, 0),
+                new Concept("subject"),
                 "REL",
-                new Concept("object", 0, 0),
+                new Concept("object"),
                 null,
                 1.0
         );
@@ -144,9 +144,9 @@ class KnowledgeGraphStoreAdapterTest {
 
     private KnowledgeTriple triple(String subject, String predicate, String object, UUID chunkId) {
         return new KnowledgeTriple(
-                new Concept(subject, 0, 0),
+                new Concept(subject),
                 predicate,
-                new Concept(object, 0, 0),
+                new Concept(object),
                 Passage.fromChunkId(chunkId),
                 1.0
         );

--- a/src/test/java/com/kairos/context_engine/use_case/GenerateSourceContextUseCaseTest.java
+++ b/src/test/java/com/kairos/context_engine/use_case/GenerateSourceContextUseCaseTest.java
@@ -118,7 +118,7 @@ class GenerateSourceContextUseCaseTest {
         assertThat(triplesCaptor.getValue())
                 .hasSize(1)
                 .allSatisfy(knowledgeTriple ->
-                        assertThat(knowledgeTriple.chunkId()).isEqualTo(chunk.getId()));
+                        assertThat(knowledgeTriple.passage().chunkId()).isEqualTo(chunk.getId()));
     }
 
     @Test

--- a/src/test/java/com/kairos/context_engine/use_case/GenerateSourceContextUseCaseTest.java
+++ b/src/test/java/com/kairos/context_engine/use_case/GenerateSourceContextUseCaseTest.java
@@ -6,7 +6,7 @@ import com.kairos.context_engine.domain.port.embedding.EmbeddingProvider;
 import com.kairos.context_engine.domain.port.graph.KnowledgeGraphStore;
 import com.kairos.context_engine.domain.port.extraction.TripleExtractor;
 import com.kairos.context_engine.domain.model.content.Chunk;
-import com.kairos.context_engine.domain.model.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 import com.kairos.context_engine.domain.model.content.Source;
 import com.kairos.context_engine.domain.model.Triple;
 import com.kairos.context_engine.domain.port.repository.ChunkRepository;

--- a/src/test/java/com/kairos/context_engine/use_case/SearchSourceUseCaseTest.java
+++ b/src/test/java/com/kairos/context_engine/use_case/SearchSourceUseCaseTest.java
@@ -5,6 +5,7 @@ import com.kairos.context_engine.application.use_case.SearchSourceUseCase;
 import com.kairos.context_engine.domain.model.content.Chunk;
 import com.kairos.context_engine.domain.model.content.Source;
 import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.Passage;
 import com.kairos.context_engine.domain.port.embedding.EmbeddingProvider;
 import com.kairos.context_engine.domain.port.graph.KnowledgeGraphSearch;
 import com.kairos.context_engine.domain.model.*;
@@ -68,7 +69,7 @@ class SearchSourceUseCaseTest {
     }
 
     private KnowledgeTriple triple(UUID chunkId) {
-        return KnowledgeTriple.create("Consciousness", "is_part_of", "Mind", chunkId);
+        return KnowledgeTriple.create("Consciousness", "is_part_of", "Mind", Passage.fromChunkId(chunkId), 1.0);
     }
 
     // =========================================================================
@@ -232,9 +233,9 @@ class SearchSourceUseCaseTest {
 
             // Same chunkId referenced by two different triples (common in PPR expansion)
             List<KnowledgeTriple> triplesWithDuplicate = List.of(
-                    KnowledgeTriple.create("Mind",    "has_property", "Consciousness", sharedId),
-                    KnowledgeTriple.create("Qualia",  "relates_to",   "Experience",    sharedId),
-                    KnowledgeTriple.create("Neuron",  "fires_during", "Thought",       uniqueId)
+                    KnowledgeTriple.create("Mind",    "has_property", "Consciousness", Passage.fromChunkId(sharedId), 1.0),
+                    KnowledgeTriple.create("Qualia",  "relates_to",   "Experience",    Passage.fromChunkId(sharedId), 1.0),
+                    KnowledgeTriple.create("Neuron",  "fires_during", "Thought",       Passage.fromChunkId(uniqueId), 1.0)
             );
 
             when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);

--- a/src/test/java/com/kairos/context_engine/use_case/SearchSourceUseCaseTest.java
+++ b/src/test/java/com/kairos/context_engine/use_case/SearchSourceUseCaseTest.java
@@ -4,6 +4,7 @@ import com.kairos.context_engine.application.query.SearchSourceQuery;
 import com.kairos.context_engine.application.use_case.SearchSourceUseCase;
 import com.kairos.context_engine.domain.model.content.Chunk;
 import com.kairos.context_engine.domain.model.content.Source;
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 import com.kairos.context_engine.domain.port.embedding.EmbeddingProvider;
 import com.kairos.context_engine.domain.port.graph.KnowledgeGraphSearch;
 import com.kairos.context_engine.domain.model.*;


### PR DESCRIPTION
## Context

This PR finishes the first knowledge model refactor for HippoRAG.

The previous model mixed structural knowledge with graph retrieval data. In particular, `KnowledgeTriple.weight` could receive PPR/search score, while `Concept` still had graph-oriented fields such as `degree` and `centrality`.

This PR makes the boundary explicit: domain knowledge stores extracted structure, while graph ranking signals stay in the graph/search layer.

## Changes

- Moved knowledge-specific models into `domain.model.knowledge`.
- Added `weight` to extracted `Triple`.
- Defaulted missing Gemini triple weights to `1.0`.
- Added `Passage` as the stable source reference for triples, backed only by `chunkId`.
- Replaced raw `chunkId` usage in `KnowledgeTriple` with `Passage`.
- Simplified `Concept` into a pure identity/value object.
- Removed unused graph metrics from `Concept` and `PhraseNode`.
- Added conservative `Concept` validation:
  - rejects null/blank names
  - trims surrounding whitespace
- Persisted structural relation weight on Neo4j `TRIPLE` relationships.
- Updated graph expansion to return both:
  - `score`: PPR/ranking score
  - `weight`: structural relationship weight
- Fixed `KnowledgeGraphSearchAdapter` to map `KnowledgeTriple.weight` from `result.weight()`, not `result.score()`.
- Filtered incomplete graph expansion rows before creating domain triples.
- Updated use cases, DTOs, graph ports, graph adapters, and tests to use the new knowledge model.

## Commit Flow

- Reorganized the knowledge model package.
- Added structural triple weight support.
- Added `Passage` and routed triples through it.
- Removed unused concept/phrase graph metrics.
- Fixed the final modeling issue by separating PPR score from triple weight.

## Why This Matters

HippoRAG needs a clean separation between:

- extracted knowledge structure
- source passage references
- graph traversal/ranking signals

After this PR:

- `Concept` represents only the concept identity.
- `Passage` points to the source chunk.
- `KnowledgeTriple` represents structural extracted knowledge.
- `KnowledgeTriple.weight` remains a relation property.
- `GraphExpansionResult.score` remains retrieval/ranking metadata.
- PPR score no longer changes the meaning of a knowledge triple.

## Tests

Added/updated tests for:

- `Concept`
- `Passage`
- `KnowledgeTriple`
- Gemini triple weight defaults
- graph mutation weight persistence
- graph store weight forwarding
- graph expansion score/weight mapping
- graph search mapping through `Passage`
- incomplete graph expansion row filtering
- affected use cases and DTO mappings