### PR TITLE
#41 Implement passage-aware weighted PPR

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,13 +477,13 @@ Test coverage by behavior includes:
 - Source enrichment is asynchronous. Querying immediately after ingestion can return empty or incomplete graph context.
 - Failed chunk reprocessing is not implemented yet. See [issue #52](https://github.com/Luca5Eckert/Kairos/issues/52).
 - If Neo4j GDS procedures are unavailable, graph expansion returns empty results instead of a dense fallback.
-- Weighted PPR is not fully implemented yet; seed scores are preserved and filtered, but the GDS query does not currently pass per-seed bias pairs or relationship weight properties.
 - OpenAPI/Swagger UI is not configured.
 
 ## Roadmap
 
 Recently completed:
 
+- [#41](https://github.com/Luca5Eckert/Kairos/issues/41): implemented passage-aware weighted Personalized PageRank with per-seed bias and relationship weights.
 - [#40](https://github.com/Luca5Eckert/Kairos/issues/40): triple recall and recognition memory filtering.
 - [PR #59](https://github.com/Luca5Eckert/Kairos/pull/59): replaced direct concept-candidate retrieval with triple-based recognition-memory seed selection.
 - [PR #51](https://github.com/Luca5Eckert/Kairos/pull/51): finalized the passage-first graph retrieval response with ranked chunks and activated triples.
@@ -493,7 +493,6 @@ Active or planned:
 
 | Issue | Description | Expected impact |
 | --- | --- | --- |
-| [#41](https://github.com/Luca5Eckert/Kairos/issues/41) | Passage-aware weighted Personalized PageRank | Improves ranking precision for queries with multiple relevant concepts |
 | [#50](https://github.com/Luca5Eckert/Kairos/issues/50) | Continue the HippoRAG 2 retrieval refactor | Aligns retrieval more closely with the reference paper and adds stronger fallback behavior |
 | [#52](https://github.com/Luca5Eckert/Kairos/issues/52) | Reprocess failed chunks without re-uploading the full source | Improves ingestion resilience and recovery |
 | [#31](https://github.com/Luca5Eckert/Kairos/issues/31) | Expand the user module beyond auth | Prepares the system for user-scoped knowledge operations |

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/adapter/HippoRagKnowledgeGraphSearchAdapter.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/adapter/HippoRagKnowledgeGraphSearchAdapter.java
@@ -9,6 +9,8 @@ import com.kairos.context_engine.domain.model.retrieval.seed.ConceptSeedTarget;
 import com.kairos.context_engine.domain.model.retrieval.seed.PassageSeedTarget;
 import com.kairos.context_engine.domain.port.graph.KnowledgeGraphSearch;
 import com.kairos.context_engine.infrastructure.graph.executor.KnowledgeGraphGdsExecutor;
+import com.kairos.context_engine.infrastructure.graph.executor.KnowledgeGraphGdsExecutor.WeightedConceptSeed;
+import com.kairos.context_engine.infrastructure.graph.executor.KnowledgeGraphGdsExecutor.WeightedPassageSeed;
 import com.kairos.context_engine.infrastructure.graph.repository.projection.GraphExpansionResult;
 import com.kairos.context_engine.infrastructure.graph.repository.projection.PassageScoringResult;
 import lombok.extern.slf4j.Slf4j;
@@ -55,15 +57,7 @@ public class HippoRagKnowledgeGraphSearchAdapter implements KnowledgeGraphSearch
             return GraphSearchResult.empty();
         }
 
-        var passageAnchorIds = new ArrayList<String>();
-        var conceptNames     = new ArrayList<String>();
-
-        for (var seed : request.seeds()) {
-            switch (seed.target()) {
-                case PassageSeedTarget t -> passageAnchorIds.add(t.chunkId().toString());
-                case ConceptSeedTarget  t -> conceptNames.add(t.concept().name());
-            }
-        }
+        WeightedGraphSeeds weightedSeeds = toWeightedSeeds(request);
 
         String graphName = GRAPH_NAME_PREFIX + UUID.randomUUID();
         boolean projected = false;
@@ -73,11 +67,11 @@ public class HippoRagKnowledgeGraphSearchAdapter implements KnowledgeGraphSearch
             projected = true;
 
             List<PassageScoringResult> passageScores = executor.runPPRPassageScores(
-                    graphName, passageAnchorIds, conceptNames,
+                    graphName, weightedSeeds.passages(), weightedSeeds.concepts(),
                     maxIterations, dampingFactor, scoreThreshold, request.limit());
 
             List<GraphExpansionResult> tripleRows = executor.runPPRActivatedTriples(
-                    graphName, passageAnchorIds, conceptNames,
+                    graphName, weightedSeeds.passages(), weightedSeeds.concepts(),
                     maxIterations, dampingFactor, scoreThreshold);
 
             if (passageScores.isEmpty() && tripleRows.isEmpty()) {
@@ -136,9 +130,30 @@ public class HippoRagKnowledgeGraphSearchAdapter implements KnowledgeGraphSearch
     }
 
     /**
-     * Deduplicates by a typed record key — no string concatenation, no delimiter
-     * collision risk regardless of predicate or concept content.
+     * Deduplicates graph seeds by target, keeping the strongest bias when the
+     * same passage or concept appears more than once.
      */
+    private WeightedGraphSeeds toWeightedSeeds(GraphSearchRequest request) {
+        Map<String, Double> passageWeights = new LinkedHashMap<>();
+        Map<String, Double> conceptWeights = new LinkedHashMap<>();
+
+        for (var seed : request.seeds()) {
+            switch (seed.target()) {
+                case PassageSeedTarget t -> passageWeights.merge(t.chunkId().toString(), seed.weight(), Math::max);
+                case ConceptSeedTarget t -> conceptWeights.merge(t.concept().name(), seed.weight(), Math::max);
+            }
+        }
+
+        List<WeightedPassageSeed> passages = passageWeights.entrySet().stream()
+                .map(entry -> new WeightedPassageSeed(entry.getKey(), entry.getValue()))
+                .toList();
+        List<WeightedConceptSeed> concepts = conceptWeights.entrySet().stream()
+                .map(entry -> new WeightedConceptSeed(entry.getKey(), entry.getValue()))
+                .toList();
+
+        return new WeightedGraphSeeds(passages, concepts);
+    }
+
     private List<KnowledgeTriple> toActivatedTriples(List<GraphExpansionResult> rows, List<ScoredPassage> scoredPassages) {
         record TripleKey(String subject, String predicate, String object, String chunkId) {}
 
@@ -179,5 +194,10 @@ public class HippoRagKnowledgeGraphSearchAdapter implements KnowledgeGraphSearch
         return message != null
                 && message.contains("There is no procedure with the name `gds.");
     }
+
+    private record WeightedGraphSeeds(
+            List<WeightedPassageSeed> passages,
+            List<WeightedConceptSeed> concepts
+    ) {}
 
 }

--- a/src/main/java/com/kairos/context_engine/infrastructure/graph/executor/KnowledgeGraphGdsExecutor.java
+++ b/src/main/java/com/kairos/context_engine/infrastructure/graph/executor/KnowledgeGraphGdsExecutor.java
@@ -18,8 +18,24 @@ public class KnowledgeGraphGdsExecutor {
                 $graphName,
                 ['PhraseNode', 'Passage'],
                 {
-                    TRIPLE:   { orientation: 'NATURAL' },
-                    CONTAINS: { orientation: 'NATURAL' }
+                    TRIPLE: {
+                        orientation: 'NATURAL',
+                        properties: {
+                            weight: {
+                                property: 'weight',
+                                defaultValue: 1.0
+                            }
+                        }
+                    },
+                    CONTAINS: {
+                        orientation: 'NATURAL',
+                        properties: {
+                            weight: {
+                                property: 'weight',
+                                defaultValue: 1.0
+                            }
+                        }
+                    }
                 }
             )
             YIELD graphName AS name
@@ -35,16 +51,27 @@ public class KnowledgeGraphGdsExecutor {
      * the (passages × triples) cartesian product that the combined query produced.
      */
     private static final String RUN_PPR_PASSAGE_SCORES = """
-            MATCH (node)
-            WHERE (node:Passage    AND node.chunkId IN $passageAnchorIds)
-               OR (node:PhraseNode AND node.name    IN $conceptNames)
-            WITH collect(DISTINCT node) AS seedNodes
-            WHERE size(seedNodes) > 0
+            WITH $passageSeeds AS passageSeeds, $conceptSeeds AS conceptSeeds
+            CALL {
+                WITH passageSeeds
+                UNWIND passageSeeds AS seed
+                MATCH (node:Passage {chunkId: seed.chunkId})
+                RETURN collect([node, seed.weight]) AS passageSourceNodes
+            }
+            CALL {
+                WITH conceptSeeds
+                UNWIND conceptSeeds AS seed
+                MATCH (node:PhraseNode {name: seed.name})
+                RETURN collect([node, seed.weight]) AS conceptSourceNodes
+            }
+            WITH passageSourceNodes + conceptSourceNodes AS sourceNodes
+            WHERE size(sourceNodes) > 0
 
             CALL gds.pageRank.stream($graphName, {
                 maxIterations: $maxIterations,
                 dampingFactor: $dampingFactor,
-                sourceNodes:   seedNodes
+                sourceNodes: sourceNodes,
+                relationshipWeightProperty: 'weight'
             })
             YIELD nodeId, score
 
@@ -68,16 +95,27 @@ public class KnowledgeGraphGdsExecutor {
      * how many passages were selected in the scoring query.
      */
     private static final String RUN_PPR_ACTIVATED_TRIPLES = """
-            MATCH (node)
-            WHERE (node:Passage    AND node.chunkId IN $passageAnchorIds)
-               OR (node:PhraseNode AND node.name    IN $conceptNames)
-            WITH collect(DISTINCT node) AS seedNodes
-            WHERE size(seedNodes) > 0
+            WITH $passageSeeds AS passageSeeds, $conceptSeeds AS conceptSeeds
+            CALL {
+                WITH passageSeeds
+                UNWIND passageSeeds AS seed
+                MATCH (node:Passage {chunkId: seed.chunkId})
+                RETURN collect([node, seed.weight]) AS passageSourceNodes
+            }
+            CALL {
+                WITH conceptSeeds
+                UNWIND conceptSeeds AS seed
+                MATCH (node:PhraseNode {name: seed.name})
+                RETURN collect([node, seed.weight]) AS conceptSourceNodes
+            }
+            WITH passageSourceNodes + conceptSourceNodes AS sourceNodes
+            WHERE size(sourceNodes) > 0
 
             CALL gds.pageRank.stream($graphName, {
                 maxIterations: $maxIterations,
                 dampingFactor: $dampingFactor,
-                sourceNodes:   seedNodes
+                sourceNodes: sourceNodes,
+                relationshipWeightProperty: 'weight'
             })
             YIELD nodeId, score
 
@@ -118,8 +156,8 @@ public class KnowledgeGraphGdsExecutor {
 
     public List<PassageScoringResult> runPPRPassageScores(
             String graphName,
-            List<String> passageAnchorIds,
-            List<String> conceptNames,
+            List<WeightedPassageSeed> passageSeeds,
+            List<WeightedConceptSeed> conceptSeeds,
             int maxIterations,
             double dampingFactor,
             double scoreThreshold,
@@ -128,13 +166,13 @@ public class KnowledgeGraphGdsExecutor {
         try (var session = neo4jDriver.session()) {
             return session.executeRead(transaction ->
                     transaction.run(RUN_PPR_PASSAGE_SCORES, Map.of(
-                            "graphName",        graphName,
-                            "passageAnchorIds", passageAnchorIds,
-                            "conceptNames",     conceptNames,
-                            "maxIterations",    (long) maxIterations,
-                            "dampingFactor",    dampingFactor,
-                            "scoreThreshold",   scoreThreshold,
-                            "limit",            (long) limit
+                            "graphName",      graphName,
+                            "passageSeeds",   toPassageSeedParams(passageSeeds),
+                            "conceptSeeds",   toConceptSeedParams(conceptSeeds),
+                            "maxIterations",  (long) maxIterations,
+                            "dampingFactor",  dampingFactor,
+                            "scoreThreshold", scoreThreshold,
+                            "limit",          (long) limit
                     )).list(record -> new PassageScoringResult(
                             nullableString(record.get("chunkId")),
                             record.get("score").isNull() ? 0d : record.get("score").asDouble()
@@ -145,8 +183,8 @@ public class KnowledgeGraphGdsExecutor {
 
     public List<GraphExpansionResult> runPPRActivatedTriples(
             String graphName,
-            List<String> passageAnchorIds,
-            List<String> conceptNames,
+            List<WeightedPassageSeed> passageSeeds,
+            List<WeightedConceptSeed> conceptSeeds,
             int maxIterations,
             double dampingFactor,
             double scoreThreshold
@@ -154,12 +192,12 @@ public class KnowledgeGraphGdsExecutor {
         try (var session = neo4jDriver.session()) {
             return session.executeRead(transaction ->
                     transaction.run(RUN_PPR_ACTIVATED_TRIPLES, Map.of(
-                            "graphName",        graphName,
-                            "passageAnchorIds", passageAnchorIds,
-                            "conceptNames",     conceptNames,
-                            "maxIterations",    (long) maxIterations,
-                            "dampingFactor",    dampingFactor,
-                            "scoreThreshold",   scoreThreshold
+                            "graphName",      graphName,
+                            "passageSeeds",   toPassageSeedParams(passageSeeds),
+                            "conceptSeeds",   toConceptSeedParams(conceptSeeds),
+                            "maxIterations",  (long) maxIterations,
+                            "dampingFactor",  dampingFactor,
+                            "scoreThreshold", scoreThreshold
                     )).list(record -> new DriverGraphExpansionResult(
                             nullableString(record.get("subject")),
                             nullableString(record.get("predicate")),
@@ -198,6 +236,24 @@ public class KnowledgeGraphGdsExecutor {
         return value == null || value.isNull() ? null : value.asString();
     }
 
+    private List<Map<String, Object>> toPassageSeedParams(List<WeightedPassageSeed> seeds) {
+        return seeds.stream()
+                .map(seed -> Map.<String, Object>of(
+                        "chunkId", seed.chunkId(),
+                        "weight", seed.weight()
+                ))
+                .toList();
+    }
+
+    private List<Map<String, Object>> toConceptSeedParams(List<WeightedConceptSeed> seeds) {
+        return seeds.stream()
+                .map(seed -> Map.<String, Object>of(
+                        "name", seed.name(),
+                        "weight", seed.weight()
+                ))
+                .toList();
+    }
+
     private record DriverGraphExpansionResult(
             String subject,
             String predicate,
@@ -206,4 +262,8 @@ public class KnowledgeGraphGdsExecutor {
             double score,
             double weight
     ) implements GraphExpansionResult {}
+
+    public record WeightedPassageSeed(String chunkId, double weight) {}
+
+    public record WeightedConceptSeed(String name, double weight) {}
 }

--- a/src/test/java/com/kairos/context_engine/infrastructure/graph/adapter/HippoRagKnowledgeGraphSearchAdapterTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/graph/adapter/HippoRagKnowledgeGraphSearchAdapterTest.java
@@ -4,6 +4,8 @@ import com.kairos.context_engine.domain.model.retrieval.graph.GraphSearchRequest
 import com.kairos.context_engine.domain.model.retrieval.graph.GraphSearchResult;
 import com.kairos.context_engine.domain.model.retrieval.seed.GraphSeed;
 import com.kairos.context_engine.infrastructure.graph.executor.KnowledgeGraphGdsExecutor;
+import com.kairos.context_engine.infrastructure.graph.executor.KnowledgeGraphGdsExecutor.WeightedConceptSeed;
+import com.kairos.context_engine.infrastructure.graph.executor.KnowledgeGraphGdsExecutor.WeightedPassageSeed;
 import com.kairos.context_engine.infrastructure.graph.repository.projection.GraphExpansionResult;
 import com.kairos.context_engine.infrastructure.graph.repository.projection.PassageScoringResult;
 import org.neo4j.driver.exceptions.ClientException;
@@ -56,8 +58,8 @@ class HippoRagKnowledgeGraphSearchAdapterTest {
     }
 
     @Test
-    @DisplayName("separates passage and concept seeds before running PPR")
-    void separatesPassageAndConceptSeeds() {
+    @DisplayName("preserves and deduplicates weighted seeds before running PPR")
+    void preservesAndDeduplicatesWeightedSeeds() {
         UUID passageId = UUID.randomUUID();
         UUID resultId = UUID.randomUUID();
         when(executor.runPPRPassageScores(anyString(), anyList(), anyList(), anyInt(), anyDouble(), anyDouble(), anyInt()))
@@ -67,16 +69,18 @@ class HippoRagKnowledgeGraphSearchAdapterTest {
 
         adapter.expandKnowledge(GraphSearchRequest.from(List.of(
                 GraphSeed.passage(passageId, 0.91),
-                GraphSeed.concept("Mind", 0.8)
+                GraphSeed.passage(passageId, 0.52),
+                GraphSeed.concept("Mind", 0.8),
+                GraphSeed.concept("Mind", 0.95)
         ), 20));
 
-        ArgumentCaptor<List<String>> passageIds = ArgumentCaptor.forClass(List.class);
-        ArgumentCaptor<List<String>> conceptNames = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<WeightedPassageSeed>> passageSeeds = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<WeightedConceptSeed>> conceptSeeds = ArgumentCaptor.forClass(List.class);
 
         verify(executor).runPPRPassageScores(
                 anyString(),
-                passageIds.capture(),
-                conceptNames.capture(),
+                passageSeeds.capture(),
+                conceptSeeds.capture(),
                 eq(7),
                 eq(0.9),
                 eq(0.12),
@@ -84,15 +88,17 @@ class HippoRagKnowledgeGraphSearchAdapterTest {
         );
         verify(executor).runPPRActivatedTriples(
                 anyString(),
-                eq(passageIds.getValue()),
-                eq(conceptNames.getValue()),
+                eq(passageSeeds.getValue()),
+                eq(conceptSeeds.getValue()),
                 eq(7),
                 eq(0.9),
                 eq(0.12)
         );
 
-        assertThat(passageIds.getValue()).containsExactly(passageId.toString());
-        assertThat(conceptNames.getValue()).containsExactly("Mind");
+        assertThat(passageSeeds.getValue())
+                .containsExactly(new WeightedPassageSeed(passageId.toString(), 0.91));
+        assertThat(conceptSeeds.getValue())
+                .containsExactly(new WeightedConceptSeed("Mind", 0.95));
     }
 
     @Test

--- a/src/test/java/com/kairos/context_engine/infrastructure/graph/executor/KnowledgeGraphGdsExecutorTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/graph/executor/KnowledgeGraphGdsExecutorTest.java
@@ -2,6 +2,8 @@ package com.kairos.context_engine.infrastructure.graph.executor;
 
 import com.kairos.context_engine.infrastructure.graph.repository.projection.GraphExpansionResult;
 import com.kairos.context_engine.infrastructure.graph.repository.projection.PassageScoringResult;
+import com.kairos.context_engine.infrastructure.graph.executor.KnowledgeGraphGdsExecutor.WeightedConceptSeed;
+import com.kairos.context_engine.infrastructure.graph.executor.KnowledgeGraphGdsExecutor.WeightedPassageSeed;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -70,6 +72,9 @@ class KnowledgeGraphGdsExecutorTest {
 
         assertThat(queryCaptor.getValue()).contains("CALL gds.graph.project(");
         assertThat(queryCaptor.getValue()).contains("['PhraseNode', 'Passage']");
+        assertThat(queryCaptor.getValue()).contains("properties:");
+        assertThat(queryCaptor.getValue()).contains("weight:");
+        assertThat(queryCaptor.getValue()).contains("defaultValue: 1.0");
         assertThat(paramsCaptor.getValue()).containsEntry("graphName", "hipporag-123");
     }
 
@@ -84,8 +89,8 @@ class KnowledgeGraphGdsExecutorTest {
 
         List<PassageScoringResult> rows = executor.runPPRPassageScores(
                 "hipporag-123",
-                List.of("passage-1"),
-                List.of("Concept"),
+                List.of(new WeightedPassageSeed("passage-1", 0.91)),
+                List.of(new WeightedConceptSeed("Concept", 0.8)),
                 20,
                 0.85,
                 0.001,
@@ -97,11 +102,14 @@ class KnowledgeGraphGdsExecutorTest {
         verify(transactionContext).run(queryCaptor.capture(), paramsCaptor.capture());
 
         assertThat(queryCaptor.getValue()).contains("MATCH (passage:Passage)-[:CONTAINS]->(phrase)");
+        assertThat(queryCaptor.getValue()).contains("collect([node, seed.weight])");
+        assertThat(queryCaptor.getValue()).contains("sourceNodes: sourceNodes");
+        assertThat(queryCaptor.getValue()).contains("relationshipWeightProperty: 'weight'");
         assertThat(queryCaptor.getValue()).contains("LIMIT $limit");
         assertThat(paramsCaptor.getValue())
                 .containsEntry("graphName", "hipporag-123")
-                .containsEntry("passageAnchorIds", List.of("passage-1"))
-                .containsEntry("conceptNames", List.of("Concept"))
+                .containsEntry("passageSeeds", List.of(Map.of("chunkId", "passage-1", "weight", 0.91)))
+                .containsEntry("conceptSeeds", List.of(Map.of("name", "Concept", "weight", 0.8)))
                 .containsEntry("maxIterations", 20L)
                 .containsEntry("dampingFactor", 0.85)
                 .containsEntry("scoreThreshold", 0.001)
@@ -129,8 +137,8 @@ class KnowledgeGraphGdsExecutorTest {
 
         List<GraphExpansionResult> rows = executor.runPPRActivatedTriples(
                 "hipporag-123",
-                List.of("passage-1"),
-                List.of("Concept"),
+                List.of(new WeightedPassageSeed("passage-1", 0.91)),
+                List.of(new WeightedConceptSeed("Concept", 0.8)),
                 15,
                 0.9,
                 0.01
@@ -141,12 +149,15 @@ class KnowledgeGraphGdsExecutorTest {
         verify(transactionContext).run(queryCaptor.capture(), paramsCaptor.capture());
 
         assertThat(queryCaptor.getValue()).contains("MATCH (phrase)-[r:TRIPLE]->(target:PhraseNode)");
+        assertThat(queryCaptor.getValue()).contains("collect([node, seed.weight])");
+        assertThat(queryCaptor.getValue()).contains("sourceNodes: sourceNodes");
+        assertThat(queryCaptor.getValue()).contains("relationshipWeightProperty: 'weight'");
         assertThat(queryCaptor.getValue()).contains("r.chunk_id              AS chunkId");
         assertThat(queryCaptor.getValue()).doesNotContain("LIMIT $limit");
         assertThat(paramsCaptor.getValue())
                 .containsEntry("graphName", "hipporag-123")
-                .containsEntry("passageAnchorIds", List.of("passage-1"))
-                .containsEntry("conceptNames", List.of("Concept"))
+                .containsEntry("passageSeeds", List.of(Map.of("chunkId", "passage-1", "weight", 0.91)))
+                .containsEntry("conceptSeeds", List.of(Map.of("name", "Concept", "weight", 0.8)))
                 .containsEntry("maxIterations", 15L)
                 .containsEntry("dampingFactor", 0.9)
                 .containsEntry("scoreThreshold", 0.01);


### PR DESCRIPTION
## Summary
Implements the V1 passage-aware weighted Personalized PageRank flow for graph retrieval.

This keeps the persisted graph model unchanged while making the GDS projection and PPR execution weight-aware.

## Changes
- Preserve `GraphSeed.weight` when converting passage and concept seeds for graph expansion
- Deduplicate repeated passage/concept seeds by keeping the strongest weight
- Pass weighted source-node pairs into `gds.pageRank.stream`
- Enable `relationshipWeightProperty: 'weight'` for PageRank execution
- Project `TRIPLE.weight` with a `1.0` fallback for older relationships
- Project `CONTAINS.weight` as `1.0` without persisting a new property
- Keep passage-first ranking behavior unchanged
- Update graph adapter/executor tests for weighted seeds and weighted PPR params
- Update README to mark weighted PPR as implemented

## Notes
- No Neo4j or PostgreSQL schema migration is required
- `GraphSeed` and `GraphSearchRequest` public domain types remain unchanged
- Ranking still groups activated phrase scores by passage using `max(score)`

## Testing
- `.\mvnw.cmd test`

Result:
- 170 tests passed
- 0 failures
- 1 skipped
