### PR TITLE
Introduce HippoRAG retrieval domain foundation

### DIFF
--- a/src/main/java/com/kairos/context_engine/application/use_case/GenerateSourceContextUseCase.java
+++ b/src/main/java/com/kairos/context_engine/application/use_case/GenerateSourceContextUseCase.java
@@ -52,20 +52,25 @@ public class GenerateSourceContextUseCase {
      * @param chunks the list of chunks associated with the source, from which to extract triples and of the knowledge graph context
      */
     private void generateKnowledgeGraph(Source source, List<Chunk> chunks) {
-        knowledgeGraphStore.createContext(chunks); // TODO: this is a bad abstraction. First we to create a series of passages nodes and this will be the foundation of context.
-        createContextForKnowledgeGraph(source,chunks); // TODO: this is a causal bad abstraction. This parte will create the relationships and structure of the foundation create before.
+        List<Passage> passages = chunks.stream()
+                .map(chunk -> Passage.fromChunkId(chunk.getId()))
+                .toList();
+        knowledgeGraphStore.savePassages(passages);
+
+        createContextForKnowledgeGraph(chunks, passages);
     }
 
 
     /**
      * Extracts triples from the content of each chunk and saves them to the knowledge graph store, associating them with the corresponding chunk ID.
-     * @param source the source for which the knowledge graph context is being generated
      * @param chunks the list of chunks from which to extract triples and of the knowledge graph context
      */
-    private void createContextForKnowledgeGraph(Source source, List<Chunk> chunks) {
-        for (Chunk chunk : chunks) {
+    private void createContextForKnowledgeGraph(List<Chunk> chunks, List<Passage> passages) {
+        for (int i = 0; i < chunks.size(); i++) {
+            Chunk chunk = chunks.get(i);
+            Passage passage = passages.get(i);
+
             List<Triple> triples = tripleExtractor.extract(chunk.getContent());
-            Passage passage = Passage.fromChunkId(chunk.getId());
 
             List<TripleExtracted> extractedTriples = triples.stream()
                     .map(triple -> this.createEmbeddingTriple(triple, chunk))

--- a/src/main/java/com/kairos/context_engine/application/use_case/SearchSourceUseCase.java
+++ b/src/main/java/com/kairos/context_engine/application/use_case/SearchSourceUseCase.java
@@ -50,11 +50,11 @@ public class SearchSourceUseCase {
     public SearchResult execute(SearchSourceQuery query) {
         float[] queryVector = embeddingPort.embed(query.searchTerm());
 
-        List<PassageCandidate> passageCandidate = semanticSearch.findPassageCandidate(queryVector, 10);
+        List<PassageCandidate> passageCandidates = semanticSearch.findPassageCandidate(queryVector, 10);
 
-        if (passageCandidate.isEmpty()) return SearchResult.empty();
+        if (passageCandidates.isEmpty()) return SearchResult.empty();
 
-        List<KnowledgeTriple> triples = knowledgeGraphSearch.expandKnowledge(passageCandidate);
+        List<KnowledgeTriple> triples = knowledgeGraphSearch.expandKnowledge(passageCandidates);
 
         List<UUID> orderedChunkIds = triples.stream()
                 .map(triple -> triple.passage().chunkId())

--- a/src/main/java/com/kairos/context_engine/application/use_case/SearchSourceUseCase.java
+++ b/src/main/java/com/kairos/context_engine/application/use_case/SearchSourceUseCase.java
@@ -1,6 +1,7 @@
 package com.kairos.context_engine.application.use_case;
 
 import com.kairos.context_engine.application.query.SearchSourceQuery;
+import com.kairos.context_engine.domain.model.retrieval.candidate.PassageCandidate;
 import com.kairos.context_engine.domain.port.embedding.EmbeddingProvider;
 import com.kairos.context_engine.domain.port.graph.KnowledgeGraphSearch;
 import com.kairos.context_engine.domain.model.content.Chunk;
@@ -49,11 +50,11 @@ public class SearchSourceUseCase {
     public SearchResult execute(SearchSourceQuery query) {
         float[] queryVector = embeddingPort.embed(query.searchTerm());
 
-        List<Chunk> semanticAnchors = semanticSearch.findTopK(queryVector, 10);
+        List<PassageCandidate> passageCandidate = semanticSearch.findPassageCandidate(queryVector, 10);
 
-        if (semanticAnchors.isEmpty()) return SearchResult.empty();
+        if (passageCandidate.isEmpty()) return SearchResult.empty();
 
-        List<KnowledgeTriple> triples = knowledgeGraphSearch.expandKnowledge(semanticAnchors);
+        List<KnowledgeTriple> triples = knowledgeGraphSearch.expandKnowledge(passageCandidate);
 
         List<UUID> orderedChunkIds = triples.stream()
                 .map(triple -> triple.passage().chunkId())

--- a/src/main/java/com/kairos/context_engine/domain/model/retrieval/candidate/PassageCandidate.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/retrieval/candidate/PassageCandidate.java
@@ -1,0 +1,17 @@
+package com.kairos.context_engine.domain.model.retrieval.candidate;
+
+import java.util.UUID;
+
+public record PassageCandidate(
+        UUID chunkId,
+        double denseScore
+) {
+    public PassageCandidate {
+        if (chunkId == null) {
+            throw new IllegalArgumentException("Passage candidate chunkId cannot be null");
+        }
+        if (!Double.isFinite(denseScore)) {
+            throw new IllegalArgumentException("Passage candidate denseScore must be finite");
+        }
+    }
+}

--- a/src/main/java/com/kairos/context_engine/domain/model/retrieval/candidate/TripleCandidate.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/retrieval/candidate/TripleCandidate.java
@@ -1,0 +1,17 @@
+package com.kairos.context_engine.domain.model.retrieval.candidate;
+
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
+
+public record TripleCandidate(
+        KnowledgeTriple triple,
+        double similarityScore
+) {
+    public TripleCandidate {
+        if (triple == null) {
+            throw new IllegalArgumentException("Triple candidate triple cannot be null");
+        }
+        if (!Double.isFinite(similarityScore)) {
+            throw new IllegalArgumentException("Triple candidate similarityScore must be finite");
+        }
+    }
+}

--- a/src/main/java/com/kairos/context_engine/domain/model/retrieval/graph/FilteredTriple.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/retrieval/graph/FilteredTriple.java
@@ -1,0 +1,23 @@
+package com.kairos.context_engine.domain.model.retrieval.graph;
+
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.retrieval.candidate.TripleCandidate;
+
+public record FilteredTriple(
+        TripleCandidate candidate,
+        boolean accepted
+) {
+    public FilteredTriple {
+        if (candidate == null) {
+            throw new IllegalArgumentException("Filtered triple candidate cannot be null");
+        }
+    }
+
+    public KnowledgeTriple triple() {
+        return candidate.triple();
+    }
+
+    public double similarityScore() {
+        return candidate.similarityScore();
+    }
+}

--- a/src/main/java/com/kairos/context_engine/domain/model/retrieval/graph/GraphSearchRequest.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/retrieval/graph/GraphSearchRequest.java
@@ -1,0 +1,21 @@
+package com.kairos.context_engine.domain.model.retrieval.graph;
+
+import com.kairos.context_engine.domain.model.retrieval.seed.GraphSeed;
+
+import java.util.List;
+
+public record GraphSearchRequest(
+        List<GraphSeed> seeds,
+        int limit
+) {
+    public GraphSearchRequest {
+        if (seeds == null) {
+            throw new IllegalArgumentException("Graph search seeds cannot be null");
+        }
+        if (limit <= 0) {
+            throw new IllegalArgumentException("Graph search limit must be positive");
+        }
+
+        seeds = List.copyOf(seeds);
+    }
+}

--- a/src/main/java/com/kairos/context_engine/domain/model/retrieval/graph/GraphSearchResult.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/retrieval/graph/GraphSearchResult.java
@@ -1,0 +1,27 @@
+package com.kairos.context_engine.domain.model.retrieval.graph;
+
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.retrieval.ranking.ScoredPassage;
+
+import java.util.List;
+
+public record GraphSearchResult(
+        List<ScoredPassage> scoredPassages,
+        List<KnowledgeTriple> activatedTriples
+) {
+    public GraphSearchResult {
+        if (scoredPassages == null) {
+            throw new IllegalArgumentException("Graph search scored passages cannot be null");
+        }
+        if (activatedTriples == null) {
+            throw new IllegalArgumentException("Graph search activated triples cannot be null");
+        }
+
+        scoredPassages = List.copyOf(scoredPassages);
+        activatedTriples = List.copyOf(activatedTriples);
+    }
+
+    public static GraphSearchResult empty() {
+        return new GraphSearchResult(List.of(), List.of());
+    }
+}

--- a/src/main/java/com/kairos/context_engine/domain/model/retrieval/ranking/RankedChunk.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/retrieval/ranking/RankedChunk.java
@@ -1,0 +1,26 @@
+package com.kairos.context_engine.domain.model.retrieval.ranking;
+
+import com.kairos.context_engine.domain.model.content.Chunk;
+import com.kairos.context_engine.domain.model.retrieval.source.RetrievalSource;
+
+public record RankedChunk(
+        Chunk chunk,
+        int rank,
+        double score,
+        RetrievalSource source
+) {
+    public RankedChunk {
+        if (chunk == null) {
+            throw new IllegalArgumentException("Ranked chunk cannot be null");
+        }
+        if (rank <= 0) {
+            throw new IllegalArgumentException("Ranked chunk rank must be positive");
+        }
+        if (!Double.isFinite(score)) {
+            throw new IllegalArgumentException("Ranked chunk score must be finite");
+        }
+        if (source == null) {
+            throw new IllegalArgumentException("Ranked chunk source cannot be null");
+        }
+    }
+}

--- a/src/main/java/com/kairos/context_engine/domain/model/retrieval/ranking/ScoredPassage.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/retrieval/ranking/ScoredPassage.java
@@ -1,0 +1,17 @@
+package com.kairos.context_engine.domain.model.retrieval.ranking;
+
+import java.util.UUID;
+
+public record ScoredPassage(
+        UUID chunkId,
+        double graphScore
+) {
+    public ScoredPassage {
+        if (chunkId == null) {
+            throw new IllegalArgumentException("Scored passage chunkId cannot be null");
+        }
+        if (!Double.isFinite(graphScore)) {
+            throw new IllegalArgumentException("Scored passage graphScore must be finite");
+        }
+    }
+}

--- a/src/main/java/com/kairos/context_engine/domain/model/retrieval/seed/ConceptSeedTarget.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/retrieval/seed/ConceptSeedTarget.java
@@ -1,0 +1,17 @@
+package com.kairos.context_engine.domain.model.retrieval.seed;
+
+import com.kairos.context_engine.domain.model.knowledge.Concept;
+
+public record ConceptSeedTarget(
+        Concept concept
+) implements GraphSeedTarget {
+    public ConceptSeedTarget {
+        if (concept == null) {
+            throw new IllegalArgumentException("Concept seed target cannot be null");
+        }
+    }
+
+    public static ConceptSeedTarget fromName(String conceptName) {
+        return new ConceptSeedTarget(Concept.create(conceptName));
+    }
+}

--- a/src/main/java/com/kairos/context_engine/domain/model/retrieval/seed/GraphSeed.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/retrieval/seed/GraphSeed.java
@@ -1,0 +1,35 @@
+package com.kairos.context_engine.domain.model.retrieval.seed;
+
+import java.util.UUID;
+
+public record GraphSeed(
+        GraphSeedTarget target,
+        SeedType type,
+        double weight
+) {
+    public GraphSeed {
+        if (target == null) {
+            throw new IllegalArgumentException("Graph seed target cannot be null");
+        }
+        if (type == null) {
+            throw new IllegalArgumentException("Graph seed type cannot be null");
+        }
+        if (!Double.isFinite(weight) || weight <= 0) {
+            throw new IllegalArgumentException("Graph seed weight must be a positive finite value");
+        }
+        if (target instanceof PassageSeedTarget && type != SeedType.PASSAGE) {
+            throw new IllegalArgumentException("Passage seed target must use PASSAGE seed type");
+        }
+        if (target instanceof ConceptSeedTarget && type != SeedType.CONCEPT) {
+            throw new IllegalArgumentException("Concept seed target must use CONCEPT seed type");
+        }
+    }
+
+    public static GraphSeed passage(UUID chunkId, double weight) {
+        return new GraphSeed(new PassageSeedTarget(chunkId), SeedType.PASSAGE, weight);
+    }
+
+    public static GraphSeed concept(String conceptName, double weight) {
+        return new GraphSeed(ConceptSeedTarget.fromName(conceptName), SeedType.CONCEPT, weight);
+    }
+}

--- a/src/main/java/com/kairos/context_engine/domain/model/retrieval/seed/GraphSeedTarget.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/retrieval/seed/GraphSeedTarget.java
@@ -1,0 +1,4 @@
+package com.kairos.context_engine.domain.model.retrieval.seed;
+
+public sealed interface GraphSeedTarget permits PassageSeedTarget, ConceptSeedTarget {
+}

--- a/src/main/java/com/kairos/context_engine/domain/model/retrieval/seed/PassageSeedTarget.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/retrieval/seed/PassageSeedTarget.java
@@ -1,0 +1,13 @@
+package com.kairos.context_engine.domain.model.retrieval.seed;
+
+import java.util.UUID;
+
+public record PassageSeedTarget(
+        UUID chunkId
+) implements GraphSeedTarget {
+    public PassageSeedTarget {
+        if (chunkId == null) {
+            throw new IllegalArgumentException("Passage seed chunkId cannot be null");
+        }
+    }
+}

--- a/src/main/java/com/kairos/context_engine/domain/model/retrieval/seed/SeedType.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/retrieval/seed/SeedType.java
@@ -1,0 +1,6 @@
+package com.kairos.context_engine.domain.model.retrieval.seed;
+
+public enum SeedType {
+    PASSAGE,
+    CONCEPT
+}

--- a/src/main/java/com/kairos/context_engine/domain/model/retrieval/source/RetrievalSource.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/retrieval/source/RetrievalSource.java
@@ -1,0 +1,8 @@
+package com.kairos.context_engine.domain.model.retrieval.source;
+
+public enum RetrievalSource {
+    DENSE,
+    GRAPH,
+    DENSE_FALLBACK,
+    HYBRID
+}

--- a/src/main/java/com/kairos/context_engine/domain/port/graph/KnowledgeGraphSearch.java
+++ b/src/main/java/com/kairos/context_engine/domain/port/graph/KnowledgeGraphSearch.java
@@ -1,10 +1,10 @@
 package com.kairos.context_engine.domain.port.graph;
 
-import com.kairos.context_engine.domain.model.content.Chunk;
 import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.retrieval.candidate.PassageCandidate;
 
 import java.util.List;
 
 public interface KnowledgeGraphSearch {
-    List<KnowledgeTriple> expandKnowledge(List<Chunk> semanticAnchors);
+    List<KnowledgeTriple> expandKnowledge(List<PassageCandidate> semanticAnchors);
 }

--- a/src/main/java/com/kairos/context_engine/domain/port/graph/KnowledgeGraphStore.java
+++ b/src/main/java/com/kairos/context_engine/domain/port/graph/KnowledgeGraphStore.java
@@ -1,7 +1,7 @@
 package com.kairos.context_engine.domain.port.graph;
 
-import com.kairos.context_engine.domain.model.content.Chunk;
 import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.Passage;
 
 import java.util.List;
 import java.util.UUID;
@@ -12,5 +12,5 @@ public interface KnowledgeGraphStore {
 
     void saveAllForChunk(UUID chunkId, List<KnowledgeTriple> knowledgeTriples);
 
-    void createContext(List<Chunk> chunks);
+    void savePassages(List<Passage> passages);
 }

--- a/src/main/java/com/kairos/context_engine/domain/port/semantic/SemanticSearch.java
+++ b/src/main/java/com/kairos/context_engine/domain/port/semantic/SemanticSearch.java
@@ -1,13 +1,14 @@
 package com.kairos.context_engine.domain.port.semantic;
 
 import com.kairos.context_engine.domain.model.content.Chunk;
+import com.kairos.context_engine.domain.model.retrieval.candidate.PassageCandidate;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface SemanticSearch {
 
-    List<Chunk> findTopK(float[] queryVector, int k);
+    List<PassageCandidate> findPassageCandidate(float[] queryVector, int k);
 
     List<Chunk> findChunks(List<UUID> triples);
 }

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapter.java
@@ -1,7 +1,7 @@
 package com.kairos.context_engine.infrastructure.graph;
 
+import com.kairos.context_engine.domain.model.retrieval.candidate.PassageCandidate;
 import com.kairos.context_engine.domain.port.graph.KnowledgeGraphSearch;
-import com.kairos.context_engine.domain.model.content.Chunk;
 import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 import com.kairos.context_engine.domain.model.knowledge.Passage;
 import lombok.RequiredArgsConstructor;
@@ -65,13 +65,13 @@ public class KnowledgeGraphSearchAdapter implements KnowledgeGraphSearch {
      * @return knowledge triples ranked by passage score; never {@code null}
      */
     @Override
-    public List<KnowledgeTriple> expandKnowledge(List<Chunk> semanticAnchors) {
+    public List<KnowledgeTriple> expandKnowledge(List<PassageCandidate> semanticAnchors) {
         if (semanticAnchors == null || semanticAnchors.isEmpty()) {
             return List.of();
         }
 
         List<String> anchorIds = semanticAnchors.stream()
-                .map(chunk -> chunk.getId().toString())
+                .map(anchors -> anchors.chunkId().toString())
                 .toList();
 
         log.info("Expanding knowledge graph | anchors={} ids={}", anchorIds.size(), anchorIds);

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapter.java
@@ -2,6 +2,7 @@ package com.kairos.context_engine.infrastructure.graph;
 
 import com.kairos.context_engine.domain.model.content.Chunk;
 import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.Passage;
 import com.kairos.context_engine.domain.port.graph.KnowledgeGraphStore;
 import com.kairos.context_engine.infrastructure.graph.entity.PassageNode;
 import com.kairos.context_engine.infrastructure.graph.repository.Neo4jPassageNodeRepository;
@@ -45,7 +46,7 @@ public class KnowledgeGraphStoreAdapter implements KnowledgeGraphStore {
             mergeTriple(triple, chunkId);
         }
 
-        log.info("Successfully processed {} triples across {} different chunks.", triples.size(), ensuredChunks.size());
+        log.info("Successfully processed {} triples across {} different passages.", triples.size(), ensuredChunks.size());
     }
 
     @Override
@@ -68,23 +69,23 @@ public class KnowledgeGraphStoreAdapter implements KnowledgeGraphStore {
 
     @Override
     @Transactional
-    public void createContext(List<Chunk> chunks) {
-            if (chunks == null || chunks.isEmpty()) {
-                log.warn("No chunks provided for context creation.");
+    public void savePassages(List<Passage> passages) {
+            if (passages == null || passages.isEmpty()) {
+                log.warn("No passages provided for context creation.");
                 return;
             }
 
-            for (Chunk chunk : chunks) {
-                if (chunk.getId() == null) {
-                    log.error("Chunk with content '{}' has null ID. Skipping context creation for this chunk.", chunk.getContent());
+            for (Passage passage : passages) {
+                if (passage.chunkId() == null) {
+                    log.error("Passage has null ID. Skipping context creation for this passage.");
                     continue;
                 }
 
-                PassageNode passageNode = new PassageNode(chunk.getId());
+                PassageNode passageNode = new PassageNode(passage.chunkId());
                 passageNodeRepository.save(passageNode);
             }
 
-            log.info("Successfully created context for {} chunks.", chunks.size());
+            log.info("Successfully created context for {} passages.", passages.size());
     }
 
     private void mergeTriple(KnowledgeTriple triple, UUID chunkId) {

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphStoreAdapter.java
@@ -1,6 +1,5 @@
 package com.kairos.context_engine.infrastructure.graph;
 
-import com.kairos.context_engine.domain.model.content.Chunk;
 import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 import com.kairos.context_engine.domain.model.knowledge.Passage;
 import com.kairos.context_engine.domain.port.graph.KnowledgeGraphStore;

--- a/src/main/java/com/kairos/context_engine/infrastructure/relational/repository/chunk/JpaChunkRepository.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/relational/repository/chunk/JpaChunkRepository.java
@@ -28,12 +28,17 @@ public interface JpaChunkRepository extends JpaRepository<ChunkEntity, UUID> {
 
     List<ChunkEntity> findAllBySource_Id(UUID sourceId);
 
+    /**
+     * Executes a native pgvector cosine distance search and returns a projection with the chunk ID and dense score.
+     * @param queryVector The dense embedding representation of the query.
+     * @param limit The top-k threshold.
+     * @return A list of passage candidates with their chunk ID and dense score, ordered by the shortest cosine distance.
+     */
     @Query(value = """
         SELECT
             c.id AS chunkId,
             1 - (c.embedding <=> cast(:queryVector AS vector)) AS denseScore
         FROM chunks c
-        WHERE c.processed = true
         ORDER BY c.embedding <=> cast(:queryVector AS vector)
         LIMIT :limit
         """, nativeQuery = true)

--- a/src/main/java/com/kairos/context_engine/infrastructure/relational/repository/chunk/JpaChunkRepository.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/relational/repository/chunk/JpaChunkRepository.java
@@ -1,6 +1,7 @@
 package com.kairos.context_engine.infrastructure.relational.repository.chunk;
 
 import com.kairos.context_engine.infrastructure.relational.entity.ChunkEntity;
+import com.kairos.context_engine.infrastructure.relational.repository.projection.PassageCandidateProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -26,4 +27,19 @@ public interface JpaChunkRepository extends JpaRepository<ChunkEntity, UUID> {
     List<ChunkEntity> findTopKByEmbedding(@Param("queryVector") float[] queryVector, @Param("limit") int limit);
 
     List<ChunkEntity> findAllBySource_Id(UUID sourceId);
+
+    @Query(value = """
+        SELECT
+            c.id AS chunkId,
+            1 - (c.embedding <=> cast(:queryVector AS vector)) AS denseScore
+        FROM chunks c
+        WHERE c.processed = true
+        ORDER BY c.embedding <=> cast(:queryVector AS vector)
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<PassageCandidateProjection> findCandidates(
+            @Param("queryVector") float[] queryVector,
+            @Param("limit") int limit
+    );
+
 }

--- a/src/main/java/com/kairos/context_engine/infrastructure/relational/repository/projection/PassageCandidateProjection.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/relational/repository/projection/PassageCandidateProjection.java
@@ -1,0 +1,8 @@
+package com.kairos.context_engine.infrastructure.relational.repository.projection;
+
+import java.util.UUID;
+
+public interface PassageCandidateProjection {
+    UUID getChunkId();
+    double getDenseScore();
+}

--- a/src/main/java/com/kairos/context_engine/infrastructure/relational/semantic/SemanticSearchAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/relational/semantic/SemanticSearchAdapter.java
@@ -1,6 +1,7 @@
 package com.kairos.context_engine.infrastructure.relational.semantic;
 
 import com.kairos.context_engine.domain.model.content.Chunk;
+import com.kairos.context_engine.domain.model.retrieval.candidate.PassageCandidate;
 import com.kairos.context_engine.domain.port.semantic.SemanticSearch;
 import com.kairos.context_engine.infrastructure.relational.entity.ChunkEntity;
 import com.kairos.context_engine.infrastructure.relational.repository.chunk.JpaChunkRepository;
@@ -32,10 +33,13 @@ public class SemanticSearchAdapter implements SemanticSearch {
      */
     @Override
     @Transactional(readOnly = true)
-    public List<Chunk> findTopK(float[] queryVector, int k) {
-        List<ChunkEntity> chunks = jpaChunkRepository.findTopKByEmbedding(queryVector, k);
-        return chunks.stream()
-                .map(ChunkEntity::toDomain)
+    public List<PassageCandidate> findPassageCandidate(float[] queryVector, int k) {
+        return jpaChunkRepository.findCandidates(queryVector, k)
+                .stream()
+                .map(candidate -> new PassageCandidate(
+                        candidate.getChunkId(),
+                        candidate.getDenseScore()
+                ))
                 .toList();
     }
 

--- a/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapterTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/graph/KnowledgeGraphSearchAdapterTest.java
@@ -1,8 +1,8 @@
 package com.kairos.context_engine.infrastructure.graph;
 
-import com.kairos.context_engine.domain.model.content.Chunk;
 import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 import com.kairos.context_engine.domain.model.knowledge.Passage;
+import com.kairos.context_engine.domain.model.retrieval.candidate.PassageCandidate;
 import com.kairos.context_engine.infrastructure.graph.repository.projection.GraphExpansionResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -70,7 +70,7 @@ class KnowledgeGraphSearchAdapterTest {
         void graphName_hasHipporagPrefixAndUUIDSuffix() {
             stubSuccessfulExpansion(List.of(expansionRow(UUID.randomUUID())));
 
-            adapter.expandKnowledge(List.of(chunk()));
+            adapter.expandKnowledge(List.of(passageCandidate()));
 
             ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
             verify(gdsExecutor).projectPhraseGraph(captor.capture());
@@ -87,7 +87,7 @@ class KnowledgeGraphSearchAdapterTest {
         void singleCall_sameGraphNameUsedAcrossAllThreeOperations() {
             stubSuccessfulExpansion(List.of(expansionRow(UUID.randomUUID())));
 
-            adapter.expandKnowledge(List.of(chunk()));
+            adapter.expandKnowledge(List.of(passageCandidate()));
 
             ArgumentCaptor<String> projectCaptor = ArgumentCaptor.forClass(String.class);
             ArgumentCaptor<String> pprCaptor     = ArgumentCaptor.forClass(String.class);
@@ -107,8 +107,8 @@ class KnowledgeGraphSearchAdapterTest {
         void twoCalls_produceDistinctGraphNames() {
             stubSuccessfulExpansion(List.of(expansionRow(UUID.randomUUID())));
 
-            adapter.expandKnowledge(List.of(chunk()));
-            adapter.expandKnowledge(List.of(chunk()));
+            adapter.expandKnowledge(List.of(passageCandidate()));
+            adapter.expandKnowledge(List.of(passageCandidate()));
 
             ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
             verify(gdsExecutor, times(2)).projectPhraseGraph(captor.capture());
@@ -133,7 +133,7 @@ class KnowledgeGraphSearchAdapterTest {
             UUID id2 = UUID.randomUUID();
             stubSuccessfulExpansion(List.of(expansionRow(id1), expansionRow(id2)));
 
-            adapter.expandKnowledge(List.of(chunkWithId(id1), chunkWithId(id2)));
+            adapter.expandKnowledge(List.of(passageCandidate(id1), passageCandidate(id2)));
 
             ArgumentCaptor<List<String>> idsCaptor = ArgumentCaptor.forClass(List.class);
             verify(gdsExecutor).runPPRExpansion(
@@ -148,7 +148,7 @@ class KnowledgeGraphSearchAdapterTest {
         void pprConstants_matchExpectedValues() {
             stubSuccessfulExpansion(List.of(expansionRow(UUID.randomUUID())));
 
-            adapter.expandKnowledge(List.of(chunk()));
+            adapter.expandKnowledge(List.of(passageCandidate()));
 
             verify(gdsExecutor).runPPRExpansion(
                     anyString(), anyList(),
@@ -173,7 +173,7 @@ class KnowledgeGraphSearchAdapterTest {
             stubSuccessfulExpansion(List.of(
                     expansionRow("Paris", "CAPITAL_OF", "France", chunkId.toString())));
 
-            List<KnowledgeTriple> triples = adapter.expandKnowledge(List.of(chunkWithId(chunkId)));
+            List<KnowledgeTriple> triples = adapter.expandKnowledge(List.of(passageCandidate(chunkId)));
 
             assertThat(triples).hasSize(1);
             KnowledgeTriple triple = triples.getFirst();
@@ -190,7 +190,7 @@ class KnowledgeGraphSearchAdapterTest {
             GraphExpansionResult row = expansionRowWithScore("Paris", "CAPITAL_OF", "France", chunkId.toString(), 0.85, 0.42);
             stubSuccessfulExpansion(List.of(row));
 
-            List<KnowledgeTriple> triples = adapter.expandKnowledge(List.of(chunkWithId(chunkId)));
+            List<KnowledgeTriple> triples = adapter.expandKnowledge(List.of(passageCandidate(chunkId)));
 
             assertThat(triples)
                     .singleElement()
@@ -206,7 +206,7 @@ class KnowledgeGraphSearchAdapterTest {
                     expansionRow("A", "rel1", "B", chunkId1.toString()),
                     expansionRow("C", "rel2", "D", chunkId2.toString())));
 
-            List<KnowledgeTriple> triples = adapter.expandKnowledge(List.of(chunk()));
+            List<KnowledgeTriple> triples = adapter.expandKnowledge(List.of(passageCandidate()));
 
             assertThat(triples).hasSize(2);
             assertThat(triples.get(0).passage().chunkId()).isEqualTo(chunkId1);
@@ -218,7 +218,7 @@ class KnowledgeGraphSearchAdapterTest {
         void repositoryReturnsEmpty_resultIsEmpty() {
             stubSuccessfulExpansion(List.of());
 
-            List<KnowledgeTriple> result = adapter.expandKnowledge(List.of(chunk()));
+            List<KnowledgeTriple> result = adapter.expandKnowledge(List.of(passageCandidate()));
 
             assertThat(result).isEmpty();
         }
@@ -240,7 +240,7 @@ class KnowledgeGraphSearchAdapterTest {
                     expansionRow("X", "rel", "Y", null),
                     expansionRow("A", "rel", "B", validId.toString())));
 
-            List<KnowledgeTriple> result = adapter.expandKnowledge(List.of(chunk()));
+            List<KnowledgeTriple> result = adapter.expandKnowledge(List.of(passageCandidate()));
 
             assertThat(result)
                     .hasSize(1)
@@ -255,7 +255,7 @@ class KnowledgeGraphSearchAdapterTest {
                     expansionRow("X", "rel", "Y", null),
                     expansionRow("A", "rel", "B", null)));
 
-            List<KnowledgeTriple> result = adapter.expandKnowledge(List.of(chunk()));
+            List<KnowledgeTriple> result = adapter.expandKnowledge(List.of(passageCandidate()));
 
             assertThat(result).isEmpty();
         }
@@ -267,7 +267,7 @@ class KnowledgeGraphSearchAdapterTest {
             stubSuccessfulExpansion(List.of(
                     expansionRow(null, null, null, chunkId.toString())));
 
-            List<KnowledgeTriple> result = adapter.expandKnowledge(List.of(chunk()));
+            List<KnowledgeTriple> result = adapter.expandKnowledge(List.of(passageCandidate()));
 
             assertThat(result).isEmpty();
         }
@@ -289,7 +289,7 @@ class KnowledgeGraphSearchAdapterTest {
             when(gdsExecutor.runPPRExpansion(anyString(), anyList(), anyInt(), anyDouble(), anyInt()))
                     .thenThrow(pprFailure);
 
-            assertThatThrownBy(() -> adapter.expandKnowledge(List.of(chunk())))
+            assertThatThrownBy(() -> adapter.expandKnowledge(List.of(passageCandidate())))
                     .isSameAs(pprFailure);
 
             verify(gdsExecutor).dropProjectedGraph(anyString());
@@ -301,7 +301,7 @@ class KnowledgeGraphSearchAdapterTest {
             RuntimeException projectionFailure = new RuntimeException("GDS projection failure");
             doThrow(projectionFailure).when(gdsExecutor).projectPhraseGraph(anyString());
 
-            assertThatThrownBy(() -> adapter.expandKnowledge(List.of(chunk())))
+            assertThatThrownBy(() -> adapter.expandKnowledge(List.of(passageCandidate())))
                     .isSameAs(projectionFailure);
 
             verify(gdsExecutor).dropProjectedGraph(anyString());
@@ -316,7 +316,7 @@ class KnowledgeGraphSearchAdapterTest {
                     .when(gdsExecutor).dropProjectedGraph(anyString());
 
             assertThatCode(() -> {
-                List<KnowledgeTriple> result = adapter.expandKnowledge(List.of(chunk()));
+                List<KnowledgeTriple> result = adapter.expandKnowledge(List.of(passageCandidate()));
                 assertThat(result).hasSize(1);
             }).doesNotThrowAnyException();
         }
@@ -332,7 +332,7 @@ class KnowledgeGraphSearchAdapterTest {
                     .thenThrow(pprFailure);
             doThrow(dropFailure).when(gdsExecutor).dropProjectedGraph(anyString());
 
-            assertThatThrownBy(() -> adapter.expandKnowledge(List.of(chunk())))
+            assertThatThrownBy(() -> adapter.expandKnowledge(List.of(passageCandidate())))
                     .isSameAs(pprFailure)
                     .isNotSameAs(dropFailure);
         }
@@ -342,7 +342,7 @@ class KnowledgeGraphSearchAdapterTest {
         void emptyResult_graphStillDropped() {
             stubSuccessfulExpansion(List.of());
 
-            adapter.expandKnowledge(List.of(chunk()));
+            adapter.expandKnowledge(List.of(passageCandidate()));
 
             verify(gdsExecutor).dropProjectedGraph(anyString());
         }
@@ -388,14 +388,12 @@ class KnowledgeGraphSearchAdapterTest {
     // Helpers
     // ═════════════════════════════════════════════════════════════════════════
 
-    private Chunk chunk() {
-        return chunkWithId(UUID.randomUUID());
+    private PassageCandidate passageCandidate() {
+        return passageCandidate(UUID.randomUUID());
     }
 
-    private Chunk chunkWithId(UUID id) {
-        Chunk chunk = mock(Chunk.class);
-        when(chunk.getId()).thenReturn(id);
-        return chunk;
+    private PassageCandidate passageCandidate(UUID id) {
+        return new PassageCandidate(id, 1.0);
     }
 
     private void stubSuccessfulExpansion(List<GraphExpansionResult> rows) {

--- a/src/test/java/com/kairos/context_engine/infrastructure/semantic/SemanticSearchAdapterTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/semantic/SemanticSearchAdapterTest.java
@@ -1,9 +1,11 @@
 package com.kairos.context_engine.infrastructure.semantic;
 
 import com.kairos.context_engine.domain.model.content.Chunk;
+import com.kairos.context_engine.domain.model.retrieval.candidate.PassageCandidate;
 import com.kairos.context_engine.infrastructure.relational.entity.ChunkEntity;
 import com.kairos.context_engine.infrastructure.relational.entity.SourceEntity;
 import com.kairos.context_engine.infrastructure.relational.repository.chunk.JpaChunkRepository;
+import com.kairos.context_engine.infrastructure.relational.repository.projection.PassageCandidateProjection;
 import com.kairos.context_engine.infrastructure.relational.repository.source.JpaSourceRepository;
 import com.kairos.context_engine.infrastructure.relational.semantic.SemanticSearchAdapter;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,6 +65,20 @@ class SemanticSearchAdapterTest {
         return new ChunkEntity(id, source, content, index, false, QUERY_VECTOR);
     }
 
+    private PassageCandidateProjection candidateProjection(UUID chunkId, double denseScore) {
+        return new PassageCandidateProjection() {
+            @Override
+            public UUID getChunkId() {
+                return chunkId;
+            }
+
+            @Override
+            public double getDenseScore() {
+                return denseScore;
+            }
+        };
+    }
+
     // =========================================================================
     // search()
     // =========================================================================
@@ -70,103 +86,100 @@ class SemanticSearchAdapterTest {
 
 
     // =========================================================================
-    // findTopK()
+    // findPassageCandidate()
     // =========================================================================
 
     @Nested
-    @DisplayName("findTopK(float[], int)")
+    @DisplayName("findPassageCandidate(float[], int)")
     class FindTopKMethod {
 
         @Test
         @DisplayName("forwards the query vector and k to jpaChunkRepository unchanged")
         void forwardsVectorAndKToRepository() {
-            when(jpaChunkRepository.findTopKByEmbedding(QUERY_VECTOR, 10)).thenReturn(List.of());
+            when(jpaChunkRepository.findCandidates(QUERY_VECTOR, 10)).thenReturn(List.of());
 
-            adapter.findTopK(QUERY_VECTOR, 10);
+            adapter.findPassageCandidate(QUERY_VECTOR, 10);
 
             ArgumentCaptor<float[]> vectorCaptor = ArgumentCaptor.forClass(float[].class);
-            verify(jpaChunkRepository).findTopKByEmbedding(vectorCaptor.capture(), eq(10));
+            verify(jpaChunkRepository).findCandidates(vectorCaptor.capture(), eq(10));
             assertThat(vectorCaptor.getValue()).isEqualTo(QUERY_VECTOR);
         }
 
         @Test
-        @DisplayName("maps each ChunkEntity to a Chunk domain model preserving content and index")
-        void mapsChunkEntitiesToDomainModels() {
-            ChunkEntity entityA = chunkEntity(UUID.randomUUID(), sourceEntityA, "Chunk text A", 0);
-            ChunkEntity entityB = chunkEntity(UUID.randomUUID(), sourceEntityB, "Chunk text B", 1);
+        @DisplayName("maps each candidate projection to a PassageCandidate")
+        void mapsCandidateProjectionsToDomainModels() {
+            UUID idA = UUID.randomUUID();
+            UUID idB = UUID.randomUUID();
 
-            when(jpaChunkRepository.findTopKByEmbedding(any(), anyInt()))
-                    .thenReturn(List.of(entityA, entityB));
+            when(jpaChunkRepository.findCandidates(any(), anyInt()))
+                    .thenReturn(List.of(
+                            candidateProjection(idA, 0.91),
+                            candidateProjection(idB, 0.72)
+                    ));
 
-            List<Chunk> result = adapter.findTopK(QUERY_VECTOR, 2);
+            List<PassageCandidate> result = adapter.findPassageCandidate(QUERY_VECTOR, 2);
 
             assertThat(result).hasSize(2);
-            assertThat(result.getFirst().getContent()).isEqualTo("Chunk text A");
-            assertThat(result.getFirst().getIndex()).isEqualTo(0);
-            assertThat(result.get(1).getContent()).isEqualTo("Chunk text B");
-            assertThat(result.get(1).getIndex()).isEqualTo(1);
+            assertThat(result)
+                    .extracting(PassageCandidate::chunkId)
+                    .containsExactly(idA, idB);
+            assertThat(result)
+                    .extracting(PassageCandidate::denseScore)
+                    .containsExactly(0.91, 0.72);
         }
 
-        @Test
-        @DisplayName("hydrates each Chunk with the embedding from its entity")
-        void hydratesChunkWithEmbedding() {
-            ChunkEntity entity = chunkEntity(UUID.randomUUID(), sourceEntityA, "Some text", 0);
-
-            when(jpaChunkRepository.findTopKByEmbedding(any(), anyInt()))
-                    .thenReturn(List.of(entity));
-
-            List<Chunk> result = adapter.findTopK(QUERY_VECTOR, 1);
-
-            assertThat(result.getFirst().getEmbedding()).isEqualTo(QUERY_VECTOR);
-        }
 
         @Test
-        @DisplayName("hydrates each Chunk with the correct parent Source")
-        void hydratesChunkWithCorrectSource() {
-            ChunkEntity entity = chunkEntity(UUID.randomUUID(), sourceEntityA, "Some text", 0);
+        @DisplayName("maps chunk id and dense score from candidate projection")
+        void mapsChunkIdAndDenseScore() {
+            UUID id = UUID.randomUUID();
 
-            when(jpaChunkRepository.findTopKByEmbedding(any(), anyInt()))
-                    .thenReturn(List.of(entity));
+            when(jpaChunkRepository.findCandidates(any(), anyInt()))
+                    .thenReturn(List.of(candidateProjection(id, 0.84)));
 
-            List<Chunk> result = adapter.findTopK(QUERY_VECTOR, 1);
+            List<PassageCandidate> result = adapter.findPassageCandidate(QUERY_VECTOR, 1);
 
-            assertThat(result.getFirst().getSource().getId()).isEqualTo(sourceEntityA.getId());
-            assertThat(result.getFirst().getSource().getTitle()).isEqualTo(sourceEntityA.getTitle());
+            assertThat(result.getFirst().chunkId()).isEqualTo(id);
+            assertThat(result.getFirst().denseScore()).isEqualTo(0.84);
         }
 
         @Test
         @DisplayName("preserves the cosine-distance ranking order returned by the repository")
         void preservesRankingOrder() {
-            ChunkEntity first  = chunkEntity(UUID.randomUUID(), sourceEntityA, "Highest relevance", 0);
-            ChunkEntity second = chunkEntity(UUID.randomUUID(), sourceEntityA, "Medium relevance",  1);
-            ChunkEntity third  = chunkEntity(UUID.randomUUID(), sourceEntityA, "Lowest relevance",  2);
+            UUID idA = UUID.randomUUID();
+            UUID idB = UUID.randomUUID();
+            UUID idC = UUID.randomUUID();
 
-            when(jpaChunkRepository.findTopKByEmbedding(any(), anyInt()))
-                    .thenReturn(List.of(first, second, third));
+            when(jpaChunkRepository.findCandidates(any(), anyInt()))
+                    .thenReturn(List.of(
+                            candidateProjection(idA, 0.95),
+                            candidateProjection(idB, 0.82),
+                            candidateProjection(idC, 0.61)
+                    ));
 
-            List<Chunk> result = adapter.findTopK(QUERY_VECTOR, 3);
+            List<PassageCandidate> result = adapter.findPassageCandidate(QUERY_VECTOR, 3);
 
             assertThat(result)
-                    .extracting(Chunk::getContent)
-                    .containsExactly("Highest relevance", "Medium relevance", "Lowest relevance");
+                    .extracting(PassageCandidate::chunkId)
+                    .containsExactly(idA, idB, idC);
         }
 
         @Test
         @DisplayName("returns an empty list when the repository finds no matching chunks")
         void returnsEmptyListWhenNoResults() {
-            when(jpaChunkRepository.findTopKByEmbedding(any(), anyInt())).thenReturn(List.of());
+            when(jpaChunkRepository.findCandidates(any(), anyInt())).thenReturn(List.of());
 
-            List<Chunk> result = adapter.findTopK(QUERY_VECTOR, 10);
+            List<PassageCandidate> result = adapter.findPassageCandidate(QUERY_VECTOR, 10);
 
             assertThat(result).isEmpty();
         }
 
         @Test
-        @DisplayName("never interacts with jpaSourceRepository during findTopK")
+        @DisplayName("never interacts with jpaSourceRepository during findPassageCandidate")
         void doesNotTouchSourceRepositoryDuringFindTopK() {
-            when(jpaChunkRepository.findTopKByEmbedding(any(), anyInt())).thenReturn(List.of());
+            when(jpaChunkRepository.findCandidates(any(), anyInt())).thenReturn(List.of());
 
-            adapter.findTopK(QUERY_VECTOR, 10);
+            adapter.findPassageCandidate(QUERY_VECTOR, 10);
 
             verifyNoInteractions(jpaSourceRepository);
         }
@@ -174,10 +187,10 @@ class SemanticSearchAdapterTest {
         @Test
         @DisplayName("propagates RuntimeException from jpaChunkRepository without wrapping")
         void propagatesRepositoryException() {
-            when(jpaChunkRepository.findTopKByEmbedding(any(), anyInt()))
+            when(jpaChunkRepository.findCandidates(any(), anyInt()))
                     .thenThrow(new RuntimeException("Connection pool exhausted"));
 
-            assertThatThrownBy(() -> adapter.findTopK(QUERY_VECTOR, 10))
+            assertThatThrownBy(() -> adapter.findPassageCandidate(QUERY_VECTOR, 10))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessage("Connection pool exhausted");
         }
@@ -338,12 +351,12 @@ class SemanticSearchAdapterTest {
 
 
         @Test
-        @DisplayName("findTopK() and findChunks() each call only jpaChunkRepository, never jpaSourceRepository")
+        @DisplayName("findPassageCandidate() and findChunks() each call only jpaChunkRepository, never jpaSourceRepository")
         void chunkMethodsDoNotTouchSourceRepository() {
-            when(jpaChunkRepository.findTopKByEmbedding(any(), anyInt())).thenReturn(List.of());
+            when(jpaChunkRepository.findCandidates(any(), anyInt())).thenReturn(List.of());
             when(jpaChunkRepository.findAllById(anyList())).thenReturn(List.of());
 
-            adapter.findTopK(QUERY_VECTOR, 5);
+            adapter.findPassageCandidate(QUERY_VECTOR, 5);
             adapter.findChunks(List.of(UUID.randomUUID()));
 
             verifyNoInteractions(jpaSourceRepository);

--- a/src/test/java/com/kairos/context_engine/use_case/GenerateSourceContextUseCaseTest.java
+++ b/src/test/java/com/kairos/context_engine/use_case/GenerateSourceContextUseCaseTest.java
@@ -2,6 +2,7 @@ package com.kairos.context_engine.use_case;
 
 import com.kairos.context_engine.application.command.GenerateSourceContextCommand;
 import com.kairos.context_engine.application.use_case.GenerateSourceContextUseCase;
+import com.kairos.context_engine.domain.model.knowledge.Passage;
 import com.kairos.context_engine.domain.port.embedding.EmbeddingProvider;
 import com.kairos.context_engine.domain.port.graph.KnowledgeGraphStore;
 import com.kairos.context_engine.domain.port.extraction.TripleExtractor;
@@ -100,17 +101,20 @@ class GenerateSourceContextUseCaseTest {
     @Test
     @DisplayName("execute - creates graph context before saving extracted triples")
     void execute_createsGraphContextForLoadedChunks() {
-        Chunk chunk = chunk("chunk content", 0);
+        UUID chunkId = UUID.randomUUID();
+
+        Chunk chunk = new Chunk(chunkId, source, "passage content", 0, false, null);
+        Passage passage = new Passage(chunkId);
         Triple triple = new Triple("backpropagation", "USES", "chain rule");
 
         when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
         when(chunkRepository.findAllBySourceId(sourceId)).thenReturn(List.of(chunk));
         when(embeddingProvider.embed(anyString())).thenReturn(new float[]{0.1f});
-        when(tripleExtractor.extract("chunk content")).thenReturn(List.of(triple));
+        when(tripleExtractor.extract("passage content")).thenReturn(List.of(triple));
 
         useCase.execute(GenerateSourceContextCommand.of(sourceId));
 
-        verify(knowledgeGraphStore).createContext(List.of(chunk));
+        verify(knowledgeGraphStore).savePassages(List.of(passage));
 
         ArgumentCaptor<List<KnowledgeTriple>> triplesCaptor = ArgumentCaptor.captor();
         verify(knowledgeGraphStore).saveAllForChunk(eq(chunk.getId()), triplesCaptor.capture());
@@ -205,7 +209,7 @@ class GenerateSourceContextUseCaseTest {
 
         verifyNoInteractions(embeddingProvider, tripleExtractor);
         verify(chunkRepository, never()).save(any(Chunk.class));
-        verify(knowledgeGraphStore).createContext(List.of());
+        verify(knowledgeGraphStore).savePassages(List.of());
         verify(knowledgeGraphStore, never()).saveAllForChunk(any(), anyList());
     }
 }

--- a/src/test/java/com/kairos/context_engine/use_case/SearchSourceUseCaseTest.java
+++ b/src/test/java/com/kairos/context_engine/use_case/SearchSourceUseCaseTest.java
@@ -6,6 +6,7 @@ import com.kairos.context_engine.domain.model.content.Chunk;
 import com.kairos.context_engine.domain.model.content.Source;
 import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 import com.kairos.context_engine.domain.model.knowledge.Passage;
+import com.kairos.context_engine.domain.model.retrieval.candidate.PassageCandidate;
 import com.kairos.context_engine.domain.port.embedding.EmbeddingProvider;
 import com.kairos.context_engine.domain.port.graph.KnowledgeGraphSearch;
 import com.kairos.context_engine.domain.model.*;
@@ -72,6 +73,10 @@ class SearchSourceUseCaseTest {
         return KnowledgeTriple.create("Consciousness", "is_part_of", "Mind", Passage.fromChunkId(chunkId), 1.0);
     }
 
+    private PassageCandidate passageCandidate(Chunk chunk) {
+        return new PassageCandidate(chunk.getId(), 1.0);
+    }
+
     // =========================================================================
     // Happy path
     // =========================================================================
@@ -85,17 +90,18 @@ class SearchSourceUseCaseTest {
         void embedsSearchTermAndForwardsVector() {
             var query   = new SearchSourceQuery(SEARCH_TERM);
             var anchor  = chunk(UUID.randomUUID(), "Consciousness arises from neural activity.", 0);
+            var candidate = passageCandidate(anchor);
             var triple  = triple(anchor.getId());
 
             when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
-            when(semanticSearch.findTopK(QUERY_VECTOR, 10)).thenReturn(List.of(anchor));
-            when(knowledgeGraphSearch.expandKnowledge(List.of(anchor))).thenReturn(List.of(triple));
+            when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10)).thenReturn(List.of(candidate));
+            when(knowledgeGraphSearch.expandKnowledge(List.of(candidate))).thenReturn(List.of(triple));
             when(semanticSearch.findChunks(List.of(anchor.getId()))).thenReturn(List.of(anchor));
 
             useCase.execute(query);
 
             ArgumentCaptor<float[]> vectorCaptor = ArgumentCaptor.forClass(float[].class);
-            verify(semanticSearch).findTopK(vectorCaptor.capture(), eq(10));
+            verify(semanticSearch).findPassageCandidate(vectorCaptor.capture(), eq(10));
             assertThat(vectorCaptor.getValue()).isEqualTo(QUERY_VECTOR);
         }
 
@@ -104,11 +110,12 @@ class SearchSourceUseCaseTest {
         void returnsNonEmptyResultWithTriplesAndChunks() {
             var query  = new SearchSourceQuery(SEARCH_TERM);
             var anchor = chunk(UUID.randomUUID(), "The mind supervenes on the brain.", 0);
+            var candidate = passageCandidate(anchor);
             var triple = triple(anchor.getId());
 
             when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
-            when(semanticSearch.findTopK(QUERY_VECTOR, 10)).thenReturn(List.of(anchor));
-            when(knowledgeGraphSearch.expandKnowledge(List.of(anchor))).thenReturn(List.of(triple));
+            when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10)).thenReturn(List.of(candidate));
+            when(knowledgeGraphSearch.expandKnowledge(List.of(candidate))).thenReturn(List.of(triple));
             when(semanticSearch.findChunks(List.of(anchor.getId()))).thenReturn(List.of(anchor));
 
             SearchResult result = useCase.execute(query);
@@ -127,16 +134,19 @@ class SearchSourceUseCaseTest {
                     chunk(UUID.randomUUID(), "Chunk B", 1),
                     chunk(UUID.randomUUID(), "Chunk C", 2)
             );
+            List<PassageCandidate> candidates = anchors.stream()
+                    .map(SearchSourceUseCaseTest.this::passageCandidate)
+                    .toList();
             var triple = triple(anchors.getFirst().getId());
 
             when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
-            when(semanticSearch.findTopK(QUERY_VECTOR, 10)).thenReturn(anchors);
-            when(knowledgeGraphSearch.expandKnowledge(anchors)).thenReturn(List.of(triple));
+            when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10)).thenReturn(candidates);
+            when(knowledgeGraphSearch.expandKnowledge(candidates)).thenReturn(List.of(triple));
             when(semanticSearch.findChunks(anyList())).thenReturn(List.of(anchors.getFirst()));
 
             useCase.execute(query);
 
-            verify(knowledgeGraphSearch).expandKnowledge(anchors);
+            verify(knowledgeGraphSearch).expandKnowledge(candidates);
         }
     }
 
@@ -152,7 +162,7 @@ class SearchSourceUseCaseTest {
         @DisplayName("returns SearchResult.empty() immediately")
         void returnsEmptyResultWhenNoAnchors() {
             when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
-            when(semanticSearch.findTopK(QUERY_VECTOR, 10)).thenReturn(List.of());
+            when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10)).thenReturn(List.of());
 
             SearchResult result = useCase.execute(new SearchSourceQuery(SEARCH_TERM));
 
@@ -163,7 +173,7 @@ class SearchSourceUseCaseTest {
         @DisplayName("never calls the knowledge graph when no anchors are present")
         void neverCallsGraphWhenNoAnchors() {
             when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
-            when(semanticSearch.findTopK(QUERY_VECTOR, 10)).thenReturn(List.of());
+            when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10)).thenReturn(List.of());
 
             useCase.execute(new SearchSourceQuery(SEARCH_TERM));
 
@@ -174,7 +184,7 @@ class SearchSourceUseCaseTest {
         @DisplayName("never calls findChunks when no anchors are present")
         void neverCallsFindChunksWhenNoAnchors() {
             when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
-            when(semanticSearch.findTopK(QUERY_VECTOR, 10)).thenReturn(List.of());
+            when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10)).thenReturn(List.of());
 
             useCase.execute(new SearchSourceQuery(SEARCH_TERM));
 
@@ -210,7 +220,7 @@ class SearchSourceUseCaseTest {
 
             // Semantic store returns chunks in reverse order (simulating unordered DB result)
             when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
-            when(semanticSearch.findTopK(QUERY_VECTOR, 10)).thenReturn(List.of(chunkFirst));
+            when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10)).thenReturn(List.of(passageCandidate(chunkFirst)));
             when(knowledgeGraphSearch.expandKnowledge(anyList())).thenReturn(orderedTriples);
             when(semanticSearch.findChunks(anyList())).thenReturn(
                     List.of(chunkThird, chunkSecond, chunkFirst)  // intentionally scrambled
@@ -239,7 +249,7 @@ class SearchSourceUseCaseTest {
             );
 
             when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
-            when(semanticSearch.findTopK(QUERY_VECTOR, 10)).thenReturn(List.of(sharedChunk));
+            when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10)).thenReturn(List.of(passageCandidate(sharedChunk)));
             when(knowledgeGraphSearch.expandKnowledge(anyList())).thenReturn(triplesWithDuplicate);
             when(semanticSearch.findChunks(anyList())).thenReturn(List.of(sharedChunk, uniqueChunk));
 
@@ -265,7 +275,7 @@ class SearchSourceUseCaseTest {
             );
 
             when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
-            when(semanticSearch.findTopK(QUERY_VECTOR, 10)).thenReturn(List.of(anchor));
+            when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10)).thenReturn(List.of(passageCandidate(anchor)));
             when(knowledgeGraphSearch.expandKnowledge(anyList())).thenReturn(triples);
             when(semanticSearch.findChunks(anyList())).thenReturn(List.of());
 
@@ -295,7 +305,7 @@ class SearchSourceUseCaseTest {
             var anchor = chunk(UUID.randomUUID(), "Orphan chunk with no graph connections.", 0);
 
             when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
-            when(semanticSearch.findTopK(QUERY_VECTOR, 10)).thenReturn(List.of(anchor));
+            when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10)).thenReturn(List.of(passageCandidate(anchor)));
             when(knowledgeGraphSearch.expandKnowledge(anyList())).thenReturn(List.of());
 
             SearchResult result = useCase.execute(new SearchSourceQuery(SEARCH_TERM));
@@ -318,7 +328,7 @@ class SearchSourceUseCaseTest {
             List<KnowledgeTriple> triples = List.of(triple(idPresent), triple(idMissing));
 
             when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
-            when(semanticSearch.findTopK(QUERY_VECTOR, 10)).thenReturn(List.of(presentChunk));
+            when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10)).thenReturn(List.of(passageCandidate(presentChunk)));
             when(knowledgeGraphSearch.expandKnowledge(anyList())).thenReturn(triples);
             when(semanticSearch.findChunks(anyList())).thenReturn(List.of(presentChunk)); // idMissing absent
 
@@ -332,11 +342,11 @@ class SearchSourceUseCaseTest {
         @DisplayName("always requests exactly top-10 anchors from the semantic port")
         void alwaysRequestsTopTenAnchors() {
             when(embeddingPort.embed(any())).thenReturn(QUERY_VECTOR);
-            when(semanticSearch.findTopK(any(), eq(10))).thenReturn(List.of());
+            when(semanticSearch.findPassageCandidate(any(), eq(10))).thenReturn(List.of());
 
             useCase.execute(new SearchSourceQuery("any term"));
 
-            verify(semanticSearch).findTopK(any(), eq(10));
+            verify(semanticSearch).findPassageCandidate(any(), eq(10));
         }
 
         @Test
@@ -344,11 +354,12 @@ class SearchSourceUseCaseTest {
         void singleChunkSingleTriple() {
             var id     = UUID.randomUUID();
             var single = chunk(id, "The only result.", 0);
+            var candidate = passageCandidate(single);
             var triple = triple(id);
 
             when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
-            when(semanticSearch.findTopK(QUERY_VECTOR, 10)).thenReturn(List.of(single));
-            when(knowledgeGraphSearch.expandKnowledge(List.of(single))).thenReturn(List.of(triple));
+            when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10)).thenReturn(List.of(candidate));
+            when(knowledgeGraphSearch.expandKnowledge(List.of(candidate))).thenReturn(List.of(triple));
             when(semanticSearch.findChunks(List.of(id))).thenReturn(List.of(single));
 
             SearchResult result = useCase.execute(new SearchSourceQuery(SEARCH_TERM));
@@ -383,7 +394,7 @@ class SearchSourceUseCaseTest {
             var anchor = chunk(UUID.randomUUID(), "Anchor.", 0);
 
             when(embeddingPort.embed(any())).thenReturn(QUERY_VECTOR);
-            when(semanticSearch.findTopK(any(), anyInt())).thenReturn(List.of(anchor));
+            when(semanticSearch.findPassageCandidate(any(), anyInt())).thenReturn(List.of(passageCandidate(anchor)));
             when(knowledgeGraphSearch.expandKnowledge(anyList()))
                     .thenThrow(new RuntimeException("Neo4j connection refused"));
 
@@ -399,7 +410,7 @@ class SearchSourceUseCaseTest {
             var triple = triple(anchor.getId());
 
             when(embeddingPort.embed(any())).thenReturn(QUERY_VECTOR);
-            when(semanticSearch.findTopK(any(), anyInt())).thenReturn(List.of(anchor));
+            when(semanticSearch.findPassageCandidate(any(), anyInt())).thenReturn(List.of(passageCandidate(anchor)));
             when(knowledgeGraphSearch.expandKnowledge(anyList())).thenReturn(List.of(triple));
             when(semanticSearch.findChunks(anyList()))
                     .thenThrow(new RuntimeException("pgvector query timeout"));
@@ -425,14 +436,14 @@ class SearchSourceUseCaseTest {
             var triple = triple(anchor.getId());
 
             when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
-            when(semanticSearch.findTopK(QUERY_VECTOR, 10)).thenReturn(List.of(anchor));
+            when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10)).thenReturn(List.of(passageCandidate(anchor)));
             when(knowledgeGraphSearch.expandKnowledge(anyList())).thenReturn(List.of(triple));
             when(semanticSearch.findChunks(anyList())).thenReturn(List.of(anchor));
 
             useCase.execute(new SearchSourceQuery(SEARCH_TERM));
 
             verify(embeddingPort, times(1)).embed(any());
-            verify(semanticSearch, times(1)).findTopK(any(), anyInt());
+            verify(semanticSearch, times(1)).findPassageCandidate(any(), anyInt());
             verify(knowledgeGraphSearch, times(1)).expandKnowledge(anyList());
             verify(semanticSearch, times(1)).findChunks(anyList());
         }
@@ -443,7 +454,7 @@ class SearchSourceUseCaseTest {
             var anchor = chunk(UUID.randomUUID(), "Anchor.", 0);
 
             when(embeddingPort.embed(any())).thenReturn(QUERY_VECTOR);
-            when(semanticSearch.findTopK(any(), anyInt())).thenReturn(List.of(anchor));
+            when(semanticSearch.findPassageCandidate(any(), anyInt())).thenReturn(List.of(passageCandidate(anchor)));
             when(knowledgeGraphSearch.expandKnowledge(anyList())).thenReturn(List.of());
 
             useCase.execute(new SearchSourceQuery(SEARCH_TERM));


### PR DESCRIPTION
## Summary

Introduces the first retrieval-domain foundation for HippoRAG 2 and adapts the current retrieval flow to use `PassageCandidate` as the dense passage recall result.

This PR intentionally avoids rewriting the full search algorithm in order to keep the review focused and prevent a large cascading refactor. The next PR can focus specifically on changing `SearchSourceUseCase` and graph search behavior toward `GraphSearchRequest`, `GraphSearchResult`, `ScoredPassage`, and `RankedChunk`.

## Context

After the knowledge model cleanup, the next step is to stop treating raw `Chunk` objects as the first-class result of dense recall.

Dense search should first return passage candidates with retrieval metadata, especially the dense score. Full chunk hydration should happen later, only after the retrieval pipeline decides which passages are actually needed.

This PR starts that transition.

## Changes

- Added retrieval-domain models:
  - `PassageCandidate`
  - `TripleCandidate`
  - `FilteredTriple`
  - `GraphSeed`
  - `SeedType`
  - `GraphSeedTarget`
  - `PassageSeedTarget`
  - `ConceptSeedTarget`
  - `GraphSearchRequest`
  - `GraphSearchResult`
  - `ScoredPassage`
  - `RankedChunk`
  - `RetrievalSource`

- Updated dense semantic search to return `PassageCandidate`.
  - `SemanticSearch.findPassageCandidate(...)` now returns `chunkId + denseScore`.
  - Added `PassageCandidateProjection` for the pgvector query.
  - Preserved dense score instead of discarding it immediately.

- Updated the current graph/search compatibility flow.
  - `SearchSourceUseCase` now receives passage candidates from semantic search.
  - `KnowledgeGraphSearch` accepts `PassageCandidate` anchors.
  - `KnowledgeGraphSearchAdapter` reads candidate `chunkId`s as graph anchor IDs.
  - Chunk hydration still happens later through `findChunks(...)`.

- Updated passage handling in context generation/store flow where needed.
  - Keeps the current behavior working with the newer `Passage` model.
  - Avoids broader algorithm changes in this PR.

- Updated tests to match the new candidate-based contract.
  - Semantic search tests now validate `PassageCandidate` mapping.
  - Graph search adapter tests now use `PassageCandidate` anchors.
  - Search use case tests now separate candidate recall from final chunk hydration.

## What This PR Does Not Do

This PR does not fully rewrite the HippoRAG retrieval algorithm yet.

Specifically, it does not complete the full transition to:

- `GraphSearchRequest` as the graph input
- `GraphSearchResult` as the graph output
- `ScoredPassage` as the primary graph result
- `RankedChunk` as the final search result
- full dense fallback behavior
- weighted PPR
- triple recall / recognition memory

Those changes should be handled in the next PR, focused mainly on the search algorithm and `SearchSourceUseCase`.

## Why This Scope

The goal here is to make the domain capable of representing the next retrieval pipeline without making the current PR difficult to review.

This gives the project a clean intermediate state:

- retrieval entities exist
- dense passage candidates preserve score
- the current flow still works
- tests pass
- the next PR can focus on behavior instead of model creation

## Next Step
Refactor the search algorithm itself, especially SearchSourceUseCase, to move from the current compatibility flow toward:

```
query
 -> PassageCandidate
 -> GraphSearchRequest
 -> GraphSearchResult
 -> ScoredPassage
 -> RankedChunk
 -> activated triples as explanation
```