### PR TITLE
#62 feat: configure test toolchain and expand HTTP contract coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <properties>
         <java.version>21</java.version>
         <spring-ai.version>2.0.0-M6</spring-ai.version>
+        <lombok.version>1.18.44</lombok.version>
     </properties>
 
     <dependencyManagement>
@@ -113,6 +114,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.ai</groupId>
@@ -135,9 +141,22 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
+                <version>0.8.14</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/com/kairos/auth/presentation/mapper/AuthMapper.java
+++ b/src/main/java/com/kairos/auth/presentation/mapper/AuthMapper.java
@@ -1,9 +1,0 @@
-package com.kairos.auth.presentation.mapper;
-
-import org.springframework.stereotype.Component;
-
-@Component
-public class AuthMapper {
-
-
-}

--- a/src/main/java/com/kairos/context_engine/presentation/dto/request/GenerateSourceContextRequest.java
+++ b/src/main/java/com/kairos/context_engine/presentation/dto/request/GenerateSourceContextRequest.java
@@ -1,6 +1,8 @@
 package com.kairos.context_engine.presentation.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record GenerateSourceContextRequest(
-        String termQuery
+        @NotBlank String termQuery
 ) {
 }

--- a/src/test/java/com/kairos/auth/presentation/controller/AuthControllerTest.java
+++ b/src/test/java/com/kairos/auth/presentation/controller/AuthControllerTest.java
@@ -1,0 +1,170 @@
+package com.kairos.auth.presentation.controller;
+
+import com.kairos.auth.application.use_case.ConfirmEmailUseCase;
+import com.kairos.auth.application.use_case.LoginUseCase;
+import com.kairos.auth.application.use_case.RegisterUseCase;
+import com.kairos.auth.domain.model.AuthenticatedSession;
+import com.kairos.share.exception.GlobalHandlerException;
+import com.kairos.user.domain.model.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+    @Mock
+    private LoginUseCase loginUseCase;
+
+    @Mock
+    private RegisterUseCase registerUseCase;
+
+    @Mock
+    private ConfirmEmailUseCase confirmEmailUseCase;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = standaloneSetup(new AuthController(loginUseCase, registerUseCase, confirmEmailUseCase))
+                .setControllerAdvice(new GlobalHandlerException())
+                .build();
+    }
+
+    @Test
+    void register_validPayload_returnsCreatedAndMapsCommand() throws Exception {
+        mockMvc.perform(post("/auth/register")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "name": "Lucas",
+                                  "username": "lucas",
+                                  "email": "lucas@example.com",
+                                  "password": "RawPassword123!"
+                                }
+                                """))
+                .andExpect(status().isCreated());
+
+        verify(registerUseCase).execute(argThat(command ->
+                command.name().equals("Lucas")
+                        && command.username().equals("lucas")
+                        && command.email().equals("lucas@example.com")
+                        && command.password().equals("RawPassword123!")
+        ));
+    }
+
+    @Test
+    void register_missingRequiredFields_returnsValidationError() throws Exception {
+        mockMvc.perform(post("/auth/register")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "name": "",
+                                  "username": "",
+                                  "email": "",
+                                  "password": ""
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Validation error"))
+                .andExpect(jsonPath("$.description").value("One or more fields are invalid"))
+                .andExpect(jsonPath("$.path").value("/auth/register"))
+                .andExpect(jsonPath("$.fieldErrors.length()").value(4));
+
+        verifyNoInteractions(registerUseCase);
+    }
+
+    @Test
+    void login_validPayload_returnsTokenAndRoles() throws Exception {
+        when(loginUseCase.execute(argThat(command ->
+                command.identifier().equals("lucas@example.com")
+                        && command.password().equals("RawPassword123!")
+        ))).thenReturn(new AuthenticatedSession("access-token", List.of(Role.FREE, Role.ADMIN)));
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "identifier": "lucas@example.com",
+                                  "password": "RawPassword123!"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("access-token"))
+                .andExpect(jsonPath("$.roles[0]").value("FREE"))
+                .andExpect(jsonPath("$.roles[1]").value("ADMIN"));
+    }
+
+    @Test
+    void login_missingRequiredFields_returnsValidationError() throws Exception {
+        mockMvc.perform(post("/auth/login")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "identifier": "",
+                                  "password": ""
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Validation error"))
+                .andExpect(jsonPath("$.path").value("/auth/login"))
+                .andExpect(jsonPath("$.fieldErrors.length()").value(2));
+
+        verifyNoInteractions(loginUseCase);
+    }
+
+    @Test
+    void confirmEmail_validPayload_returnsTokenAndRoles() throws Exception {
+        when(confirmEmailUseCase.execute(argThat(command ->
+                command.code().equals("123456")
+                        && command.email().equals("lucas@example.com")
+        ))).thenReturn(new AuthenticatedSession("confirmed-token", List.of(Role.FREE)));
+
+        mockMvc.perform(post("/auth/confirm-email")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "code": "123456",
+                                  "email": "lucas@example.com"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("confirmed-token"))
+                .andExpect(jsonPath("$.roles[0]").value("FREE"));
+    }
+
+    @Test
+    void confirmEmail_missingRequiredFields_returnsValidationError() throws Exception {
+        mockMvc.perform(post("/auth/confirm-email")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "code": "",
+                                  "email": ""
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Validation error"))
+                .andExpect(jsonPath("$.path").value("/auth/confirm-email"))
+                .andExpect(jsonPath("$.fieldErrors.length()").value(2));
+
+        verifyNoInteractions(confirmEmailUseCase);
+    }
+}

--- a/src/test/java/com/kairos/context_engine/presentation/controller/SourceControllerSecurityTest.java
+++ b/src/test/java/com/kairos/context_engine/presentation/controller/SourceControllerSecurityTest.java
@@ -1,0 +1,67 @@
+package com.kairos.context_engine.presentation.controller;
+
+import com.kairos.context_engine.application.use_case.SearchSourceUseCase;
+import com.kairos.context_engine.application.use_case.UploadSourceUseCase;
+import com.kairos.context_engine.presentation.mapper.SourceMapper;
+import com.kairos.share.security.config.AuthSecurityConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SourceController.class)
+@Import(AuthSecurityConfiguration.class)
+class SourceControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UploadSourceUseCase uploadSourceUseCase;
+
+    @MockitoBean
+    private SearchSourceUseCase searchSourceUseCase;
+
+    @MockitoBean
+    private SourceMapper mapper;
+
+    @Test
+    void uploadSource_withoutAuthentication_returnsUnauthorized() throws Exception {
+        mockMvc.perform(post("/sources")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "title": "RAG notes",
+                                  "content": "Knowledge graphs improve retrieval."
+                                }
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void uploadSource_withJwtAuthentication_reachesController() throws Exception {
+        mockMvc.perform(post("/sources")
+                        .with(jwt())
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "title": "RAG notes",
+                                  "content": "Knowledge graphs improve retrieval."
+                                }
+                                """))
+                .andExpect(status().isCreated());
+
+        verify(uploadSourceUseCase).execute(argThat(command ->
+                command.title().equals("RAG notes")
+                        && command.content().equals("Knowledge graphs improve retrieval.")
+        ));
+    }
+}

--- a/src/test/java/com/kairos/context_engine/presentation/controller/SourceControllerTest.java
+++ b/src/test/java/com/kairos/context_engine/presentation/controller/SourceControllerTest.java
@@ -5,6 +5,7 @@ import com.kairos.context_engine.application.use_case.UploadSourceUseCase;
 import com.kairos.context_engine.domain.model.SearchResult;
 import com.kairos.context_engine.presentation.dto.response.ContextResponse;
 import com.kairos.context_engine.presentation.mapper.SourceMapper;
+import com.kairos.share.exception.GlobalHandlerException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,6 +22,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
@@ -41,6 +43,7 @@ class SourceControllerTest {
     @BeforeEach
     void setUp() {
         mockMvc = standaloneSetup(new SourceController(uploadSourceUseCase, searchSourceUseCase, mapper))
+                .setControllerAdvice(new GlobalHandlerException())
                 .build();
     }
 
@@ -84,6 +87,44 @@ class SourceControllerTest {
     }
 
     @Test
+    void uploadSource_missingRequiredFields_returnsValidationError() throws Exception {
+        mockMvc.perform(post("/sources")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "title": "",
+                                  "content": ""
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Validation error"))
+                .andExpect(jsonPath("$.description").value("One or more fields are invalid"))
+                .andExpect(jsonPath("$.path").value("/sources"))
+                .andExpect(jsonPath("$.fieldErrors.length()").value(2));
+
+        verifyNoInteractions(uploadSourceUseCase);
+    }
+
+    @Test
+    void uploadSource_malformedJson_returnsErrorResponse() throws Exception {
+        mockMvc.perform(post("/sources")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "title": "RAG notes",
+                                  "content":
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Malformed JSON request"))
+                .andExpect(jsonPath("$.path").value("/sources"));
+
+        verifyNoInteractions(uploadSourceUseCase);
+    }
+
+    @Test
     void searchSourceContext_usesPostSearchEndpoint() throws Exception {
         SearchResult result = SearchResult.empty();
         ContextResponse response = new ContextResponse(List.of(), List.of());
@@ -100,9 +141,29 @@ class SourceControllerTest {
                                   "termQuery": "How does graph retrieval work?"
                                 }
                                 """))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.knowledgeGraph.length()").value(0))
+                .andExpect(jsonPath("$.chunkContexts.length()").value(0));
 
         verify(mapper).toContextResponse(result);
+    }
+
+    @Test
+    void searchSourceContext_blankTermQuery_returnsValidationError() throws Exception {
+        mockMvc.perform(post("/sources/search")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "termQuery": ""
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Validation error"))
+                .andExpect(jsonPath("$.path").value("/sources/search"))
+                .andExpect(jsonPath("$.fieldErrors[0].field").value("termQuery"));
+
+        verifyNoInteractions(searchSourceUseCase, mapper);
     }
 
     @Test
@@ -114,7 +175,10 @@ class SourceControllerTest {
                                   "termQuery": "How does graph retrieval work?"
                                 }
                                 """))
-                .andExpect(status().isMethodNotAllowed());
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(jsonPath("$.code").value(405))
+                .andExpect(jsonPath("$.message").value("Method not allowed"))
+                .andExpect(jsonPath("$.path").value("/sources"));
 
         verifyNoInteractions(searchSourceUseCase, mapper);
     }

--- a/src/test/java/com/kairos/context_engine/presentation/mapper/SourceMapperTest.java
+++ b/src/test/java/com/kairos/context_engine/presentation/mapper/SourceMapperTest.java
@@ -1,0 +1,54 @@
+package com.kairos.context_engine.presentation.mapper;
+
+import com.kairos.context_engine.domain.model.SearchResult;
+import com.kairos.context_engine.domain.model.content.Chunk;
+import com.kairos.context_engine.domain.model.content.Source;
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.Passage;
+import com.kairos.context_engine.domain.model.retrieval.ranking.RankedChunk;
+import com.kairos.context_engine.domain.model.retrieval.source.RetrievalSource;
+import com.kairos.context_engine.presentation.dto.response.ContextResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SourceMapperTest {
+
+    private final SourceMapper mapper = new SourceMapper();
+
+    @Test
+    void toContextResponse_preservesKnowledgeGraphAndChunkContextFields() {
+        UUID authorId = UUID.randomUUID();
+        UUID sourceId = UUID.randomUUID();
+        UUID chunkId = UUID.randomUUID();
+        Source source = new Source(sourceId, "RAG notes", "Knowledge graphs improve retrieval.", authorId);
+        Chunk chunk = Chunk.create(chunkId, source, "Chunk content", 0, true, new float[]{0.1f, 0.2f});
+        KnowledgeTriple triple = KnowledgeTriple.create(
+                "HippoRAG",
+                "USES",
+                "Knowledge graph",
+                Passage.fromChunkId(chunkId),
+                0.8
+        );
+        RankedChunk rankedChunk = new RankedChunk(chunk, 1, 0.95, RetrievalSource.HYBRID);
+        SearchResult searchResult = SearchResult.from(List.of(triple), List.of(rankedChunk));
+
+        ContextResponse response = mapper.toContextResponse(searchResult);
+
+        assertThat(response.knowledgeGraph()).hasSize(1);
+        assertThat(response.knowledgeGraph().getFirst().subject()).isEqualTo("HippoRAG");
+        assertThat(response.knowledgeGraph().getFirst().predicate()).isEqualTo("USES");
+        assertThat(response.knowledgeGraph().getFirst().object()).isEqualTo("Knowledge graph");
+        assertThat(response.knowledgeGraph().getFirst().chunkId()).isEqualTo(chunkId);
+
+        assertThat(response.chunkContexts()).hasSize(1);
+        assertThat(response.chunkContexts().getFirst().chunkId()).isEqualTo(chunkId);
+        assertThat(response.chunkContexts().getFirst().content()).isEqualTo("Chunk content");
+        assertThat(response.chunkContexts().getFirst().rank()).isEqualTo(1);
+        assertThat(response.chunkContexts().getFirst().score()).isEqualTo(0.95);
+        assertThat(response.chunkContexts().getFirst().source()).isEqualTo(RetrievalSource.HYBRID);
+    }
+}

--- a/src/test/java/com/kairos/share/exception/GlobalHandlerExceptionTest.java
+++ b/src/test/java/com/kairos/share/exception/GlobalHandlerExceptionTest.java
@@ -1,0 +1,163 @@
+package com.kairos.share.exception;
+
+import com.kairos.auth.infrastructure.email.EmailConfirmationDeliveryException;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+class GlobalHandlerExceptionTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = standaloneSetup(new ErrorContractController())
+                .setControllerAdvice(new GlobalHandlerException())
+                .build();
+    }
+
+    @Test
+    void handleValidationError_returnsErrorEnvelopeWithFieldErrors() throws Exception {
+        mockMvc.perform(post("/contract/validation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": ""
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Validation error"))
+                .andExpect(jsonPath("$.description").value("One or more fields are invalid"))
+                .andExpect(jsonPath("$.path").value("/contract/validation"))
+                .andExpect(jsonPath("$.fieldErrors[0].field").value("name"));
+    }
+
+    @Test
+    void handleMalformedJson_returnsErrorEnvelope() throws Exception {
+        mockMvc.perform(post("/contract/validation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name":
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Malformed JSON request"))
+                .andExpect(jsonPath("$.path").value("/contract/validation"));
+    }
+
+    @Test
+    void handleMissingRequestParameter_returnsErrorEnvelope() throws Exception {
+        mockMvc.perform(get("/contract/missing-param"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Missing request parameter"))
+                .andExpect(jsonPath("$.description").value("Required parameter 'value' of type 'String' is missing"))
+                .andExpect(jsonPath("$.path").value("/contract/missing-param"));
+    }
+
+    @Test
+    void handleTypeMismatch_returnsErrorEnvelope() throws Exception {
+        mockMvc.perform(get("/contract/type-mismatch")
+                        .param("count", "not-a-number"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("Type mismatch"))
+                .andExpect(jsonPath("$.description").value("Parameter 'count' expects type 'Integer' but received 'not-a-number'"))
+                .andExpect(jsonPath("$.path").value("/contract/type-mismatch"));
+    }
+
+    @Test
+    void handleEntityNotFound_returnsErrorEnvelope() throws Exception {
+        mockMvc.perform(get("/contract/entity-not-found"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(404))
+                .andExpect(jsonPath("$.message").value("Entity not found"))
+                .andExpect(jsonPath("$.description").value("Source not found"))
+                .andExpect(jsonPath("$.path").value("/contract/entity-not-found"));
+    }
+
+    @Test
+    void handleMethodNotAllowed_returnsErrorEnvelope() throws Exception {
+        mockMvc.perform(get("/contract/post-only"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(jsonPath("$.code").value(405))
+                .andExpect(jsonPath("$.message").value("Method not allowed"))
+                .andExpect(jsonPath("$.path").value("/contract/post-only"));
+    }
+
+    @Test
+    void handleEmailDeliveryError_returnsServiceUnavailableEnvelope() throws Exception {
+        mockMvc.perform(get("/contract/email-error"))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.code").value(503))
+                .andExpect(jsonPath("$.message").value("Email delivery unavailable"))
+                .andExpect(jsonPath("$.description").value("SMTP unavailable"))
+                .andExpect(jsonPath("$.path").value("/contract/email-error"));
+    }
+
+    @Test
+    void handleUnexpectedError_returnsInternalServerErrorEnvelope() throws Exception {
+        mockMvc.perform(get("/contract/unexpected-error"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value(500))
+                .andExpect(jsonPath("$.message").value("Internal server error"))
+                .andExpect(jsonPath("$.description").value("boom"))
+                .andExpect(jsonPath("$.path").value("/contract/unexpected-error"));
+    }
+
+    @RestController
+    private static class ErrorContractController {
+
+        @PostMapping("/contract/validation")
+        void validation(@RequestBody @Valid ValidationRequest request) {
+        }
+
+        @GetMapping("/contract/missing-param")
+        void missingParam(@RequestParam String value) {
+        }
+
+        @GetMapping("/contract/type-mismatch")
+        void typeMismatch(@RequestParam Integer count) {
+        }
+
+        @GetMapping("/contract/entity-not-found")
+        void entityNotFound() {
+            throw new EntityNotFoundException("Source not found");
+        }
+
+        @PostMapping("/contract/post-only")
+        void postOnly() {
+        }
+
+        @GetMapping("/contract/email-error")
+        void emailError() {
+            throw new EmailConfirmationDeliveryException("SMTP unavailable", new RuntimeException("down"));
+        }
+
+        @GetMapping("/contract/unexpected-error")
+        void unexpectedError() throws Exception {
+            throw new Exception("boom");
+        }
+    }
+
+    private record ValidationRequest(@NotBlank String name) {
+    }
+}

--- a/src/test/java/com/kairos/share/presentation/ApiContractFactoryTest.java
+++ b/src/test/java/com/kairos/share/presentation/ApiContractFactoryTest.java
@@ -1,0 +1,51 @@
+package com.kairos.share.presentation;
+
+import com.kairos.auth.application.command.ConfirmEmailCommand;
+import com.kairos.auth.application.command.LoginCommand;
+import com.kairos.auth.application.command.RegisterCommand;
+import com.kairos.auth.presentation.dto.login.LoginResponse;
+import com.kairos.context_engine.application.command.UploadSourceCommand;
+import com.kairos.context_engine.application.query.SearchSourceQuery;
+import com.kairos.user.domain.model.Role;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApiContractFactoryTest {
+
+    @Test
+    void authCommandFactories_preserveInputValues() {
+        RegisterCommand register = RegisterCommand.of("Lucas", "lucas", "lucas@example.com", "RawPassword123!");
+        LoginCommand login = LoginCommand.of("lucas@example.com", "RawPassword123!");
+        ConfirmEmailCommand confirmEmail = ConfirmEmailCommand.of("123456", "lucas@example.com");
+
+        assertThat(register.name()).isEqualTo("Lucas");
+        assertThat(register.username()).isEqualTo("lucas");
+        assertThat(register.email()).isEqualTo("lucas@example.com");
+        assertThat(register.password()).isEqualTo("RawPassword123!");
+        assertThat(login.identifier()).isEqualTo("lucas@example.com");
+        assertThat(login.password()).isEqualTo("RawPassword123!");
+        assertThat(confirmEmail.code()).isEqualTo("123456");
+        assertThat(confirmEmail.email()).isEqualTo("lucas@example.com");
+    }
+
+    @Test
+    void sourceCommandAndQueryFactories_preserveInputValues() {
+        UploadSourceCommand upload = UploadSourceCommand.of("RAG notes", "Knowledge graphs improve retrieval.");
+        SearchSourceQuery search = SearchSourceQuery.of("How does graph retrieval work?");
+
+        assertThat(upload.title()).isEqualTo("RAG notes");
+        assertThat(upload.content()).isEqualTo("Knowledge graphs improve retrieval.");
+        assertThat(search.searchTerm()).isEqualTo("How does graph retrieval work?");
+    }
+
+    @Test
+    void loginResponseFactory_convertsRolesToPublicNames() {
+        LoginResponse response = LoginResponse.of("access-token", List.of(Role.FREE, Role.ADMIN));
+
+        assertThat(response.accessToken()).isEqualTo("access-token");
+        assertThat(response.roles()).containsExactly("FREE", "ADMIN");
+    }
+}

--- a/src/test/java/com/kairos/user/infrastructure/persistence/mapper/UserEntityMapperTest.java
+++ b/src/test/java/com/kairos/user/infrastructure/persistence/mapper/UserEntityMapperTest.java
@@ -1,0 +1,67 @@
+package com.kairos.user.infrastructure.persistence.mapper;
+
+import com.kairos.user.domain.model.Role;
+import com.kairos.user.domain.model.User;
+import com.kairos.user.infrastructure.persistence.entity.UserEntity;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserEntityMapperTest {
+
+    private final UserEntityMapper mapper = new UserEntityMapper();
+
+    @Test
+    void toEntity_preservesAllUserFields() {
+        UUID userId = UUID.randomUUID();
+        User user = new User.Builder()
+                .id(userId)
+                .name("Lucas")
+                .username("lucas")
+                .email("lucas@example.com")
+                .hashPassword("hashed-password")
+                .role(Role.ADMIN)
+                .emailConfirmed(true)
+                .confirmationCodeHash("confirmation-hash")
+                .build();
+
+        UserEntity entity = mapper.toEntity(user);
+
+        assertThat(entity.getId()).isEqualTo(userId);
+        assertThat(entity.getName()).isEqualTo("Lucas");
+        assertThat(entity.getUsername()).isEqualTo("lucas");
+        assertThat(entity.getEmail()).isEqualTo("lucas@example.com");
+        assertThat(entity.getHashPassword()).isEqualTo("hashed-password");
+        assertThat(entity.getRole()).isEqualTo(Role.ADMIN);
+        assertThat(entity.isEmailConfirmed()).isTrue();
+        assertThat(entity.getConfirmationCodeHash()).isEqualTo("confirmation-hash");
+    }
+
+    @Test
+    void toDomain_preservesAllEntityFields() {
+        UUID userId = UUID.randomUUID();
+        UserEntity entity = UserEntity.builder()
+                .id(userId)
+                .name("Lucas")
+                .username("lucas")
+                .email("lucas@example.com")
+                .hashPassword("hashed-password")
+                .role(Role.PREMIUM)
+                .emailConfirmed(false)
+                .confirmationCodeHash("confirmation-hash")
+                .build();
+
+        User user = mapper.toDomain(entity);
+
+        assertThat(user.getId()).isEqualTo(userId);
+        assertThat(user.getName()).isEqualTo("Lucas");
+        assertThat(user.getUsername()).isEqualTo("lucas");
+        assertThat(user.getEmail()).isEqualTo("lucas@example.com");
+        assertThat(user.getHashPassword()).isEqualTo("hashed-password");
+        assertThat(user.getRole()).isEqualTo(Role.PREMIUM);
+        assertThat(user.isEmailConfirmed()).isFalse();
+        assertThat(user.getConfirmationCodeHash()).isEqualTo("confirmation-hash");
+    }
+}


### PR DESCRIPTION
## Resumo

Esta PR amplia a cobertura dos contratos HTTP publicos do Kairos, com foco nos fluxos de autenticacao, ingestao de sources, busca contextual, envelope global de erro e mapeamentos entre camadas.

O objetivo principal e proteger comportamentos que fazem parte do contrato externo da API: status HTTP, payloads de sucesso, payloads de erro, validacao de campos obrigatorios, preservacao de dados em mappers e conversao de roles para o formato exposto ao cliente.

## Contexto

A issue #62 tambem absorve o escopo da #63 para evitar PRs pequenos demais. Por isso, alem dos controllers, esta PR cobre DTOs, factories simples, mappers e o `GlobalHandlerException`.

Antes desta mudanca, varios fluxos importantes estavam testados indiretamente ou apenas pelo status HTTP. Agora os testes tambem verificam o corpo das respostas, especialmente o formato `ErrorResponse`, que e parte sensivel do contrato da API.

## Alteracoes

- Adiciona testes de contrato para `POST /auth/register`, `POST /auth/login` e `POST /auth/confirm-email`, cobrindo sucesso e validacao.
- Amplia os testes de `/sources` e `/sources/search`, incluindo upload valido, busca valida, payload invalido, JSON malformado e metodo nao permitido.
- Adiciona validacao `@NotBlank` em `GenerateSourceContextRequest.termQuery`, garantindo que busca vazia retorne erro de validacao.
- Cobre a protecao de `/sources` com Spring Security: sem autenticacao retorna `401` e com JWT mockado alcanca o controller.
- Adiciona cobertura direta para `GlobalHandlerException`, incluindo validacao, JSON invalido, parametro ausente, type mismatch, entity not found, method not allowed, erro de email e erro inesperado.
- Cobre `UserEntityMapper`, `SourceMapper`, factories de commands/queries e `LoginResponse.of`, garantindo preservacao dos campos relevantes.
- Remove `AuthMapper`, que estava vazio, anotado como componente e sem referencias.
- Configura o processamento explicito de annotations do Lombok e atualiza o JaCoCo para `0.8.14`, permitindo rodar a suite em JDK 25 sem depender de parametros manuais.

## Cobertura e qualidade

- Controllers de auth e sources passam a ter cobertura de sucesso e erro relevante.
- O pacote de DTOs de response do context engine e o `SourceMapper` ficam protegidos por testes unitarios.
- O formato global de erro fica protegido contra regressao em status, mensagem, descricao, path e `fieldErrors`.
- A remocao do `AuthMapper` reduz superficie inutil no contexto Spring.

## Validacao

- `.\mvnw.cmd test`
- Resultado: `209 tests`, `0 failures`, `0 errors`, `1 skipped`
- JaCoCo executado com sucesso ao final da suite.

## Observacoes

- O arquivo de descricao desta PR nao deve ser commitado junto com a implementacao.
- A cobertura de linhas ficou em aproximadamente `84,26%`.
- A cobertura de branches ficou em aproximadamente `65,97%`.

Closes #62
