### PR TITLE
#40 Refactor question search to retrieve stored triples and select graph seeds with recognition memory

### DIFF
--- a/src/main/java/com/kairos/context_engine/application/use_case/SearchSourceUseCase.java
+++ b/src/main/java/com/kairos/context_engine/application/use_case/SearchSourceUseCase.java
@@ -1,8 +1,8 @@
 package com.kairos.context_engine.application.use_case;
 
 import com.kairos.context_engine.application.query.SearchSourceQuery;
-import com.kairos.context_engine.domain.model.retrieval.candidate.ConceptCandidate;
 import com.kairos.context_engine.domain.model.retrieval.candidate.PassageCandidate;
+import com.kairos.context_engine.domain.model.retrieval.candidate.TripleCandidate;
 import com.kairos.context_engine.domain.model.retrieval.graph.GraphSearchRequest;
 import com.kairos.context_engine.domain.model.retrieval.graph.GraphSearchResult;
 import com.kairos.context_engine.domain.model.retrieval.ranking.RankedChunk;
@@ -10,6 +10,7 @@ import com.kairos.context_engine.domain.model.retrieval.seed.GraphSeed;
 import com.kairos.context_engine.domain.port.embedding.EmbeddingProvider;
 import com.kairos.context_engine.domain.port.graph.KnowledgeGraphSearch;
 import com.kairos.context_engine.domain.model.SearchResult;
+import com.kairos.context_engine.domain.port.recognition.RecognitionMemory;
 import com.kairos.context_engine.domain.port.semantic.SemanticSearch;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,12 +40,19 @@ public class SearchSourceUseCase {
     private final EmbeddingProvider embeddingPort;
     private final KnowledgeGraphSearch knowledgeGraphSearch;
     private final SemanticSearch semanticSearch;
+    private final RecognitionMemory recognitionMemory;
 
     @Value("${kairos.retrieval.semantic-anchor-limit:10}")
     private int semanticAnchorLimit = 10;
 
     @Value("${kairos.retrieval.graph-passage-limit:20}")
     private int graphPassageLimit = 20;
+
+    @Value("${kairos.retrieval.triple-candidate-limit:30}")
+    private int tripleCandidateLimit = 30;
+
+    @Value("${kairos.retrieval.recognition-seed-limit:10}")
+    private int recognitionSeedLimit = 10;
 
     @Value("${kairos.retrieval.seed-min-score:0.45}")
     private double seedMinScore = 0.45d;
@@ -61,9 +69,12 @@ public class SearchSourceUseCase {
         float[] queryVector = embeddingPort.embed(query.searchTerm());
 
         List<PassageCandidate> passageCandidates = semanticSearch.findPassageCandidate(queryVector, semanticAnchorLimit);
-        List<ConceptCandidate> conceptCandidates = semanticSearch.findConceptCandidate(queryVector, semanticAnchorLimit);
+        List<TripleCandidate> tripleCandidates = semanticSearch.findTripleCandidates(queryVector, tripleCandidateLimit);
+        List<GraphSeed> conceptSeeds = tripleCandidates.isEmpty()
+                ? List.of()
+                : recognitionMemory.recognize(query.searchTerm(), tripleCandidates, recognitionSeedLimit);
 
-        var seeds = instanceSeedsFromCandidates(passageCandidates, conceptCandidates);
+        var seeds = instanceSeedsFromCandidates(passageCandidates, conceptSeeds);
 
         if (seeds.isEmpty()) {
             return SearchResult.empty();
@@ -81,16 +92,10 @@ public class SearchSourceUseCase {
     }
 
 
-    private List<GraphSeed> instanceSeedsFromCandidates(List<PassageCandidate> passageCandidates, List<ConceptCandidate> conceptCandidates) {
+    private List<GraphSeed> instanceSeedsFromCandidates(List<PassageCandidate> passageCandidates, List<GraphSeed> conceptSeeds) {
         double passageThreshold = seedThreshold(
                 passageCandidates.stream()
                         .mapToDouble(PassageCandidate::denseScore)
-                        .max()
-                        .orElse(0d)
-        );
-        double conceptThreshold = seedThreshold(
-                conceptCandidates.stream()
-                        .mapToDouble(ConceptCandidate::similarityScore)
                         .max()
                         .orElse(0d)
         );
@@ -99,9 +104,9 @@ public class SearchSourceUseCase {
                 .filter(candidate -> candidate.denseScore() >= passageThreshold)
                 .map(candidate -> GraphSeed.passage(candidate.chunkId(), candidate.denseScore()));
 
-        var conceptSeed = conceptCandidates.stream()
-                .filter(candidate -> candidate.similarityScore() >= conceptThreshold)
-                .map(candidate -> GraphSeed.concept(candidate.concept().name(), candidate.similarityScore()));
+        var conceptSeed = conceptSeeds == null
+                ? Stream.<GraphSeed>empty()
+                : conceptSeeds.stream();
 
         return Stream.concat(passageSeed, conceptSeed).toList();
     }

--- a/src/main/java/com/kairos/context_engine/application/use_case/SearchSourceUseCase.java
+++ b/src/main/java/com/kairos/context_engine/application/use_case/SearchSourceUseCase.java
@@ -104,9 +104,19 @@ public class SearchSourceUseCase {
                 .filter(candidate -> candidate.denseScore() >= passageThreshold)
                 .map(candidate -> GraphSeed.passage(candidate.chunkId(), candidate.denseScore()));
 
+        double conceptThreshold = seedThreshold(
+                conceptSeeds == null
+                        ? 0d
+                        : conceptSeeds.stream()
+                                .mapToDouble(GraphSeed::weight)
+                                .max()
+                                .orElse(0d)
+        );
+
         var conceptSeed = conceptSeeds == null
                 ? Stream.<GraphSeed>empty()
-                : conceptSeeds.stream();
+                : conceptSeeds.stream()
+                        .filter(seed -> seed.weight() >= conceptThreshold);
 
         return Stream.concat(passageSeed, conceptSeed).toList();
     }

--- a/src/main/java/com/kairos/context_engine/domain/model/retrieval/candidate/TripleCandidate.java
+++ b/src/main/java/com/kairos/context_engine/domain/model/retrieval/candidate/TripleCandidate.java
@@ -1,0 +1,38 @@
+package com.kairos.context_engine.domain.model.retrieval.candidate;
+
+import java.util.UUID;
+
+public record TripleCandidate(
+        String key,
+        String subject,
+        String predicate,
+        String object,
+        UUID chunkId,
+        double similarityScore
+) {
+    public TripleCandidate {
+        if (key == null || key.isBlank()) {
+            throw new IllegalArgumentException("Triple candidate key cannot be null or blank");
+        }
+        if (subject == null || subject.isBlank()) {
+            throw new IllegalArgumentException("Triple candidate subject cannot be null or blank");
+        }
+        if (predicate == null || predicate.isBlank()) {
+            throw new IllegalArgumentException("Triple candidate predicate cannot be null or blank");
+        }
+        if (object == null || object.isBlank()) {
+            throw new IllegalArgumentException("Triple candidate object cannot be null or blank");
+        }
+        if (chunkId == null) {
+            throw new IllegalArgumentException("Triple candidate chunkId cannot be null");
+        }
+        if (!Double.isFinite(similarityScore)) {
+            throw new IllegalArgumentException("Triple candidate similarity score must be finite");
+        }
+
+        key = key.trim();
+        subject = subject.trim();
+        predicate = predicate.trim();
+        object = object.trim();
+    }
+}

--- a/src/main/java/com/kairos/context_engine/domain/port/recognition/RecognitionMemory.java
+++ b/src/main/java/com/kairos/context_engine/domain/port/recognition/RecognitionMemory.java
@@ -1,0 +1,11 @@
+package com.kairos.context_engine.domain.port.recognition;
+
+import com.kairos.context_engine.domain.model.retrieval.candidate.TripleCandidate;
+import com.kairos.context_engine.domain.model.retrieval.seed.GraphSeed;
+
+import java.util.List;
+
+public interface RecognitionMemory {
+
+    List<GraphSeed> recognize(String searchTerm, List<TripleCandidate> candidates, int maxSeeds);
+}

--- a/src/main/java/com/kairos/context_engine/domain/port/semantic/SemanticSearch.java
+++ b/src/main/java/com/kairos/context_engine/domain/port/semantic/SemanticSearch.java
@@ -1,8 +1,8 @@
 package com.kairos.context_engine.domain.port.semantic;
 
 import com.kairos.context_engine.domain.model.content.Chunk;
-import com.kairos.context_engine.domain.model.retrieval.candidate.ConceptCandidate;
 import com.kairos.context_engine.domain.model.retrieval.candidate.PassageCandidate;
+import com.kairos.context_engine.domain.model.retrieval.candidate.TripleCandidate;
 import com.kairos.context_engine.domain.model.retrieval.ranking.RankedChunk;
 import com.kairos.context_engine.domain.model.retrieval.ranking.ScoredPassage;
 
@@ -17,5 +17,5 @@ public interface SemanticSearch {
 
     List<RankedChunk> hydrateAndRankChunks(List<ScoredPassage> scoredPassages);
 
-    List<ConceptCandidate> findConceptCandidate(float[] queryVector, int semanticAnchorLimit);
+    List<TripleCandidate> findTripleCandidates(float[] queryVector, int limit);
 }

--- a/src/main/java/com/kairos/context_engine/infrastructure/extraction/GeminiTripleExtractorAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/extraction/GeminiTripleExtractorAdapter.java
@@ -6,6 +6,7 @@ import com.kairos.context_engine.infrastructure.ai.gemini.dto.TripleExtractionRe
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.AdvisorParams;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -71,7 +72,7 @@ public class GeminiTripleExtractorAdapter implements TripleExtractor {
 
     private final ChatClient chatClient;
 
-    public GeminiTripleExtractorAdapter(ChatClient chatClient) {
+    public GeminiTripleExtractorAdapter(@Qualifier("tripleExtractionChatClient") ChatClient chatClient) {
         this.chatClient = chatClient;
     }
 

--- a/src/main/java/com/kairos/context_engine/infrastructure/recognition/GeminiRecognitionMemoryAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/recognition/GeminiRecognitionMemoryAdapter.java
@@ -8,6 +8,7 @@ import com.kairos.context_engine.infrastructure.recognition.dto.RecognizedConcep
 import com.kairos.context_engine.infrastructure.recognition.dto.RecognitionMemoryResult;
 import org.springframework.ai.chat.client.AdvisorParams;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.util.LinkedHashMap;
@@ -43,7 +44,7 @@ public class GeminiRecognitionMemoryAdapter implements RecognitionMemory {
 
     private final ChatClient chatClient;
 
-    public GeminiRecognitionMemoryAdapter(ChatClient chatClient) {
+    public GeminiRecognitionMemoryAdapter(@Qualifier("recognitionMemoryChatClient") ChatClient chatClient) {
         this.chatClient = chatClient;
     }
 

--- a/src/main/java/com/kairos/context_engine/infrastructure/recognition/GeminiRecognitionMemoryAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/recognition/GeminiRecognitionMemoryAdapter.java
@@ -1,0 +1,153 @@
+package com.kairos.context_engine.infrastructure.recognition;
+
+import com.kairos.context_engine.domain.model.retrieval.candidate.TripleCandidate;
+import com.kairos.context_engine.domain.model.retrieval.seed.ConceptSeedTarget;
+import com.kairos.context_engine.domain.model.retrieval.seed.GraphSeed;
+import com.kairos.context_engine.domain.port.recognition.RecognitionMemory;
+import com.kairos.context_engine.infrastructure.recognition.dto.RecognizedConcept;
+import com.kairos.context_engine.infrastructure.recognition.dto.RecognitionMemoryResult;
+import org.springframework.ai.chat.client.AdvisorParams;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Component
+public class GeminiRecognitionMemoryAdapter implements RecognitionMemory {
+
+    static final String PROMPT = """
+            You are the recognition memory stage of a graph retrieval pipeline.
+
+            Given a user question and a ranked list of candidate triples, select the concepts that should seed graph
+            Personalized PageRank. Only choose concepts that are directly useful for answering the question.
+
+            Rules:
+            - Return at most {maxSeeds} concepts.
+            - Every returned concept must be exactly one candidate triple subject or object.
+            - Do not return predicates.
+            - Do not invent, translate, rename, pluralize, or normalize concepts beyond the supplied subject/object text.
+            - Prefer a smaller set of highly relevant concepts over broad recall.
+            - Use confidence from 0.0 to 1.0, where higher means the concept is more central to the question.
+
+            Question:
+            {question}
+
+            Candidate triples:
+            {triples}
+            """;
+
+    private final ChatClient chatClient;
+
+    public GeminiRecognitionMemoryAdapter(ChatClient chatClient) {
+        this.chatClient = chatClient;
+    }
+
+    @Override
+    public List<GraphSeed> recognize(String searchTerm, List<TripleCandidate> candidates, int maxSeeds) {
+        if (searchTerm == null || searchTerm.isBlank() || candidates == null || candidates.isEmpty() || maxSeeds <= 0) {
+            return List.of();
+        }
+
+        RecognitionMemoryResult result = chatClient.prompt()
+                .advisors(AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT)
+                .user(user -> user.text(PROMPT)
+                        .param("question", searchTerm)
+                        .param("triples", renderCandidates(candidates))
+                        .param("maxSeeds", Integer.toString(maxSeeds)))
+                .call()
+                .entity(RecognitionMemoryResult.class);
+
+        return toSeeds(result, candidates, maxSeeds);
+    }
+
+    List<GraphSeed> toSeeds(RecognitionMemoryResult result, List<TripleCandidate> candidates, int maxSeeds) {
+        if (result == null || result.concepts() == null || candidates == null || candidates.isEmpty() || maxSeeds <= 0) {
+            return List.of();
+        }
+
+        Map<String, AllowedConcepts> allowedConceptsByTripleKey = new LinkedHashMap<>();
+        for (TripleCandidate candidate : candidates) {
+            allowedConceptsByTripleKey.put(candidate.key(), AllowedConcepts.from(candidate));
+        }
+
+        Map<String, GraphSeed> seedsByConcept = new LinkedHashMap<>();
+        for (RecognizedConcept recognized : result.concepts()) {
+            if (seedsByConcept.size() >= maxSeeds) {
+                break;
+            }
+
+            GraphSeed seed = toSeed(recognized, allowedConceptsByTripleKey);
+            if (seed == null) {
+                continue;
+            }
+
+            String dedupeKey = ((ConceptSeedTarget) seed.target())
+                    .concept()
+                    .name()
+                    .toLowerCase(Locale.ROOT);
+            seedsByConcept.putIfAbsent(dedupeKey, seed);
+        }
+
+        return List.copyOf(seedsByConcept.values());
+    }
+
+    private GraphSeed toSeed(RecognizedConcept recognized, Map<String, AllowedConcepts> allowedConceptsByTripleKey) {
+        if (recognized == null
+                || recognized.tripleKey() == null
+                || recognized.concept() == null
+                || recognized.concept().isBlank()
+                || !Double.isFinite(recognized.confidence())
+                || recognized.confidence() <= 0
+                || recognized.confidence() > 1) {
+            return null;
+        }
+
+        AllowedConcepts allowedConcepts = allowedConceptsByTripleKey.get(recognized.tripleKey());
+        if (allowedConcepts == null) {
+            return null;
+        }
+
+        String canonicalConcept = allowedConcepts.canonicalConcept(recognized.concept());
+        if (canonicalConcept == null) {
+            return null;
+        }
+
+        return GraphSeed.concept(canonicalConcept, recognized.confidence());
+    }
+
+    private String renderCandidates(List<TripleCandidate> candidates) {
+        return candidates.stream()
+                .filter(Objects::nonNull)
+                .map(candidate -> "- key: %s | subject: %s | predicate: %s | object: %s | score: %.6f".formatted(
+                        candidate.key(),
+                        candidate.subject(),
+                        candidate.predicate(),
+                        candidate.object(),
+                        candidate.similarityScore()
+                ))
+                .collect(Collectors.joining(System.lineSeparator()));
+    }
+
+    private record AllowedConcepts(String subject, String object) {
+
+        private static AllowedConcepts from(TripleCandidate candidate) {
+            return new AllowedConcepts(candidate.subject(), candidate.object());
+        }
+
+        private String canonicalConcept(String concept) {
+            String normalized = concept.trim().toLowerCase(Locale.ROOT);
+            if (subject.toLowerCase(Locale.ROOT).equals(normalized)) {
+                return subject;
+            }
+            if (object.toLowerCase(Locale.ROOT).equals(normalized)) {
+                return object;
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/kairos/context_engine/infrastructure/recognition/dto/RecognitionMemoryResult.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/recognition/dto/RecognitionMemoryResult.java
@@ -1,0 +1,8 @@
+package com.kairos.context_engine.infrastructure.recognition.dto;
+
+import java.util.List;
+
+public record RecognitionMemoryResult(
+        List<RecognizedConcept> concepts
+) {
+}

--- a/src/main/java/com/kairos/context_engine/infrastructure/recognition/dto/RecognizedConcept.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/recognition/dto/RecognizedConcept.java
@@ -1,0 +1,8 @@
+package com.kairos.context_engine.infrastructure.recognition.dto;
+
+public record RecognizedConcept(
+        String tripleKey,
+        String concept,
+        double confidence
+) {
+}

--- a/src/main/java/com/kairos/context_engine/infrastructure/relational/projection/TripleCandidateProjection.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/relational/projection/TripleCandidateProjection.java
@@ -1,0 +1,18 @@
+package com.kairos.context_engine.infrastructure.relational.projection;
+
+import java.util.UUID;
+
+public interface TripleCandidateProjection {
+
+    String getKey();
+
+    String getSubject();
+
+    String getPredicate();
+
+    String getObject();
+
+    UUID getChunkId();
+
+    Double getSimilarity();
+}

--- a/src/main/java/com/kairos/context_engine/infrastructure/relational/repository/triple/JpaTripleRepository.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/relational/repository/triple/JpaTripleRepository.java
@@ -1,7 +1,7 @@
 package com.kairos.context_engine.infrastructure.relational.repository.triple;
 
 import com.kairos.context_engine.infrastructure.relational.entity.TripleEntity;
-import com.kairos.context_engine.infrastructure.relational.projection.ConceptCandidateProjection;
+import com.kairos.context_engine.infrastructure.relational.projection.TripleCandidateProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,35 +13,22 @@ import java.util.List;
 public interface JpaTripleRepository extends JpaRepository<TripleEntity, String> {
 
 
-    /**
-     * Executes a native pgvector cosine similarity search across all unique concepts (subjects and objects) in the triples table.
-     * The query uses a Common Table Expression (CTE) to combine distinct subjects and objects into a single set of concepts, each with its associated embedding.
-     * It then calculates the cosine similarity between the query vector and each concept's embedding, returning the top-k concepts ordered by similarity.
-     * @param queryVector The dense embedding representation of the query concept.
-     * @param limit The maximum number of candidate concepts to return.
-     * @return A list of concept candidates with their name and similarity score, ordered by descending similarity.
-     */
     @Query(
             value = """
-                    WITH concepts AS (
-                        SELECT DISTINCT subject AS concept, embedding
-                        FROM triples
-                        WHERE embedding IS NOT NULL
-                        UNION ALL
-                        SELECT DISTINCT object AS concept, embedding
-                        FROM triples
-                        WHERE embedding IS NOT NULL
-                    )
                     SELECT
-                        c.concept AS name,
-                        MAX(1 - (c.embedding <=> cast(:queryVector AS vector))) AS similarity
-                    FROM concepts c
-                    GROUP BY c.concept
-                    ORDER BY MAX(1 - (c.embedding <=> cast(:queryVector AS vector))) DESC
+                        t.key       AS key,
+                        t.subject   AS subject,
+                        t.predicate AS predicate,
+                        t.object    AS object,
+                        t.chunk_id  AS chunkId,
+                        1 - (t.embedding <=> cast(:queryVector AS vector)) AS similarity
+                    FROM triples t
+                    WHERE t.embedding IS NOT NULL
+                    ORDER BY t.embedding <=> cast(:queryVector AS vector)
                     LIMIT :limit
                     """, nativeQuery = true
     )
-    List<ConceptCandidateProjection> findCandidates(
+    List<TripleCandidateProjection> findTripleCandidates(
             @Param("queryVector") float[] queryVector,
             @Param("limit") int limit
     );

--- a/src/main/java/com/kairos/context_engine/infrastructure/relational/repository/triple/JpaTripleRepository.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/relational/repository/triple/JpaTripleRepository.java
@@ -24,6 +24,13 @@ public interface JpaTripleRepository extends JpaRepository<TripleEntity, String>
                         1 - (t.embedding <=> cast(:queryVector AS vector)) AS similarity
                     FROM triples t
                     WHERE t.embedding IS NOT NULL
+                      AND t.chunk_id IS NOT NULL
+                      AND t.subject IS NOT NULL
+                      AND TRIM(t.subject) <> ''
+                      AND t.predicate IS NOT NULL
+                      AND TRIM(t.predicate) <> ''
+                      AND t.object IS NOT NULL
+                      AND TRIM(t.object) <> ''
                     ORDER BY t.embedding <=> cast(:queryVector AS vector)
                     LIMIT :limit
                     """, nativeQuery = true

--- a/src/main/java/com/kairos/context_engine/infrastructure/relational/semantic/SemanticSearchAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/relational/semantic/SemanticSearchAdapter.java
@@ -106,7 +106,8 @@ public class SemanticSearchAdapter implements SemanticSearch {
                         && hasText(candidate.getPredicate())
                         && hasText(candidate.getObject())
                         && candidate.getChunkId() != null
-                        && candidate.getSimilarity() != null)
+                        && candidate.getSimilarity() != null
+                        && Double.isFinite(candidate.getSimilarity()))
                 .map(candidate -> new TripleCandidate(
                         candidate.getKey(),
                         candidate.getSubject(),

--- a/src/main/java/com/kairos/context_engine/infrastructure/relational/semantic/SemanticSearchAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/relational/semantic/SemanticSearchAdapter.java
@@ -1,9 +1,8 @@
 package com.kairos.context_engine.infrastructure.relational.semantic;
 
 import com.kairos.context_engine.domain.model.content.Chunk;
-import com.kairos.context_engine.domain.model.knowledge.Concept;
-import com.kairos.context_engine.domain.model.retrieval.candidate.ConceptCandidate;
 import com.kairos.context_engine.domain.model.retrieval.candidate.PassageCandidate;
+import com.kairos.context_engine.domain.model.retrieval.candidate.TripleCandidate;
 import com.kairos.context_engine.domain.model.retrieval.ranking.RankedChunk;
 import com.kairos.context_engine.domain.model.retrieval.ranking.ScoredPassage;
 import com.kairos.context_engine.domain.model.retrieval.source.RetrievalSource;
@@ -99,16 +98,28 @@ public class SemanticSearchAdapter implements SemanticSearch {
 
     @Override
     @Transactional(readOnly = true)
-    public List<ConceptCandidate> findConceptCandidate(float[] queryVector, int semanticAnchorLimit) {
-        var conceptCandidate = jpaTripleRepository.findCandidates(queryVector, semanticAnchorLimit);
-
-        return conceptCandidate.stream()
-                .filter(candidate -> candidate.getName() != null && candidate.getSimilarity() != null)
-                .map(candidate -> new ConceptCandidate(
-                        new Concept(candidate.getName()),
+    public List<TripleCandidate> findTripleCandidates(float[] queryVector, int limit) {
+        return jpaTripleRepository.findTripleCandidates(queryVector, limit)
+                .stream()
+                .filter(candidate -> hasText(candidate.getKey())
+                        && hasText(candidate.getSubject())
+                        && hasText(candidate.getPredicate())
+                        && hasText(candidate.getObject())
+                        && candidate.getChunkId() != null
+                        && candidate.getSimilarity() != null)
+                .map(candidate -> new TripleCandidate(
+                        candidate.getKey(),
+                        candidate.getSubject(),
+                        candidate.getPredicate(),
+                        candidate.getObject(),
+                        candidate.getChunkId(),
                         candidate.getSimilarity()
                 ))
                 .toList();
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 
     private RankedChunk toRankedChunk(ScoredPassage scoredPassage, Chunk chunk, AtomicInteger rank) {

--- a/src/main/java/com/kairos/share/ai/ArtificialIntelligenceConfig.java
+++ b/src/main/java/com/kairos/share/ai/ArtificialIntelligenceConfig.java
@@ -20,4 +20,17 @@ public class ArtificialIntelligenceConfig {
                 .build();
     }
 
+    @Bean
+    ChatClient recognitionMemoryChatClient(ChatClient.Builder builder) {
+        return builder
+                .defaultSystem("""
+                        You are a graph retrieval recognition memory.
+                        Select only relevant graph seed concepts from the provided candidate triples.
+                        Return concepts exactly as they appear in the candidate triple subject or object.
+                        Do not invent facts, concepts, or relationships.
+                        """
+                )
+                .build();
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,6 +76,8 @@ kairos:
   retrieval:
     semantic-anchor-limit: ${KAIROS_SEMANTIC_ANCHOR_LIMIT:10}
     graph-passage-limit: ${KAIROS_GRAPH_PASSAGE_LIMIT:20}
+    triple-candidate-limit: ${KAIROS_TRIPLE_CANDIDATE_LIMIT:30}
+    recognition-seed-limit: ${KAIROS_RECOGNITION_SEED_LIMIT:10}
     seed-min-score: ${KAIROS_SEED_MIN_SCORE:0.45}
     seed-relative-threshold: ${KAIROS_SEED_RELATIVE_THRESHOLD:0.85}
   graph:

--- a/src/test/java/com/kairos/context_engine/infrastructure/recognition/GeminiRecognitionMemoryAdapterTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/recognition/GeminiRecognitionMemoryAdapterTest.java
@@ -1,0 +1,129 @@
+package com.kairos.context_engine.infrastructure.recognition;
+
+import com.kairos.context_engine.domain.model.retrieval.candidate.TripleCandidate;
+import com.kairos.context_engine.domain.model.retrieval.seed.ConceptSeedTarget;
+import com.kairos.context_engine.domain.model.retrieval.seed.GraphSeed;
+import com.kairos.context_engine.infrastructure.recognition.dto.RecognizedConcept;
+import com.kairos.context_engine.infrastructure.recognition.dto.RecognitionMemoryResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("GeminiRecognitionMemoryAdapter")
+class GeminiRecognitionMemoryAdapterTest {
+
+    @Test
+    @DisplayName("prompt renders with question, triples and max seed parameters")
+    void promptShouldRenderWithParameters() throws Exception {
+        Field promptField = GeminiRecognitionMemoryAdapter.class.getDeclaredField("PROMPT");
+        promptField.setAccessible(true);
+
+        String prompt = (String) promptField.get(null);
+        String renderedPrompt = new PromptTemplate(prompt).render(Map.of(
+                "question", "How does Spring Data use repositories?",
+                "triples", "spring data | USES | repository pattern",
+                "maxSeeds", "10"
+        ));
+
+        assertThat(renderedPrompt)
+                .contains("How does Spring Data use repositories?")
+                .contains("spring data | USES | repository pattern")
+                .contains("10");
+    }
+
+    @Test
+    @DisplayName("toSeeds keeps only accepted subject/object concepts and deduplicates canonically")
+    void toSeedsValidatesRecognizedConcepts() {
+        TripleCandidate candidate = tripleCandidate(
+                "mind-RELATES_TO-consciousness",
+                "mind",
+                "RELATES_TO",
+                "consciousness",
+                0.91
+        );
+        RecognitionMemoryResult result = new RecognitionMemoryResult(List.of(
+                new RecognizedConcept("mind-RELATES_TO-consciousness", "mind", 0.8),
+                new RecognizedConcept("mind-RELATES_TO-consciousness", "Mind", 0.7),
+                new RecognizedConcept("mind-RELATES_TO-consciousness", "consciousness", 0.6),
+                new RecognizedConcept("mind-RELATES_TO-consciousness", "hallucinated", 0.9),
+                new RecognizedConcept("unknown", "mind", 0.9),
+                new RecognizedConcept("mind-RELATES_TO-consciousness", " ", 0.9),
+                new RecognizedConcept("mind-RELATES_TO-consciousness", "mind", 0.0),
+                new RecognizedConcept("mind-RELATES_TO-consciousness", "mind", 1.1)
+        ));
+
+        List<GraphSeed> seeds = new GeminiRecognitionMemoryAdapter(null)
+                .toSeeds(result, List.of(candidate), 10);
+
+        assertThat(seeds).hasSize(2);
+        assertThat(seeds)
+                .extracting(seed -> ((ConceptSeedTarget) seed.target()).concept().name())
+                .containsExactly("mind", "consciousness");
+        assertThat(seeds)
+                .extracting(GraphSeed::weight)
+                .containsExactly(0.8, 0.6);
+    }
+
+    @Test
+    @DisplayName("toSeeds respects the configured maximum seed count")
+    void toSeedsRespectsMaxSeedCount() {
+        List<TripleCandidate> candidates = IntStream.range(0, 12)
+                .mapToObj(index -> tripleCandidate(
+                        "subject-" + index + "-REL-object-" + index,
+                        "subject-" + index,
+                        "REL",
+                        "object-" + index,
+                        0.9
+                ))
+                .toList();
+        RecognitionMemoryResult result = new RecognitionMemoryResult(
+                candidates.stream()
+                        .map(candidate -> new RecognizedConcept(candidate.key(), candidate.subject(), 0.8))
+                        .toList()
+        );
+
+        List<GraphSeed> seeds = new GeminiRecognitionMemoryAdapter(null)
+                .toSeeds(result, candidates, 10);
+
+        assertThat(seeds).hasSize(10);
+        assertThat(seeds)
+                .extracting(seed -> ((ConceptSeedTarget) seed.target()).concept().name())
+                .containsExactly(
+                        "subject-0", "subject-1", "subject-2", "subject-3", "subject-4",
+                        "subject-5", "subject-6", "subject-7", "subject-8", "subject-9"
+                );
+    }
+
+    @Test
+    @DisplayName("toSeeds returns empty when model returns no structured concepts")
+    void toSeedsReturnsEmptyForMissingResult() {
+        List<GraphSeed> seeds = new GeminiRecognitionMemoryAdapter(null)
+                .toSeeds(new RecognitionMemoryResult(null), List.of(tripleCandidate(
+                        "mind-RELATES_TO-consciousness",
+                        "mind",
+                        "RELATES_TO",
+                        "consciousness",
+                        0.91
+                )), 10);
+
+        assertThat(seeds).isEmpty();
+    }
+
+    private TripleCandidate tripleCandidate(
+            String key,
+            String subject,
+            String predicate,
+            String object,
+            double similarity
+    ) {
+        return new TripleCandidate(key, subject, predicate, object, UUID.randomUUID(), similarity);
+    }
+}

--- a/src/test/java/com/kairos/context_engine/infrastructure/semantic/SemanticSearchAdapterTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/semantic/SemanticSearchAdapterTest.java
@@ -1,17 +1,16 @@
 package com.kairos.context_engine.infrastructure.semantic;
 
 import com.kairos.context_engine.domain.model.content.Chunk;
-import com.kairos.context_engine.domain.model.knowledge.Concept;
-import com.kairos.context_engine.domain.model.retrieval.candidate.ConceptCandidate;
 import com.kairos.context_engine.domain.model.retrieval.candidate.PassageCandidate;
+import com.kairos.context_engine.domain.model.retrieval.candidate.TripleCandidate;
 import com.kairos.context_engine.domain.model.retrieval.ranking.RankedChunk;
 import com.kairos.context_engine.domain.model.retrieval.ranking.ScoredPassage;
 import com.kairos.context_engine.domain.model.retrieval.source.RetrievalSource;
 import com.kairos.context_engine.infrastructure.relational.entity.ChunkEntity;
 import com.kairos.context_engine.infrastructure.relational.entity.SourceEntity;
-import com.kairos.context_engine.infrastructure.relational.repository.chunk.JpaChunkRepository;
-import com.kairos.context_engine.infrastructure.relational.projection.ConceptCandidateProjection;
 import com.kairos.context_engine.infrastructure.relational.projection.PassageCandidateProjection;
+import com.kairos.context_engine.infrastructure.relational.projection.TripleCandidateProjection;
+import com.kairos.context_engine.infrastructure.relational.repository.chunk.JpaChunkRepository;
 import com.kairos.context_engine.infrastructure.relational.repository.source.JpaSourceRepository;
 import com.kairos.context_engine.infrastructure.relational.repository.triple.JpaTripleRepository;
 import com.kairos.context_engine.infrastructure.relational.semantic.SemanticSearchAdapter;
@@ -31,13 +30,19 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.anyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("SemanticSearchAdapter")
 class SemanticSearchAdapterTest {
+
+    private static final float[] QUERY_VECTOR = {0.1f, 0.2f, 0.3f, 0.4f};
 
     @Mock
     private JpaSourceRepository jpaSourceRepository;
@@ -51,98 +56,18 @@ class SemanticSearchAdapterTest {
     @InjectMocks
     private SemanticSearchAdapter adapter;
 
-    // -------------------------------------------------------------------------
-    // Fixtures
-    // -------------------------------------------------------------------------
-
-    private static final float[] QUERY_VECTOR = {0.1f, 0.2f, 0.3f, 0.4f};
-
     private SourceEntity sourceEntityA;
     private SourceEntity sourceEntityB;
 
     @BeforeEach
     void setUp() {
-        sourceEntityA = new SourceEntity(
-                UUID.randomUUID(), "Philosophy of Mind", "Content A"
-        );
-        sourceEntityB = new SourceEntity(
-                UUID.randomUUID(), "Cognitive Science", "Content B"
-        );
+        sourceEntityA = new SourceEntity(UUID.randomUUID(), "Philosophy of Mind", "Content A");
+        sourceEntityB = new SourceEntity(UUID.randomUUID(), "Cognitive Science", "Content B");
     }
-
-    private ChunkEntity chunkEntity(UUID id, SourceEntity source, String content, int index) {
-        return new ChunkEntity(id, source, content, index, false, QUERY_VECTOR);
-    }
-
-    private PassageCandidateProjection candidateProjection(UUID chunkId, double denseScore) {
-        return new PassageCandidateProjection() {
-            @Override
-            public UUID getChunkId() {
-                return chunkId;
-            }
-
-            @Override
-            public Double getDenseScore() {
-                return denseScore;
-            }
-        };
-    }
-
-    private PassageCandidateProjection candidateProjection(UUID chunkId, Double denseScore) {
-        return new PassageCandidateProjection() {
-            @Override
-            public UUID getChunkId() {
-                return chunkId;
-            }
-
-            @Override
-            public Double getDenseScore() {
-                return denseScore;
-            }
-        };
-    }
-
-    private ConceptCandidateProjection conceptCandidateProjection(String name, double similarityScore) {
-        return new ConceptCandidateProjection() {
-            @Override
-            public String getName() {
-                return name;
-            }
-
-            @Override
-            public Double getSimilarity() {
-                return similarityScore;
-            }
-        };
-    }
-
-    private ConceptCandidateProjection conceptCandidateProjection(String name, Double similarityScore) {
-        return new ConceptCandidateProjection() {
-            @Override
-            public String getName() {
-                return name;
-            }
-
-            @Override
-            public Double getSimilarity() {
-                return similarityScore;
-            }
-        };
-    }
-
-    // =========================================================================
-    // search()
-    // =========================================================================
-
-
-
-    // =========================================================================
-    // findPassageCandidate()
-    // =========================================================================
 
     @Nested
     @DisplayName("findPassageCandidate(float[], int)")
-    class FindTopKMethod {
+    class FindPassageCandidateMethod {
 
         @Test
         @DisplayName("forwards the query vector and k to jpaChunkRepository unchanged")
@@ -164,13 +89,12 @@ class SemanticSearchAdapterTest {
 
             when(jpaChunkRepository.findCandidates(any(), anyInt()))
                     .thenReturn(List.of(
-                            candidateProjection(idA, 0.91),
-                            candidateProjection(idB, 0.72)
+                            passageCandidateProjection(idA, 0.91),
+                            passageCandidateProjection(idB, 0.72)
                     ));
 
             List<PassageCandidate> result = adapter.findPassageCandidate(QUERY_VECTOR, 2);
 
-            assertThat(result).hasSize(2);
             assertThat(result)
                     .extracting(PassageCandidate::chunkId)
                     .containsExactly(idA, idB);
@@ -179,61 +103,13 @@ class SemanticSearchAdapterTest {
                     .containsExactly(0.91, 0.72);
         }
 
-
-        @Test
-        @DisplayName("maps chunk id and dense score from candidate projection")
-        void mapsChunkIdAndDenseScore() {
-            UUID id = UUID.randomUUID();
-
-            when(jpaChunkRepository.findCandidates(any(), anyInt()))
-                    .thenReturn(List.of(candidateProjection(id, 0.84)));
-
-            List<PassageCandidate> result = adapter.findPassageCandidate(QUERY_VECTOR, 1);
-
-            assertThat(result.getFirst().chunkId()).isEqualTo(id);
-            assertThat(result.getFirst().denseScore()).isEqualTo(0.84);
-        }
-
-        @Test
-        @DisplayName("preserves the cosine-distance ranking order returned by the repository")
-        void preservesRankingOrder() {
-            UUID idA = UUID.randomUUID();
-            UUID idB = UUID.randomUUID();
-            UUID idC = UUID.randomUUID();
-
-            when(jpaChunkRepository.findCandidates(any(), anyInt()))
-                    .thenReturn(List.of(
-                            candidateProjection(idA, 0.95),
-                            candidateProjection(idB, 0.82),
-                            candidateProjection(idC, 0.61)
-                    ));
-
-            List<PassageCandidate> result = adapter.findPassageCandidate(QUERY_VECTOR, 3);
-
-            assertThat(result)
-                    .extracting(PassageCandidate::chunkId)
-                    .containsExactly(idA, idB, idC);
-        }
-
-        @Test
-        @DisplayName("returns an empty list when the repository finds no matching chunks")
-        void returnsEmptyListWhenNoResults() {
-            when(jpaChunkRepository.findCandidates(any(), anyInt())).thenReturn(List.of());
-
-            List<PassageCandidate> result = adapter.findPassageCandidate(QUERY_VECTOR, 10);
-
-            assertThat(result).isEmpty();
-        }
-
         @Test
         @DisplayName("skips candidate projections with null dense scores")
         void skipsNullDenseScores() {
-            UUID id = UUID.randomUUID();
-
             when(jpaChunkRepository.findCandidates(any(), anyInt()))
                     .thenReturn(List.of(
-                            candidateProjection(id, null),
-                            candidateProjection(UUID.randomUUID(), 0.73)
+                            passageCandidateProjection(UUID.randomUUID(), null),
+                            passageCandidateProjection(UUID.randomUUID(), 0.73)
                     ));
 
             List<PassageCandidate> result = adapter.findPassageCandidate(QUERY_VECTOR, 2);
@@ -241,16 +117,6 @@ class SemanticSearchAdapterTest {
             assertThat(result)
                     .singleElement()
                     .satisfies(candidate -> assertThat(candidate.denseScore()).isEqualTo(0.73));
-        }
-
-        @Test
-        @DisplayName("never interacts with jpaSourceRepository during findPassageCandidate")
-        void doesNotTouchSourceRepositoryDuringFindTopK() {
-            when(jpaChunkRepository.findCandidates(any(), anyInt())).thenReturn(List.of());
-
-            adapter.findPassageCandidate(QUERY_VECTOR, 10);
-
-            verifyNoInteractions(jpaSourceRepository);
         }
 
         @Test
@@ -265,260 +131,113 @@ class SemanticSearchAdapterTest {
         }
     }
 
-    // =========================================================================
-    // findConceptCandidate()
-    // =========================================================================
-
     @Nested
-    @DisplayName("findConceptCandidate(float[], int)")
-    class FindConceptCandidateMethod {
+    @DisplayName("findTripleCandidates(float[], int)")
+    class FindTripleCandidatesMethod {
 
         @Test
         @DisplayName("forwards the query vector and limit to jpaTripleRepository unchanged")
         void forwardsVectorAndLimitToRepository() {
-            when(jpaTripleRepository.findCandidates(QUERY_VECTOR, 10)).thenReturn(List.of());
+            when(jpaTripleRepository.findTripleCandidates(QUERY_VECTOR, 30)).thenReturn(List.of());
 
-            adapter.findConceptCandidate(QUERY_VECTOR, 10);
+            adapter.findTripleCandidates(QUERY_VECTOR, 30);
 
             ArgumentCaptor<float[]> vectorCaptor = ArgumentCaptor.forClass(float[].class);
-            verify(jpaTripleRepository).findCandidates(vectorCaptor.capture(), eq(10));
+            verify(jpaTripleRepository).findTripleCandidates(vectorCaptor.capture(), eq(30));
             assertThat(vectorCaptor.getValue()).isEqualTo(QUERY_VECTOR);
         }
 
         @Test
-        @DisplayName("maps each candidate projection to a ConceptCandidate")
-        void mapsCandidateProjectionsToDomainModels() {
-            when(jpaTripleRepository.findCandidates(any(), anyInt()))
+        @DisplayName("maps each triple projection to a TripleCandidate")
+        void mapsTripleProjectionsToDomainModels() {
+            UUID firstChunkId = UUID.randomUUID();
+            UUID secondChunkId = UUID.randomUUID();
+            when(jpaTripleRepository.findTripleCandidates(any(), anyInt()))
                     .thenReturn(List.of(
-                            conceptCandidateProjection("consciousness", 0.91),
-                            conceptCandidateProjection("qualia", 0.72)
+                            tripleCandidateProjection("mind-REL-consciousness", "mind", "REL", "consciousness", firstChunkId, 0.91),
+                            tripleCandidateProjection("brain-USES-neurons", "brain", "USES", "neurons", secondChunkId, 0.72)
                     ));
 
-            List<ConceptCandidate> result = adapter.findConceptCandidate(QUERY_VECTOR, 2);
+            List<TripleCandidate> result = adapter.findTripleCandidates(QUERY_VECTOR, 2);
 
             assertThat(result).hasSize(2);
             assertThat(result)
-                    .extracting(candidate -> candidate.concept().name())
-                    .containsExactly("consciousness", "qualia");
+                    .extracting(TripleCandidate::key)
+                    .containsExactly("mind-REL-consciousness", "brain-USES-neurons");
             assertThat(result)
-                    .extracting(ConceptCandidate::similarityScore)
+                    .extracting(TripleCandidate::chunkId)
+                    .containsExactly(firstChunkId, secondChunkId);
+            assertThat(result)
+                    .extracting(TripleCandidate::similarityScore)
                     .containsExactly(0.91, 0.72);
         }
 
         @Test
-        @DisplayName("maps concept name and similarity score from candidate projection")
-        void mapsNameAndSimilarityScore() {
-            when(jpaTripleRepository.findCandidates(any(), anyInt()))
-                    .thenReturn(List.of(conceptCandidateProjection("neural correlates", 0.84)));
-
-            List<ConceptCandidate> result = adapter.findConceptCandidate(QUERY_VECTOR, 1);
-
-            assertThat(result.getFirst().concept().name()).isEqualTo("neural correlates");
-            assertThat(result.getFirst().similarityScore()).isEqualTo(0.84);
-        }
-
-        @Test
-        @DisplayName("preserves the similarity ranking order returned by the repository")
+        @DisplayName("preserves the proximity ranking order returned by the repository")
         void preservesRankingOrder() {
-            when(jpaTripleRepository.findCandidates(any(), anyInt()))
+            when(jpaTripleRepository.findTripleCandidates(any(), anyInt()))
                     .thenReturn(List.of(
-                            conceptCandidateProjection("intentionality", 0.95),
-                            conceptCandidateProjection("phenomenology", 0.82),
-                            conceptCandidateProjection("epistemology", 0.61)
+                            tripleCandidateProjection("a-R-b", "a", "R", "b", UUID.randomUUID(), 0.95),
+                            tripleCandidateProjection("c-R-d", "c", "R", "d", UUID.randomUUID(), 0.82),
+                            tripleCandidateProjection("e-R-f", "e", "R", "f", UUID.randomUUID(), 0.61)
                     ));
 
-            List<ConceptCandidate> result = adapter.findConceptCandidate(QUERY_VECTOR, 3);
+            List<TripleCandidate> result = adapter.findTripleCandidates(QUERY_VECTOR, 3);
 
             assertThat(result)
-                    .extracting(candidate -> candidate.concept().name())
-                    .containsExactly("intentionality", "phenomenology", "epistemology");
+                    .extracting(TripleCandidate::key)
+                    .containsExactly("a-R-b", "c-R-d", "e-R-f");
         }
 
         @Test
-        @DisplayName("returns an empty list when the repository finds no matching concepts")
-        void returnsEmptyListWhenNoResults() {
-            when(jpaTripleRepository.findCandidates(any(), anyInt())).thenReturn(List.of());
+        @DisplayName("returns an empty list when no triple candidates are found")
+        void returnsEmptyWhenNoResults() {
+            when(jpaTripleRepository.findTripleCandidates(any(), anyInt())).thenReturn(List.of());
 
-            List<ConceptCandidate> result = adapter.findConceptCandidate(QUERY_VECTOR, 10);
+            List<TripleCandidate> result = adapter.findTripleCandidates(QUERY_VECTOR, 30);
 
             assertThat(result).isEmpty();
         }
 
         @Test
-        @DisplayName("skips candidate projections with null similarity scores")
-        void skipsNullSimilarityScores() {
-            when(jpaTripleRepository.findCandidates(any(), anyInt()))
+        @DisplayName("skips projections with incomplete triple data")
+        void skipsIncompleteTripleData() {
+            when(jpaTripleRepository.findTripleCandidates(any(), anyInt()))
                     .thenReturn(List.of(
-                            conceptCandidateProjection("missing embedding", null),
-                            conceptCandidateProjection("valid concept", 0.64)
+                            tripleCandidateProjection(null, "mind", "REL", "consciousness", UUID.randomUUID(), 0.91),
+                            tripleCandidateProjection("blank-subject", " ", "REL", "consciousness", UUID.randomUUID(), 0.82),
+                            tripleCandidateProjection("missing-score", "mind", "REL", "consciousness", UUID.randomUUID(), null),
+                            tripleCandidateProjection("valid", "mind", "REL", "consciousness", UUID.randomUUID(), 0.7)
                     ));
 
-            List<ConceptCandidate> result = adapter.findConceptCandidate(QUERY_VECTOR, 2);
+            List<TripleCandidate> result = adapter.findTripleCandidates(QUERY_VECTOR, 4);
 
             assertThat(result)
                     .singleElement()
-                    .satisfies(candidate -> assertThat(candidate.similarityScore()).isEqualTo(0.64));
+                    .satisfies(candidate -> assertThat(candidate.key()).isEqualTo("valid"));
         }
 
         @Test
-        @DisplayName("never interacts with jpaChunkRepository during findConceptCandidate")
-        void doesNotTouchChunkRepository() {
-            when(jpaTripleRepository.findCandidates(any(), anyInt())).thenReturn(List.of());
+        @DisplayName("never interacts with chunk or source repositories during triple lookup")
+        void doesNotTouchOtherRepositories() {
+            when(jpaTripleRepository.findTripleCandidates(any(), anyInt())).thenReturn(List.of());
 
-            adapter.findConceptCandidate(QUERY_VECTOR, 10);
+            adapter.findTripleCandidates(QUERY_VECTOR, 30);
 
-            verifyNoInteractions(jpaChunkRepository);
-        }
-
-        @Test
-        @DisplayName("never interacts with jpaSourceRepository during findConceptCandidate")
-        void doesNotTouchSourceRepository() {
-            when(jpaTripleRepository.findCandidates(any(), anyInt())).thenReturn(List.of());
-
-            adapter.findConceptCandidate(QUERY_VECTOR, 10);
-
-            verifyNoInteractions(jpaSourceRepository);
+            verifyNoInteractions(jpaChunkRepository, jpaSourceRepository);
         }
 
         @Test
         @DisplayName("propagates RuntimeException from jpaTripleRepository without wrapping")
         void propagatesRepositoryException() {
-            when(jpaTripleRepository.findCandidates(any(), anyInt()))
-                    .thenThrow(new RuntimeException("Embedding computation failed"));
+            when(jpaTripleRepository.findTripleCandidates(any(), anyInt()))
+                    .thenThrow(new RuntimeException("Vector index unavailable"));
 
-            assertThatThrownBy(() -> adapter.findConceptCandidate(QUERY_VECTOR, 10))
+            assertThatThrownBy(() -> adapter.findTripleCandidates(QUERY_VECTOR, 30))
                     .isInstanceOf(RuntimeException.class)
-                    .hasMessage("Embedding computation failed");
-        }
-
-        @Test
-        @DisplayName("creates Concept instances with correct names from projection")
-        void createsConceptInstancesCorrectly() {
-            when(jpaTripleRepository.findCandidates(any(), anyInt()))
-                    .thenReturn(List.of(conceptCandidateProjection("mind", 0.75)));
-
-            List<ConceptCandidate> result = adapter.findConceptCandidate(QUERY_VECTOR, 1);
-
-            Concept resultConcept = result.getFirst().concept();
-            assertThat(resultConcept).isEqualTo(new Concept("mind"));
-        }
-
-        @Test
-        @DisplayName("handles extreme similarity scores correctly (very low)")
-        void handlesExtremeLowScores() {
-            when(jpaTripleRepository.findCandidates(any(), anyInt()))
-                    .thenReturn(List.of(conceptCandidateProjection("concept", 0.0)));
-
-            List<ConceptCandidate> result = adapter.findConceptCandidate(QUERY_VECTOR, 1);
-
-            assertThat(result.getFirst().similarityScore()).isEqualTo(0.0);
-        }
-
-        @Test
-        @DisplayName("handles extreme similarity scores correctly (very high)")
-        void handlesExtremeHighScores() {
-            when(jpaTripleRepository.findCandidates(any(), anyInt()))
-                    .thenReturn(List.of(conceptCandidateProjection("concept", 1.0)));
-
-            List<ConceptCandidate> result = adapter.findConceptCandidate(QUERY_VECTOR, 1);
-
-            assertThat(result.getFirst().similarityScore()).isEqualTo(1.0);
-        }
-
-        @Test
-        @DisplayName("handles concept names with special characters")
-        void handlesSpecialCharactersInNames() {
-            String specialName = "concept-with_special.chars@2024";
-            when(jpaTripleRepository.findCandidates(any(), anyInt()))
-                    .thenReturn(List.of(conceptCandidateProjection(specialName, 0.85)));
-
-            List<ConceptCandidate> result = adapter.findConceptCandidate(QUERY_VECTOR, 1);
-
-            assertThat(result.getFirst().concept().name()).isEqualTo(specialName);
-        }
-
-        @Test
-        @DisplayName("handles concept names with whitespace correctly")
-        void handlesWhitespaceInNames() {
-            String nameWithSpaces = "multi word concept phrase";
-            when(jpaTripleRepository.findCandidates(any(), anyInt()))
-                    .thenReturn(List.of(conceptCandidateProjection(nameWithSpaces, 0.75)));
-
-            List<ConceptCandidate> result = adapter.findConceptCandidate(QUERY_VECTOR, 1);
-
-            assertThat(result.getFirst().concept().name()).isEqualTo(nameWithSpaces);
-        }
-
-        @Test
-        @DisplayName("processes large result sets efficiently")
-        void handlesLargeResultSets() {
-            List<ConceptCandidateProjection> largeResultSet = new java.util.ArrayList<>();
-            for (int i = 0; i < 100; i++) {
-                largeResultSet.add(conceptCandidateProjection("concept_" + i, 1.0 - (i * 0.01)));
-            }
-
-            when(jpaTripleRepository.findCandidates(any(), anyInt())).thenReturn(largeResultSet);
-
-            List<ConceptCandidate> result = adapter.findConceptCandidate(QUERY_VECTOR, 100);
-
-            assertThat(result).hasSize(100);
-            assertThat(result.getFirst().concept().name()).isEqualTo("concept_0");
-            assertThat(result.getLast().concept().name()).isEqualTo("concept_99");
-        }
-
-        @Test
-        @DisplayName("calls repository only once per invocation")
-        void callsRepositoryOnlyOnce() {
-            when(jpaTripleRepository.findCandidates(any(), anyInt()))
-                    .thenReturn(List.of(conceptCandidateProjection("concept", 0.85)));
-
-            adapter.findConceptCandidate(QUERY_VECTOR, 5);
-
-            verify(jpaTripleRepository, times(1)).findCandidates(any(float[].class), eq(5));
-        }
-
-        @Test
-        @DisplayName("returns different results on successive calls with different parameters")
-        void returnsDifferentResultsOnDifferentCalls() {
-            ConceptCandidateProjection proj1 = conceptCandidateProjection("consciousness", 0.90);
-            ConceptCandidateProjection proj2 = conceptCandidateProjection("phenomenology", 0.75);
-
-            when(jpaTripleRepository.findCandidates(any(), eq(1)))
-                    .thenReturn(List.of(proj1));
-            when(jpaTripleRepository.findCandidates(any(), eq(2)))
-                    .thenReturn(List.of(proj1, proj2));
-
-            List<ConceptCandidate> result1 = adapter.findConceptCandidate(QUERY_VECTOR, 1);
-            List<ConceptCandidate> result2 = adapter.findConceptCandidate(QUERY_VECTOR, 2);
-
-            assertThat(result1).hasSize(1);
-            assertThat(result2).hasSize(2);
-        }
-
-        @Test
-        @DisplayName("maintains immutability - does not modify returned list")
-        void maintainsImmutability() {
-            when(jpaTripleRepository.findCandidates(any(), anyInt()))
-                    .thenReturn(List.of(
-                            conceptCandidateProjection("concept1", 0.80),
-                            conceptCandidateProjection("concept2", 0.60)
-                    ));
-
-            List<ConceptCandidate> result = adapter.findConceptCandidate(QUERY_VECTOR, 2);
-            int originalSize = result.size();
-
-            // Try to modify (should fail or not affect returned list)
-            assertThatThrownBy(() -> result.add(new ConceptCandidate(
-                    new Concept("fake"), 0.5
-            ))).isInstanceOf(UnsupportedOperationException.class);
-
-            assertThat(result).hasSize(originalSize);
+                    .hasMessage("Vector index unavailable");
         }
     }
-
-    // =========================================================================
-    // findChunks()
-    // =========================================================================
 
     @Nested
     @DisplayName("findChunks(List<UUID>)")
@@ -534,99 +253,22 @@ class SemanticSearchAdapterTest {
         }
 
         @Test
-        @DisplayName("returns empty list immediately when given an empty ID list")
-        void returnsEmptyForEmptyInput() {
-            List<Chunk> result = adapter.findChunks(List.of());
-
-            assertThat(result).isEmpty();
-            verifyNoInteractions(jpaChunkRepository);
-        }
-
-        @Test
-        @DisplayName("delegates to jpaChunkRepository.findAllById with the exact IDs provided")
-        void delegatesWithExactIds() {
-            UUID idA = UUID.randomUUID();
-            UUID idB = UUID.randomUUID();
-            List<UUID> ids = List.of(idA, idB);
-
-            when(jpaChunkRepository.findAllById(ids)).thenReturn(List.of());
-
-            adapter.findChunks(ids);
-
-            verify(jpaChunkRepository).findAllById(ids);
-        }
-
-        @Test
         @DisplayName("maps each retrieved ChunkEntity to a domain Chunk")
         void mapsFetchedEntitiesToDomainModels() {
             UUID idA = UUID.randomUUID();
             UUID idB = UUID.randomUUID();
 
-            ChunkEntity entityA = chunkEntity(idA, sourceEntityA, "First chunk",  0);
-            ChunkEntity entityB = chunkEntity(idB, sourceEntityA, "Second chunk", 1);
-
             when(jpaChunkRepository.findAllById(anyList()))
-                    .thenReturn(List.of(entityA, entityB));
+                    .thenReturn(List.of(
+                            chunkEntity(idA, sourceEntityA, "First chunk", 0),
+                            chunkEntity(idB, sourceEntityA, "Second chunk", 1)
+                    ));
 
             List<Chunk> result = adapter.findChunks(List.of(idA, idB));
 
-            assertThat(result).hasSize(2);
-            assertThat(result).extracting(Chunk::getContent)
-                    .containsExactlyInAnyOrder("First chunk", "Second chunk");
-        }
-
-        @Test
-        @DisplayName("returns partial results when the store does not contain all requested IDs")
-        void returnsPartialResultsForMissingIds() {
-            UUID presentId = UUID.randomUUID();
-            UUID missingId = UUID.randomUUID();
-
-            ChunkEntity presentEntity = chunkEntity(presentId, sourceEntityA, "Present", 0);
-
-            // Store returns only the chunk that exists
-            when(jpaChunkRepository.findAllById(anyList()))
-                    .thenReturn(List.of(presentEntity));
-
-            List<Chunk> result = adapter.findChunks(List.of(presentId, missingId));
-
-            assertThat(result).hasSize(1);
-            assertThat(result.getFirst().getContent()).isEqualTo("Present");
-        }
-
-        @Test
-        @DisplayName("does not guarantee ordering — result order matches what the repository returns")
-        void doesNotGuaranteeOrdering() {
-            // The Javadoc explicitly states order is not guaranteed.
-            // This test documents and verifies that the adapter does NOT impose its own sort.
-            UUID idFirst  = UUID.randomUUID();
-            UUID idSecond = UUID.randomUUID();
-
-            ChunkEntity entitySecond = chunkEntity(idSecond, sourceEntityA, "Second in DB", 1);
-            ChunkEntity entityFirst  = chunkEntity(idFirst,  sourceEntityA, "First in DB",  0);
-
-            // Repository deliberately returns them in reverse order
-            when(jpaChunkRepository.findAllById(anyList()))
-                    .thenReturn(List.of(entitySecond, entityFirst));
-
-            List<Chunk> result = adapter.findChunks(List.of(idFirst, idSecond));
-
             assertThat(result)
                     .extracting(Chunk::getContent)
-                    .containsExactly("Second in DB", "First in DB");
-        }
-
-        @Test
-        @DisplayName("handles a single-element ID list correctly")
-        void handlesSingleId() {
-            UUID id = UUID.randomUUID();
-            ChunkEntity entity = chunkEntity(id, sourceEntityA, "Single chunk", 0);
-
-            when(jpaChunkRepository.findAllById(List.of(id))).thenReturn(List.of(entity));
-
-            List<Chunk> result = adapter.findChunks(List.of(id));
-
-            assertThat(result).hasSize(1);
-            assertThat(result.getFirst().getContent()).isEqualTo("Single chunk");
+                    .containsExactlyInAnyOrder("First chunk", "Second chunk");
         }
 
         @Test
@@ -638,32 +280,7 @@ class SemanticSearchAdapterTest {
 
             assertThat(result).isEmpty();
         }
-
-        @Test
-        @DisplayName("never interacts with jpaSourceRepository during findChunks")
-        void doesNotTouchSourceRepository() {
-            when(jpaChunkRepository.findAllById(anyList())).thenReturn(List.of());
-
-            adapter.findChunks(List.of(UUID.randomUUID()));
-
-            verifyNoInteractions(jpaSourceRepository);
-        }
-
-        @Test
-        @DisplayName("propagates RuntimeException from jpaChunkRepository.findAllById without wrapping")
-        void propagatesRepositoryException() {
-            when(jpaChunkRepository.findAllById(anyList()))
-                    .thenThrow(new RuntimeException("Deadlock detected"));
-
-            assertThatThrownBy(() -> adapter.findChunks(List.of(UUID.randomUUID())))
-                    .isInstanceOf(RuntimeException.class)
-                    .hasMessage("Deadlock detected");
-        }
     }
-
-    // =========================================================================
-    // Cross-method isolation
-    // =========================================================================
 
     @Nested
     @DisplayName("hydrateAndRankChunks(List<ScoredPassage>)")
@@ -679,24 +296,16 @@ class SemanticSearchAdapterTest {
         }
 
         @Test
-        @DisplayName("returns empty list immediately when given an empty scored passage list")
-        void returnsEmptyForEmptyInput() {
-            List<RankedChunk> result = adapter.hydrateAndRankChunks(List.of());
-
-            assertThat(result).isEmpty();
-            verifyNoInteractions(jpaChunkRepository);
-        }
-
-        @Test
         @DisplayName("hydrates chunks while preserving scored passage order")
         void preservesScoredPassageOrder() {
             UUID idA = UUID.randomUUID();
             UUID idB = UUID.randomUUID();
-            ChunkEntity entityA = chunkEntity(idA, sourceEntityA, "First in repository", 0);
-            ChunkEntity entityB = chunkEntity(idB, sourceEntityB, "Second in repository", 1);
 
             when(jpaChunkRepository.findAllById(anyList()))
-                    .thenReturn(List.of(entityA, entityB));
+                    .thenReturn(List.of(
+                            chunkEntity(idA, sourceEntityA, "First in repository", 0),
+                            chunkEntity(idB, sourceEntityB, "Second in repository", 1)
+                    ));
 
             List<RankedChunk> result = adapter.hydrateAndRankChunks(List.of(
                     new ScoredPassage(idB, 0.91),
@@ -712,57 +321,68 @@ class SemanticSearchAdapterTest {
             assertThat(result)
                     .extracting(RankedChunk::score)
                     .containsExactly(0.91, 0.72);
-        }
-
-        @Test
-        @DisplayName("ignores scored passages whose chunk is missing from storage")
-        void ignoresMissingChunks() {
-            UUID presentId = UUID.randomUUID();
-            UUID missingId = UUID.randomUUID();
-            ChunkEntity present = chunkEntity(presentId, sourceEntityA, "Present chunk", 0);
-
-            when(jpaChunkRepository.findAllById(anyList())).thenReturn(List.of(present));
-
-            List<RankedChunk> result = adapter.hydrateAndRankChunks(List.of(
-                    new ScoredPassage(missingId, 0.98),
-                    new ScoredPassage(presentId, 0.75)
-            ));
-
-            assertThat(result).hasSize(1);
-            assertThat(result.getFirst().chunk().getId()).isEqualTo(presentId);
-            assertThat(result.getFirst().rank()).isEqualTo(1);
-        }
-
-        @Test
-        @DisplayName("marks hydrated ranked chunks as graph-sourced")
-        void usesGraphRetrievalSource() {
-            UUID id = UUID.randomUUID();
-            when(jpaChunkRepository.findAllById(anyList()))
-                    .thenReturn(List.of(chunkEntity(id, sourceEntityA, "Graph result", 0)));
-
-            List<RankedChunk> result = adapter.hydrateAndRankChunks(List.of(new ScoredPassage(id, 0.64)));
-
             assertThat(result)
-                    .singleElement()
-                    .satisfies(rankedChunk -> assertThat(rankedChunk.source()).isEqualTo(RetrievalSource.GRAPH));
+                    .extracting(RankedChunk::source)
+                    .containsExactly(RetrievalSource.GRAPH, RetrievalSource.GRAPH);
         }
     }
 
-    @Nested
-    @DisplayName("cross-method isolation")
-    class CrossMethodIsolation {
+    private ChunkEntity chunkEntity(UUID id, SourceEntity source, String content, int index) {
+        return new ChunkEntity(id, source, content, index, false, QUERY_VECTOR);
+    }
 
+    private PassageCandidateProjection passageCandidateProjection(UUID chunkId, Double denseScore) {
+        return new PassageCandidateProjection() {
+            @Override
+            public UUID getChunkId() {
+                return chunkId;
+            }
 
-        @Test
-        @DisplayName("findPassageCandidate() and findChunks() each call only jpaChunkRepository, never jpaSourceRepository")
-        void chunkMethodsDoNotTouchSourceRepository() {
-            when(jpaChunkRepository.findCandidates(any(), anyInt())).thenReturn(List.of());
-            when(jpaChunkRepository.findAllById(anyList())).thenReturn(List.of());
+            @Override
+            public Double getDenseScore() {
+                return denseScore;
+            }
+        };
+    }
 
-            adapter.findPassageCandidate(QUERY_VECTOR, 5);
-            adapter.findChunks(List.of(UUID.randomUUID()));
+    private TripleCandidateProjection tripleCandidateProjection(
+            String key,
+            String subject,
+            String predicate,
+            String object,
+            UUID chunkId,
+            Double similarity
+    ) {
+        return new TripleCandidateProjection() {
+            @Override
+            public String getKey() {
+                return key;
+            }
 
-            verifyNoInteractions(jpaSourceRepository);
-        }
+            @Override
+            public String getSubject() {
+                return subject;
+            }
+
+            @Override
+            public String getPredicate() {
+                return predicate;
+            }
+
+            @Override
+            public String getObject() {
+                return object;
+            }
+
+            @Override
+            public UUID getChunkId() {
+                return chunkId;
+            }
+
+            @Override
+            public Double getSimilarity() {
+                return similarity;
+            }
+        };
     }
 }

--- a/src/test/java/com/kairos/context_engine/infrastructure/semantic/SemanticSearchAdapterTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/semantic/SemanticSearchAdapterTest.java
@@ -218,6 +218,23 @@ class SemanticSearchAdapterTest {
         }
 
         @Test
+        @DisplayName("skips projections with non-finite similarity")
+        void skipsNonFiniteSimilarity() {
+            when(jpaTripleRepository.findTripleCandidates(any(), anyInt()))
+                    .thenReturn(List.of(
+                            tripleCandidateProjection("nan", "mind", "REL", "consciousness", UUID.randomUUID(), Double.NaN),
+                            tripleCandidateProjection("positive-infinity", "brain", "REL", "neurons", UUID.randomUUID(), Double.POSITIVE_INFINITY),
+                            tripleCandidateProjection("valid", "spring", "IMPLEMENTS", "repositories", UUID.randomUUID(), 0.7)
+                    ));
+
+            List<TripleCandidate> result = adapter.findTripleCandidates(QUERY_VECTOR, 3);
+
+            assertThat(result)
+                    .singleElement()
+                    .satisfies(candidate -> assertThat(candidate.key()).isEqualTo("valid"));
+        }
+
+        @Test
         @DisplayName("never interacts with chunk or source repositories during triple lookup")
         void doesNotTouchOtherRepositories() {
             when(jpaTripleRepository.findTripleCandidates(any(), anyInt())).thenReturn(List.of());

--- a/src/test/java/com/kairos/context_engine/use_case/SearchSourceUseCaseTest.java
+++ b/src/test/java/com/kairos/context_engine/use_case/SearchSourceUseCaseTest.java
@@ -5,20 +5,21 @@ import com.kairos.context_engine.application.use_case.SearchSourceUseCase;
 import com.kairos.context_engine.domain.model.SearchResult;
 import com.kairos.context_engine.domain.model.content.Chunk;
 import com.kairos.context_engine.domain.model.content.Source;
-import com.kairos.context_engine.domain.model.knowledge.Concept;
 import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
 import com.kairos.context_engine.domain.model.knowledge.Passage;
-import com.kairos.context_engine.domain.model.retrieval.candidate.ConceptCandidate;
 import com.kairos.context_engine.domain.model.retrieval.candidate.PassageCandidate;
+import com.kairos.context_engine.domain.model.retrieval.candidate.TripleCandidate;
 import com.kairos.context_engine.domain.model.retrieval.graph.GraphSearchRequest;
 import com.kairos.context_engine.domain.model.retrieval.graph.GraphSearchResult;
 import com.kairos.context_engine.domain.model.retrieval.ranking.RankedChunk;
 import com.kairos.context_engine.domain.model.retrieval.ranking.ScoredPassage;
 import com.kairos.context_engine.domain.model.retrieval.seed.ConceptSeedTarget;
+import com.kairos.context_engine.domain.model.retrieval.seed.GraphSeed;
 import com.kairos.context_engine.domain.model.retrieval.seed.PassageSeedTarget;
 import com.kairos.context_engine.domain.model.retrieval.source.RetrievalSource;
 import com.kairos.context_engine.domain.port.embedding.EmbeddingProvider;
 import com.kairos.context_engine.domain.port.graph.KnowledgeGraphSearch;
+import com.kairos.context_engine.domain.port.recognition.RecognitionMemory;
 import com.kairos.context_engine.domain.port.semantic.SemanticSearch;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -56,6 +57,9 @@ class SearchSourceUseCaseTest {
     @Mock
     private SemanticSearch semanticSearch;
 
+    @Mock
+    private RecognitionMemory recognitionMemory;
+
     @InjectMocks
     private SearchSourceUseCase useCase;
 
@@ -82,14 +86,15 @@ class SearchSourceUseCaseTest {
 
         when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
         when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10)).thenReturn(candidates);
-        when(semanticSearch.findConceptCandidate(QUERY_VECTOR, 10)).thenReturn(List.of());
+        when(semanticSearch.findTripleCandidates(QUERY_VECTOR, 30)).thenReturn(List.of());
         when(knowledgeGraphSearch.expandKnowledge(any(GraphSearchRequest.class))).thenReturn(GraphSearchResult.empty());
 
         SearchResult result = useCase.execute(new SearchSourceQuery(SEARCH_TERM));
 
         ArgumentCaptor<GraphSearchRequest> requestCaptor = ArgumentCaptor.forClass(GraphSearchRequest.class);
         verify(semanticSearch).findPassageCandidate(QUERY_VECTOR, 10);
-        verify(semanticSearch).findConceptCandidate(QUERY_VECTOR, 10);
+        verify(semanticSearch).findTripleCandidates(QUERY_VECTOR, 30);
+        verifyNoInteractions(recognitionMemory);
         verify(knowledgeGraphSearch).expandKnowledge(requestCaptor.capture());
         verify(semanticSearch, never()).hydrateAndRankChunks(any());
 
@@ -106,14 +111,22 @@ class SearchSourceUseCaseTest {
     }
 
     @Test
-    @DisplayName("filters weak concept candidates before graph expansion")
-    void filtersWeakConceptCandidatesBeforeGraphExpansion() {
+    @DisplayName("uses recognition memory to transform triple candidates into concept seeds")
+    void usesRecognitionMemoryToBuildConceptSeeds() {
+        TripleCandidate tripleCandidate = new TripleCandidate(
+                "spring-IMPLEMENTS-repository pattern",
+                "spring",
+                "IMPLEMENTS",
+                "repository pattern",
+                UUID.randomUUID(),
+                0.88
+        );
+
         when(embeddingPort.embed("Spring")).thenReturn(QUERY_VECTOR);
         when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10)).thenReturn(List.of());
-        when(semanticSearch.findConceptCandidate(QUERY_VECTOR, 10)).thenReturn(List.of(
-                new ConceptCandidate(new Concept("spring data"), 0.88),
-                new ConceptCandidate(new Concept("lucas"), 0.39)
-        ));
+        when(semanticSearch.findTripleCandidates(QUERY_VECTOR, 30)).thenReturn(List.of(tripleCandidate));
+        when(recognitionMemory.recognize("Spring", List.of(tripleCandidate), 10))
+                .thenReturn(List.of(GraphSeed.concept("spring", 0.88)));
         when(knowledgeGraphSearch.expandKnowledge(any(GraphSearchRequest.class))).thenReturn(GraphSearchResult.empty());
 
         SearchResult result = useCase.execute(new SearchSourceQuery("Spring"));
@@ -124,10 +137,42 @@ class SearchSourceUseCaseTest {
         GraphSearchRequest request = requestCaptor.getValue();
         assertThat(request.seeds()).singleElement()
                 .satisfies(seed -> {
-                    assertThat(((ConceptSeedTarget) seed.target()).concept().name()).isEqualTo("spring data");
+                    assertThat(((ConceptSeedTarget) seed.target()).concept().name()).isEqualTo("spring");
                     assertThat(seed.weight()).isEqualTo(0.88);
                 });
         assertThat(result).isEqualTo(SearchResult.empty());
+    }
+
+    @Test
+    @DisplayName("keeps passage seeds and appends concept seeds recognized from triples")
+    void keepsPassageSeedsAndAppendsRecognizedConceptSeeds() {
+        UUID passageId = UUID.randomUUID();
+        TripleCandidate tripleCandidate = new TripleCandidate(
+                "mind-RELATES_TO-consciousness",
+                "mind",
+                "RELATES_TO",
+                "consciousness",
+                UUID.randomUUID(),
+                0.91
+        );
+
+        when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
+        when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10))
+                .thenReturn(List.of(new PassageCandidate(passageId, 0.9)));
+        when(semanticSearch.findTripleCandidates(QUERY_VECTOR, 30)).thenReturn(List.of(tripleCandidate));
+        when(recognitionMemory.recognize(SEARCH_TERM, List.of(tripleCandidate), 10))
+                .thenReturn(List.of(GraphSeed.concept("consciousness", 0.82)));
+        when(knowledgeGraphSearch.expandKnowledge(any(GraphSearchRequest.class))).thenReturn(GraphSearchResult.empty());
+
+        useCase.execute(new SearchSourceQuery(SEARCH_TERM));
+
+        ArgumentCaptor<GraphSearchRequest> requestCaptor = ArgumentCaptor.forClass(GraphSearchRequest.class);
+        verify(knowledgeGraphSearch).expandKnowledge(requestCaptor.capture());
+
+        GraphSearchRequest request = requestCaptor.getValue();
+        assertThat(request.seeds()).hasSize(2);
+        assertThat(((PassageSeedTarget) request.seeds().get(0).target()).chunkId()).isEqualTo(passageId);
+        assertThat(((ConceptSeedTarget) request.seeds().get(1).target()).concept().name()).isEqualTo("consciousness");
     }
 
     @Test
@@ -135,12 +180,13 @@ class SearchSourceUseCaseTest {
     void returnsEmptyWhenNoCandidatesExist() {
         when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
         when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10)).thenReturn(List.of());
-        when(semanticSearch.findConceptCandidate(QUERY_VECTOR, 10)).thenReturn(List.of());
+        when(semanticSearch.findTripleCandidates(QUERY_VECTOR, 30)).thenReturn(List.of());
 
         SearchResult result = useCase.execute(new SearchSourceQuery(SEARCH_TERM));
 
         assertThat(result).isEqualTo(SearchResult.empty());
         verifyNoInteractions(knowledgeGraphSearch);
+        verifyNoInteractions(recognitionMemory);
         verify(semanticSearch, never()).hydrateAndRankChunks(any());
     }
 
@@ -152,7 +198,7 @@ class SearchSourceUseCaseTest {
                 new PassageCandidate(UUID.randomUUID(), 0.0),
                 new PassageCandidate(UUID.randomUUID(), -0.15)
         ));
-        when(semanticSearch.findConceptCandidate(QUERY_VECTOR, 10)).thenReturn(List.of());
+        when(semanticSearch.findTripleCandidates(QUERY_VECTOR, 30)).thenReturn(List.of());
 
         SearchResult result = useCase.execute(new SearchSourceQuery(SEARCH_TERM));
 
@@ -179,7 +225,7 @@ class SearchSourceUseCaseTest {
         when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
         when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10))
                 .thenReturn(List.of(new PassageCandidate(topId, 0.9)));
-        when(semanticSearch.findConceptCandidate(QUERY_VECTOR, 10)).thenReturn(List.of());
+        when(semanticSearch.findTripleCandidates(QUERY_VECTOR, 30)).thenReturn(List.of());
         when(knowledgeGraphSearch.expandKnowledge(any(GraphSearchRequest.class)))
                 .thenReturn(new GraphSearchResult(scoredPassages, List.of(triple)));
         when(semanticSearch.hydrateAndRankChunks(scoredPassages)).thenReturn(rankedChunks);
@@ -209,7 +255,7 @@ class SearchSourceUseCaseTest {
         when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
         when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10))
                 .thenReturn(List.of(new PassageCandidate(UUID.randomUUID(), 0.9)));
-        when(semanticSearch.findConceptCandidate(QUERY_VECTOR, 10)).thenReturn(List.of());
+        when(semanticSearch.findTripleCandidates(QUERY_VECTOR, 30)).thenReturn(List.of());
         when(knowledgeGraphSearch.expandKnowledge(any(GraphSearchRequest.class)))
                 .thenThrow(new RuntimeException("Neo4j connection refused"));
 
@@ -227,7 +273,7 @@ class SearchSourceUseCaseTest {
         when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
         when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10))
                 .thenReturn(List.of(new PassageCandidate(chunkId, 0.9)));
-        when(semanticSearch.findConceptCandidate(QUERY_VECTOR, 10)).thenReturn(List.of());
+        when(semanticSearch.findTripleCandidates(QUERY_VECTOR, 30)).thenReturn(List.of());
         when(knowledgeGraphSearch.expandKnowledge(any(GraphSearchRequest.class)))
                 .thenReturn(new GraphSearchResult(scoredPassages, List.of()));
         when(semanticSearch.hydrateAndRankChunks(scoredPassages))

--- a/src/test/java/com/kairos/context_engine/use_case/SearchSourceUseCaseTest.java
+++ b/src/test/java/com/kairos/context_engine/use_case/SearchSourceUseCaseTest.java
@@ -144,6 +144,41 @@ class SearchSourceUseCaseTest {
     }
 
     @Test
+    @DisplayName("filters weak concept seeds returned by recognition memory before graph expansion")
+    void filtersWeakRecognizedConceptSeedsBeforeGraphExpansion() {
+        TripleCandidate tripleCandidate = new TripleCandidate(
+                "spring-IMPLEMENTS-repository pattern",
+                "spring",
+                "IMPLEMENTS",
+                "repository pattern",
+                UUID.randomUUID(),
+                0.88
+        );
+
+        when(embeddingPort.embed("Spring")).thenReturn(QUERY_VECTOR);
+        when(semanticSearch.findPassageCandidate(QUERY_VECTOR, 10)).thenReturn(List.of());
+        when(semanticSearch.findTripleCandidates(QUERY_VECTOR, 30)).thenReturn(List.of(tripleCandidate));
+        when(recognitionMemory.recognize("Spring", List.of(tripleCandidate), 10))
+                .thenReturn(List.of(
+                        GraphSeed.concept("spring", 0.88),
+                        GraphSeed.concept("repository pattern", 0.39)
+                ));
+        when(knowledgeGraphSearch.expandKnowledge(any(GraphSearchRequest.class))).thenReturn(GraphSearchResult.empty());
+
+        useCase.execute(new SearchSourceQuery("Spring"));
+
+        ArgumentCaptor<GraphSearchRequest> requestCaptor = ArgumentCaptor.forClass(GraphSearchRequest.class);
+        verify(knowledgeGraphSearch).expandKnowledge(requestCaptor.capture());
+
+        GraphSearchRequest request = requestCaptor.getValue();
+        assertThat(request.seeds()).singleElement()
+                .satisfies(seed -> {
+                    assertThat(((ConceptSeedTarget) seed.target()).concept().name()).isEqualTo("spring");
+                    assertThat(seed.weight()).isEqualTo(0.88);
+                });
+    }
+
+    @Test
     @DisplayName("keeps passage seeds and appends concept seeds recognized from triples")
     void keepsPassageSeedsAndAppendsRecognizedConceptSeeds() {
         UUID passageId = UUID.randomUUID();


### PR DESCRIPTION
## Overview

This PR refactors the question search retrieval flow introduced in #40 by replacing the previous direct concept-candidate retrieval with a triple-based recognition flow.

The main retrieval pipeline remains the same:

1. Embed the user question.
2. Retrieve passage candidates.
3. Build graph seeds.
4. Run graph expansion with PPR.
5. Hydrate the expanded context.
6. Generate the final answer.

The intentional change is limited to the middle of the flow where concept seeds are produced. Instead of retrieving concepts directly from embeddings, the system now retrieves stored triples by vector proximity and lets a recognition-memory step decide which triple subjects or objects should become graph concept seeds.

Closes #40.

## Why This Change

Previously, the search flow retrieved concept candidates directly from vector similarity. That made graph seed selection depend on isolated concept matches, without preserving the relationship context in which those concepts appeared.

This PR changes that behavior so retrieval starts from the stored triples themselves. Triples carry more semantic context because they include:

- `subject`
- `predicate`
- `object`
- `chunkId`
- vector similarity score

After retrieving the most relevant triples, the new `RecognitionMemory` port uses structured LLM output to select which `subject` and/or `object` values are relevant enough to seed graph expansion.

This keeps the graph expansion model unchanged while making seed selection more context-aware.

## Main Changes

### Triple-Based Semantic Retrieval

Added a new `TripleCandidate` domain model containing:

- `key`
- `subject`
- `predicate`
- `object`
- `chunkId`
- `similarityScore`

Updated the `SemanticSearch` port by removing the direct concept-candidate lookup and adding:

```java
findTripleCandidates(float[] queryVector, int limit)
```

The JPA repository now queries the `triples` table directly using pgvector proximity search:

```sql
ORDER BY t.embedding <=> cast(:queryVector AS vector)
```

The query filters invalid rows before applying `LIMIT`, including null or blank triple fields and missing `chunk_id`. This prevents the adapter from receiving a limited result set that may later be mostly discarded.

### Recognition Memory

Added a new `RecognitionMemory` application port.

The Gemini-backed adapter receives:

- the original search term
- the ranked triple candidates
- the maximum number of graph seeds to return

It returns `List<GraphSeed>` using only concept names selected from the triple `subject` or `object`.

The LLM output is treated as untrusted and validated defensively. The adapter discards:

- empty concepts
- duplicated concepts
- concepts not present in the candidate triples
- hallucinated concepts
- concepts beyond the configured seed limit

This keeps LLM usage constrained to recognition and ranking, while the application code remains responsible for enforcing correctness.

### Dedicated ChatClient

The recognition-memory adapter now uses a dedicated `ChatClient` bean with its own system prompt.

This avoids sharing the extraction-focused default prompt used by the triple extractor. The recognition step has a different responsibility, so it now receives a prompt focused on selecting graph seed concepts from candidate triples without inventing new concepts or relationships.

### SearchSourceUseCase Orchestration

`SearchSourceUseCase` keeps the existing passage candidate flow and replaces only the concept-candidate path.

The new flow is:

```text
question embedding
  -> passage candidates
  -> triple candidates
  -> RecognitionMemory
  -> GraphSeed.concept(...)
  -> passage seeds + concept seeds
  -> KnowledgeGraphSearch.expandKnowledge(...)
```

Passage seeds still use the existing dense-score threshold behavior.

Recognition-derived concept seeds are also thresholded before graph expansion so weak LLM-confidence seeds do not affect PPR expansion.

### Configuration

Added retrieval configuration values:

```yaml
kairos:
  retrieval:
    triple-candidate-limit: 30
    recognition-seed-limit: 10
```

These keep the triple retrieval window and the final recognition seed count explicit and configurable.

## Deliberate Non-Changes

This PR intentionally does not change:

- controllers
- API response DTOs
- graph expansion behavior
- `HippoRagKnowledgeGraphSearchAdapter`
- `KnowledgeGraphGdsExecutor`
- PPR execution
- hydration flow
- answer generation flow

PPR already supports concept seeds and resolves phrase nodes by name, so this refactor reuses that existing behavior instead of changing the graph execution layer.

## Review Feedback Addressed

This PR also includes fixes from review feedback:

- Concept seeds from `RecognitionMemory` now pass through seed thresholding before graph expansion.
- Triple retrieval filters invalid rows in SQL before `LIMIT`.
- Triple candidate mapping ignores non-finite similarity scores.
- Recognition memory uses a dedicated qualified `ChatClient` instead of reusing the extraction prompt context.

## Testing

Updated and added tests for:

- preserving passage seed behavior
- using recognition memory to produce concept graph seeds
- filtering weak recognition-derived concept seeds
- mapping triple projections into `TripleCandidate`
- preserving repository result ordering
- ignoring incomplete triple rows
- ignoring non-finite similarity scores
- validating recognition-memory output
- deduplicating recognized concepts
- enforcing the recognition seed limit
- discarding concepts not present in candidate triple subjects or objects

## Validation

The package build without test execution passes:

```bash
mvn -q "-Dmaven.test.skip=true" package
```

Diff whitespace validation passes:

```bash
git diff --check
```

Focused test execution is currently blocked during `testCompile` by existing unrelated baseline test compilation errors across other test classes. This was already observed before these review changes and should be handled separately from this PR.

## Design Notes

The main design decision was to keep graph expansion unchanged and improve only how concept seeds are selected.

Using triples as the retrieval unit gives the recognition step more context than isolated concept embeddings, while still allowing the final graph search to start from the same `GraphSeed.concept(...)` abstraction used by the current PPR flow.

The LLM is not allowed to create new graph concepts. It can only select from existing triple subjects and objects, and the adapter validates that constraint before returning seeds.
