### PR TITLE
#65 test: expand knowledge engine coverage

### DIFF
--- a/src/test/java/com/kairos/context_engine/domain/model/retrieval/RetrievalModelTest.java
+++ b/src/test/java/com/kairos/context_engine/domain/model/retrieval/RetrievalModelTest.java
@@ -1,0 +1,169 @@
+package com.kairos.context_engine.domain.model.retrieval;
+
+import com.kairos.context_engine.domain.model.content.Chunk;
+import com.kairos.context_engine.domain.model.content.Source;
+import com.kairos.context_engine.domain.model.knowledge.KnowledgeTriple;
+import com.kairos.context_engine.domain.model.knowledge.Passage;
+import com.kairos.context_engine.domain.model.retrieval.graph.GraphSearchRequest;
+import com.kairos.context_engine.domain.model.retrieval.graph.GraphSearchResult;
+import com.kairos.context_engine.domain.model.retrieval.ranking.RankedChunk;
+import com.kairos.context_engine.domain.model.retrieval.ranking.ScoredPassage;
+import com.kairos.context_engine.domain.model.retrieval.seed.ConceptSeedTarget;
+import com.kairos.context_engine.domain.model.retrieval.seed.GraphSeed;
+import com.kairos.context_engine.domain.model.retrieval.seed.PassageSeedTarget;
+import com.kairos.context_engine.domain.model.retrieval.seed.SeedType;
+import com.kairos.context_engine.domain.model.retrieval.source.RetrievalSource;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RetrievalModelTest {
+
+    @Test
+    void graphSeed_shouldCreateTypedPassageAndConceptSeeds() {
+        UUID chunkId = UUID.randomUUID();
+
+        GraphSeed passageSeed = GraphSeed.passage(chunkId, 0.7);
+        GraphSeed conceptSeed = GraphSeed.concept("  Spring  ", 0.8);
+
+        assertThat(passageSeed.type()).isEqualTo(SeedType.PASSAGE);
+        assertThat(((PassageSeedTarget) passageSeed.target()).chunkId()).isEqualTo(chunkId);
+        assertThat(passageSeed.weight()).isEqualTo(0.7);
+        assertThat(conceptSeed.type()).isEqualTo(SeedType.CONCEPT);
+        assertThat(((ConceptSeedTarget) conceptSeed.target()).concept().name()).isEqualTo("Spring");
+        assertThat(conceptSeed.weight()).isEqualTo(0.8);
+    }
+
+    @Test
+    void graphSeed_shouldRejectInvalidFieldsAndMismatchedTypes() {
+        UUID chunkId = UUID.randomUUID();
+
+        assertThatThrownBy(() -> new GraphSeed(null, SeedType.PASSAGE, 0.7))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Graph seed target cannot be null");
+        assertThatThrownBy(() -> new GraphSeed(new PassageSeedTarget(chunkId), null, 0.7))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Graph seed type cannot be null");
+        assertThatThrownBy(() -> GraphSeed.passage(chunkId, 0.0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Graph seed weight must be a positive finite value");
+        assertThatThrownBy(() -> GraphSeed.passage(chunkId, Double.NaN))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Graph seed weight must be a positive finite value");
+        assertThatThrownBy(() -> GraphSeed.passage(chunkId, Double.POSITIVE_INFINITY))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Graph seed weight must be a positive finite value");
+        assertThatThrownBy(() -> new GraphSeed(new PassageSeedTarget(chunkId), SeedType.CONCEPT, 0.7))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Passage seed target must use PASSAGE seed type");
+        assertThatThrownBy(() -> new GraphSeed(ConceptSeedTarget.fromName("Spring"), SeedType.PASSAGE, 0.7))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Concept seed target must use CONCEPT seed type");
+    }
+
+    @Test
+    void seedTargets_shouldRejectNullValues() {
+        assertThatThrownBy(() -> new PassageSeedTarget(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Passage seed chunkId cannot be null");
+        assertThatThrownBy(() -> new ConceptSeedTarget(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Concept seed target cannot be null");
+    }
+
+    @Test
+    void graphSearchRequest_shouldDefensivelyCopySeeds() {
+        UUID userId = UUID.randomUUID();
+        List<GraphSeed> seeds = new ArrayList<>();
+        seeds.add(GraphSeed.passage(UUID.randomUUID(), 0.7));
+
+        GraphSearchRequest request = GraphSearchRequest.from(userId, seeds, 10);
+        seeds.add(GraphSeed.concept("Spring", 0.8));
+
+        assertThat(request.userId()).isEqualTo(userId);
+        assertThat(request.seeds()).hasSize(1);
+        assertThat(request.limit()).isEqualTo(10);
+        assertThatThrownBy(() -> request.seeds().add(GraphSeed.concept("JPA", 0.9)))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void graphSearchRequest_shouldRejectInvalidFields() {
+        List<GraphSeed> seeds = List.of(GraphSeed.passage(UUID.randomUUID(), 0.7));
+
+        assertThatThrownBy(() -> GraphSearchRequest.from(null, seeds, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Graph search userId cannot be null");
+        assertThatThrownBy(() -> GraphSearchRequest.from(UUID.randomUUID(), null, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Graph search seeds cannot be null");
+        assertThatThrownBy(() -> GraphSearchRequest.from(UUID.randomUUID(), seeds, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Graph search limit must be positive");
+    }
+
+    @Test
+    void graphSearchResult_shouldDefensivelyCopyLists() {
+        UUID chunkId = UUID.randomUUID();
+        List<ScoredPassage> scoredPassages = new ArrayList<>();
+        scoredPassages.add(new ScoredPassage(chunkId, 0.9));
+        List<KnowledgeTriple> activatedTriples = new ArrayList<>();
+        activatedTriples.add(KnowledgeTriple.create("Spring", "USES", "JPA", Passage.fromChunkId(chunkId), 1.0));
+
+        GraphSearchResult result = new GraphSearchResult(scoredPassages, activatedTriples);
+        scoredPassages.clear();
+        activatedTriples.clear();
+
+        assertThat(result.scoredPassages()).hasSize(1);
+        assertThat(result.activatedTriples()).hasSize(1);
+        assertThatThrownBy(() -> result.scoredPassages().add(new ScoredPassage(UUID.randomUUID(), 0.5)))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> result.activatedTriples().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void graphSearchResult_shouldRejectNullLists() {
+        assertThatThrownBy(() -> new GraphSearchResult(null, List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Graph search scored passages cannot be null");
+        assertThatThrownBy(() -> new GraphSearchResult(List.of(), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Graph search activated triples cannot be null");
+    }
+
+    @Test
+    void rankingModels_shouldRejectInvalidFields() {
+        Chunk chunk = new Chunk(UUID.randomUUID(), new Source("title", "content"), "content", 0, true, new float[]{0.1f});
+
+        assertThatThrownBy(() -> new ScoredPassage(null, 0.8))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Scored passage chunkId cannot be null");
+        assertThatThrownBy(() -> new ScoredPassage(UUID.randomUUID(), Double.NaN))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Scored passage graphScore must be finite");
+        assertThatThrownBy(() -> new ScoredPassage(UUID.randomUUID(), Double.NEGATIVE_INFINITY))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Scored passage graphScore must be finite");
+        assertThatThrownBy(() -> new RankedChunk(null, 1, 0.8, RetrievalSource.GRAPH))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Ranked chunk cannot be null");
+        assertThatThrownBy(() -> new RankedChunk(chunk, 0, 0.8, RetrievalSource.GRAPH))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Ranked chunk rank must be positive");
+        assertThatThrownBy(() -> new RankedChunk(chunk, 1, Double.NaN, RetrievalSource.GRAPH))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Ranked chunk score must be finite");
+        assertThatThrownBy(() -> new RankedChunk(chunk, 1, Double.POSITIVE_INFINITY, RetrievalSource.GRAPH))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Ranked chunk score must be finite");
+        assertThatThrownBy(() -> new RankedChunk(chunk, 1, 0.8, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Ranked chunk source cannot be null");
+    }
+}

--- a/src/test/java/com/kairos/context_engine/domain/model/retrieval/candidate/RetrievalCandidateTest.java
+++ b/src/test/java/com/kairos/context_engine/domain/model/retrieval/candidate/RetrievalCandidateTest.java
@@ -1,0 +1,98 @@
+package com.kairos.context_engine.domain.model.retrieval.candidate;
+
+import com.kairos.context_engine.domain.model.knowledge.Concept;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RetrievalCandidateTest {
+
+    @Test
+    void tripleCandidate_shouldTrimTextFields() {
+        UUID chunkId = UUID.randomUUID();
+
+        TripleCandidate candidate = new TripleCandidate(
+                "  key  ",
+                "  subject  ",
+                "  predicate  ",
+                "  object  ",
+                chunkId,
+                0.75
+        );
+
+        assertThat(candidate.key()).isEqualTo("key");
+        assertThat(candidate.subject()).isEqualTo("subject");
+        assertThat(candidate.predicate()).isEqualTo("predicate");
+        assertThat(candidate.object()).isEqualTo("object");
+        assertThat(candidate.chunkId()).isEqualTo(chunkId);
+        assertThat(candidate.similarityScore()).isEqualTo(0.75);
+    }
+
+    @Test
+    void tripleCandidate_shouldRejectInvalidFields() {
+        UUID chunkId = UUID.randomUUID();
+
+        assertThatThrownBy(() -> new TripleCandidate(null, "s", "p", "o", chunkId, 0.1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Triple candidate key cannot be null or blank");
+        assertThatThrownBy(() -> new TripleCandidate(" ", "s", "p", "o", chunkId, 0.1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Triple candidate key cannot be null or blank");
+        assertThatThrownBy(() -> new TripleCandidate("k", null, "p", "o", chunkId, 0.1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Triple candidate subject cannot be null or blank");
+        assertThatThrownBy(() -> new TripleCandidate("k", " ", "p", "o", chunkId, 0.1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Triple candidate subject cannot be null or blank");
+        assertThatThrownBy(() -> new TripleCandidate("k", "s", null, "o", chunkId, 0.1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Triple candidate predicate cannot be null or blank");
+        assertThatThrownBy(() -> new TripleCandidate("k", "s", " ", "o", chunkId, 0.1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Triple candidate predicate cannot be null or blank");
+        assertThatThrownBy(() -> new TripleCandidate("k", "s", "p", null, chunkId, 0.1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Triple candidate object cannot be null or blank");
+        assertThatThrownBy(() -> new TripleCandidate("k", "s", "p", " ", chunkId, 0.1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Triple candidate object cannot be null or blank");
+        assertThatThrownBy(() -> new TripleCandidate("k", "s", "p", "o", null, 0.1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Triple candidate chunkId cannot be null");
+        assertThatThrownBy(() -> new TripleCandidate("k", "s", "p", "o", chunkId, Double.NaN))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Triple candidate similarity score must be finite");
+        assertThatThrownBy(() -> new TripleCandidate("k", "s", "p", "o", chunkId, Double.POSITIVE_INFINITY))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Triple candidate similarity score must be finite");
+    }
+
+    @Test
+    void passageCandidate_shouldRejectInvalidFields() {
+        assertThatThrownBy(() -> new PassageCandidate(null, 0.7))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Passage candidate chunkId cannot be null");
+        assertThatThrownBy(() -> new PassageCandidate(UUID.randomUUID(), Double.NaN))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Passage candidate denseScore must be finite");
+        assertThatThrownBy(() -> new PassageCandidate(UUID.randomUUID(), Double.NEGATIVE_INFINITY))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Passage candidate denseScore must be finite");
+    }
+
+    @Test
+    void conceptCandidate_shouldRejectInvalidFields() {
+        assertThatThrownBy(() -> new ConceptCandidate(null, 0.7))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Concept cannot be null");
+        assertThatThrownBy(() -> new ConceptCandidate(Concept.create("Spring"), Double.NaN))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("SimilarityScore must be finite");
+        assertThatThrownBy(() -> new ConceptCandidate(Concept.create("Spring"), Double.POSITIVE_INFINITY))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("SimilarityScore must be finite");
+    }
+}

--- a/src/test/java/com/kairos/context_engine/infrastructure/event/consumer/CreatedSourceListenerTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/event/consumer/CreatedSourceListenerTest.java
@@ -10,6 +10,9 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.*;
 
 class CreatedSourceListenerTest {
@@ -37,6 +40,23 @@ class CreatedSourceListenerTest {
 
         GenerateSourceContextCommand command = captor.getValue();
 
-        assert command.sourceId().equals(sourceId);
+        assertThat(command.sourceId()).isEqualTo(sourceId);
+    }
+
+    @Test
+    void shouldPropagateUseCaseFailures() {
+        UUID sourceId = UUID.randomUUID();
+        CreatedSourceEvent event = new CreatedSourceEvent(sourceId);
+        doThrow(new RuntimeException("Context generation failed"))
+                .when(useCase).execute(any(GenerateSourceContextCommand.class));
+
+        assertThatThrownBy(() -> listener.handleCreatedSourceEvent(event))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Context generation failed");
+
+        ArgumentCaptor<GenerateSourceContextCommand> captor =
+                ArgumentCaptor.forClass(GenerateSourceContextCommand.class);
+        verify(useCase).execute(captor.capture());
+        assertThat(captor.getValue().sourceId()).isEqualTo(sourceId);
     }
 }

--- a/src/test/java/com/kairos/context_engine/infrastructure/event/publisher/SpringSourceEventPublisherTest.java
+++ b/src/test/java/com/kairos/context_engine/infrastructure/event/publisher/SpringSourceEventPublisherTest.java
@@ -8,6 +8,8 @@ import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.*;
 
 class SpringSourceEventPublisherTest {
@@ -28,5 +30,18 @@ class SpringSourceEventPublisherTest {
         publisher.send(event);
 
         verify(applicationEventPublisher, times(1)).publishEvent(event);
+    }
+
+    @Test
+    void shouldPropagateApplicationEventPublisherFailures() {
+        CreatedSourceEvent event = new CreatedSourceEvent(UUID.randomUUID());
+        doThrow(new RuntimeException("Spring event bus unavailable"))
+                .when(applicationEventPublisher).publishEvent(event);
+
+        assertThatThrownBy(() -> publisher.send(event))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Spring event bus unavailable");
+
+        verify(applicationEventPublisher).publishEvent(event);
     }
 }

--- a/src/test/java/com/kairos/context_engine/use_case/GenerateSourceContextUseCaseTest.java
+++ b/src/test/java/com/kairos/context_engine/use_case/GenerateSourceContextUseCaseTest.java
@@ -35,6 +35,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -244,6 +245,32 @@ class GenerateSourceContextUseCaseTest {
             // Called twice: once for "first" chunk, once for "second" chunk (in embedChunks phase)
             verify(embeddingProvider, times(2)).embed(anyString());
         }
+
+        @Test
+        @DisplayName("stops before graph generation when a later chunk embedding fails")
+        void stopsBeforeGraphGenerationWhenChunkEmbeddingFails() {
+            Chunk first = chunk("first", 0);
+            Chunk second = chunk("second", 1);
+
+            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
+            when(chunkRepository.findAllNotProcessedBySourceId(sourceId))
+                    .thenReturn(List.of(first, second));
+            when(embeddingProvider.embed("first")).thenReturn(new float[]{0.1f});
+            when(embeddingProvider.embed("second"))
+                    .thenThrow(new RuntimeException("Second embedding failed"));
+
+            assertThatThrownBy(() -> useCase.execute(GenerateSourceContextCommand.of(sourceId)))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("Second embedding failed");
+
+            assertThat(first.getEmbedding()).containsExactly(0.1f);
+            assertThat(first.isProcessed()).isFalse();
+            assertThat(second.getEmbedding()).isNull();
+            assertThat(second.isProcessed()).isFalse();
+            verify(chunkRepository).save(first);
+            verify(chunkRepository, never()).save(second);
+            verifyNoInteractions(knowledgeGraphStore, tripleExtractor, tripleRepository);
+        }
     }
 
     // =========================================================================
@@ -384,6 +411,35 @@ class GenerateSourceContextUseCaseTest {
 
             assertThat(chunk.isProcessed()).isTrue();
         }
+
+        @Test
+        @DisplayName("marks chunk as processed only after triples and graph relationships are saved")
+        void marksChunkAsProcessedOnlyAfterTripleAndGraphPersistence() {
+            Chunk chunk = chunk("content", 0);
+            Triple triple = triple("spring", "USES", "jpa");
+
+            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
+            when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of(chunk));
+            when(embeddingProvider.embed("content")).thenReturn(new float[]{0.1f});
+            when(embeddingProvider.embed(chunk.getId() + ":spring-USES-jpa")).thenReturn(new float[]{0.2f});
+            when(tripleExtractor.extract("content")).thenReturn(List.of(triple));
+            doAnswer(invocation -> {
+                assertThat(chunk.isProcessed()).isFalse();
+                return null;
+            }).when(tripleRepository).saveAll(anyList());
+            doAnswer(invocation -> {
+                assertThat(chunk.isProcessed()).isFalse();
+                return null;
+            }).when(knowledgeGraphStore).saveAllForChunk(eq(chunk.getId()), eq(authorId), anyList());
+
+            useCase.execute(GenerateSourceContextCommand.of(sourceId));
+
+            assertThat(chunk.isProcessed()).isTrue();
+            var inOrder = inOrder(tripleRepository, knowledgeGraphStore, chunkRepository);
+            inOrder.verify(tripleRepository).saveAll(anyList());
+            inOrder.verify(knowledgeGraphStore).saveAllForChunk(eq(chunk.getId()), eq(authorId), anyList());
+            inOrder.verify(chunkRepository).save(chunk);
+        }
     }
 
     // =========================================================================
@@ -486,6 +542,39 @@ class GenerateSourceContextUseCaseTest {
             assertThatThrownBy(() -> useCase.execute(GenerateSourceContextCommand.of(sourceId)))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessage("Embedding service unavailable");
+        }
+
+        @Test
+        @DisplayName("propagates triple embedding exceptions without saving triples or marking chunks")
+        void propagatesTripleEmbeddingExceptionWithoutPersistingTriplesOrMarkingChunks() {
+            Chunk first = chunk("first", 0);
+            Chunk second = chunk("second", 1);
+            Triple triple = triple("A", "RELATES_TO", "B");
+
+            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
+            when(chunkRepository.findAllNotProcessedBySourceId(sourceId))
+                    .thenReturn(List.of(first, second));
+            when(embeddingProvider.embed("first")).thenReturn(new float[]{0.1f});
+            when(embeddingProvider.embed("second")).thenReturn(new float[]{0.2f});
+            when(tripleExtractor.extract("first")).thenReturn(List.of(triple));
+            when(embeddingProvider.embed(first.getId() + ":A-RELATES_TO-B"))
+                    .thenThrow(new RuntimeException("Triple embedding failed"));
+
+            assertThatThrownBy(() -> useCase.execute(GenerateSourceContextCommand.of(sourceId)))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("Triple embedding failed");
+
+            assertThat(first.isProcessed()).isFalse();
+            assertThat(second.isProcessed()).isFalse();
+            verify(knowledgeGraphStore).savePassages(passageCaptor.capture(), eq(authorId));
+            assertThat(passageCaptor.getValue())
+                    .extracting(Passage::chunkId)
+                    .containsExactly(first.getId(), second.getId());
+            verify(tripleRepository, never()).saveAll(anyList());
+            verify(knowledgeGraphStore, never()).saveAllForChunk(any(UUID.class), any(UUID.class), anyList());
+            verify(tripleExtractor, never()).extract("second");
+            verify(chunkRepository, times(1)).save(first);
+            verify(chunkRepository, times(1)).save(second);
         }
 
         @Test

--- a/src/test/java/com/kairos/context_engine/use_case/SearchSourceUseCaseTest.java
+++ b/src/test/java/com/kairos/context_engine/use_case/SearchSourceUseCaseTest.java
@@ -121,6 +121,58 @@ class SearchSourceUseCaseTest {
     }
 
     @Test
+    @DisplayName("discards passage candidates below the absolute seed threshold")
+    void discardsPassageCandidatesBelowAbsoluteThreshold() {
+        UUID strongId = UUID.randomUUID();
+        UUID belowAbsoluteThresholdId = UUID.randomUUID();
+
+        when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
+        when(semanticSearch.findPassageCandidate(QUERY_VECTOR, userId, 10)).thenReturn(List.of(
+                new PassageCandidate(strongId, 0.50),
+                new PassageCandidate(belowAbsoluteThresholdId, 0.44)
+        ));
+        when(semanticSearch.findTripleCandidates(QUERY_VECTOR, userId, 30)).thenReturn(List.of());
+        when(knowledgeGraphSearch.expandKnowledge(any(GraphSearchRequest.class))).thenReturn(GraphSearchResult.empty());
+
+        useCase.execute(new SearchSourceQuery(SEARCH_TERM));
+
+        ArgumentCaptor<GraphSearchRequest> requestCaptor = ArgumentCaptor.forClass(GraphSearchRequest.class);
+        verify(knowledgeGraphSearch).expandKnowledge(requestCaptor.capture());
+
+        assertThat(requestCaptor.getValue().seeds()).singleElement()
+                .satisfies(seed -> {
+                    assertThat(((PassageSeedTarget) seed.target()).chunkId()).isEqualTo(strongId);
+                    assertThat(seed.weight()).isEqualTo(0.50);
+                });
+    }
+
+    @Test
+    @DisplayName("discards passage candidates below the relative seed threshold")
+    void discardsPassageCandidatesBelowRelativeThreshold() {
+        UUID bestId = UUID.randomUUID();
+        UUID keptId = UUID.randomUUID();
+        UUID belowRelativeThresholdId = UUID.randomUUID();
+
+        when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
+        when(semanticSearch.findPassageCandidate(QUERY_VECTOR, userId, 10)).thenReturn(List.of(
+                new PassageCandidate(bestId, 0.90),
+                new PassageCandidate(keptId, 0.77),
+                new PassageCandidate(belowRelativeThresholdId, 0.764)
+        ));
+        when(semanticSearch.findTripleCandidates(QUERY_VECTOR, userId, 30)).thenReturn(List.of());
+        when(knowledgeGraphSearch.expandKnowledge(any(GraphSearchRequest.class))).thenReturn(GraphSearchResult.empty());
+
+        useCase.execute(new SearchSourceQuery(SEARCH_TERM));
+
+        ArgumentCaptor<GraphSearchRequest> requestCaptor = ArgumentCaptor.forClass(GraphSearchRequest.class);
+        verify(knowledgeGraphSearch).expandKnowledge(requestCaptor.capture());
+
+        assertThat(requestCaptor.getValue().seeds())
+                .extracting(seed -> ((PassageSeedTarget) seed.target()).chunkId())
+                .containsExactly(bestId, keptId);
+    }
+
+    @Test
     @DisplayName("uses recognition memory to transform triple candidates into concept seeds")
     void usesRecognitionMemoryToBuildConceptSeeds() {
         TripleCandidate tripleCandidate = new TripleCandidate(
@@ -189,6 +241,40 @@ class SearchSourceUseCaseTest {
     }
 
     @Test
+    @DisplayName("discards concept seeds below absolute and relative thresholds")
+    void discardsConceptSeedsBelowAbsoluteAndRelativeThresholds() {
+        TripleCandidate tripleCandidate = new TripleCandidate(
+                "spring-IMPLEMENTS-repository pattern",
+                "spring",
+                "IMPLEMENTS",
+                "repository pattern",
+                UUID.randomUUID(),
+                0.91
+        );
+
+        when(embeddingPort.embed("Spring")).thenReturn(QUERY_VECTOR);
+        when(semanticSearch.findPassageCandidate(QUERY_VECTOR, userId, 10)).thenReturn(List.of());
+        when(semanticSearch.findTripleCandidates(QUERY_VECTOR, userId, 30)).thenReturn(List.of(tripleCandidate));
+        when(recognitionMemory.recognize("Spring", List.of(tripleCandidate), 10))
+                .thenReturn(List.of(
+                        GraphSeed.concept("spring", 0.90),
+                        GraphSeed.concept("repository pattern", 0.77),
+                        GraphSeed.concept("jpa", 0.764),
+                        GraphSeed.concept("transaction", 0.44)
+                ));
+        when(knowledgeGraphSearch.expandKnowledge(any(GraphSearchRequest.class))).thenReturn(GraphSearchResult.empty());
+
+        useCase.execute(new SearchSourceQuery("Spring"));
+
+        ArgumentCaptor<GraphSearchRequest> requestCaptor = ArgumentCaptor.forClass(GraphSearchRequest.class);
+        verify(knowledgeGraphSearch).expandKnowledge(requestCaptor.capture());
+
+        assertThat(requestCaptor.getValue().seeds())
+                .extracting(seed -> ((ConceptSeedTarget) seed.target()).concept().name())
+                .containsExactly("spring", "repository pattern");
+    }
+
+    @Test
     @DisplayName("keeps passage seeds and appends concept seeds recognized from triples")
     void keepsPassageSeedsAndAppendsRecognizedConceptSeeds() {
         UUID passageId = UUID.randomUUID();
@@ -232,6 +318,54 @@ class SearchSourceUseCaseTest {
         assertThat(result).isEqualTo(SearchResult.empty());
         verifyNoInteractions(knowledgeGraphSearch);
         verifyNoInteractions(recognitionMemory);
+        verify(semanticSearch, never()).hydrateAndRankChunks(any(), any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("returns empty result when recognition memory returns no concept seeds")
+    void returnsEmptyWhenRecognitionMemoryReturnsNoConceptSeeds() {
+        TripleCandidate tripleCandidate = new TripleCandidate(
+                "mind-RELATES_TO-consciousness",
+                "mind",
+                "RELATES_TO",
+                "consciousness",
+                UUID.randomUUID(),
+                0.91
+        );
+
+        when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
+        when(semanticSearch.findPassageCandidate(QUERY_VECTOR, userId, 10)).thenReturn(List.of());
+        when(semanticSearch.findTripleCandidates(QUERY_VECTOR, userId, 30)).thenReturn(List.of(tripleCandidate));
+        when(recognitionMemory.recognize(SEARCH_TERM, List.of(tripleCandidate), 10)).thenReturn(List.of());
+
+        SearchResult result = useCase.execute(new SearchSourceQuery(SEARCH_TERM));
+
+        assertThat(result).isEqualTo(SearchResult.empty());
+        verifyNoInteractions(knowledgeGraphSearch);
+        verify(semanticSearch, never()).hydrateAndRankChunks(any(), any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("returns empty result when recognition memory returns null")
+    void returnsEmptyWhenRecognitionMemoryReturnsNull() {
+        TripleCandidate tripleCandidate = new TripleCandidate(
+                "mind-RELATES_TO-consciousness",
+                "mind",
+                "RELATES_TO",
+                "consciousness",
+                UUID.randomUUID(),
+                0.91
+        );
+
+        when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
+        when(semanticSearch.findPassageCandidate(QUERY_VECTOR, userId, 10)).thenReturn(List.of());
+        when(semanticSearch.findTripleCandidates(QUERY_VECTOR, userId, 30)).thenReturn(List.of(tripleCandidate));
+        when(recognitionMemory.recognize(SEARCH_TERM, List.of(tripleCandidate), 10)).thenReturn(null);
+
+        SearchResult result = useCase.execute(new SearchSourceQuery(SEARCH_TERM));
+
+        assertThat(result).isEqualTo(SearchResult.empty());
+        verifyNoInteractions(knowledgeGraphSearch);
         verify(semanticSearch, never()).hydrateAndRankChunks(any(), any(UUID.class));
     }
 
@@ -286,6 +420,46 @@ class SearchSourceUseCaseTest {
     }
 
     @Test
+    @DisplayName("skips hydration and activated triples when graph expansion has no scored passages")
+    void skipsHydrationWhenGraphExpansionHasNoScoredPassages() {
+        UUID seedId = UUID.randomUUID();
+        KnowledgeTriple activatedTriple = triple(seedId);
+
+        when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
+        when(semanticSearch.findPassageCandidate(QUERY_VECTOR, userId, 10))
+                .thenReturn(List.of(new PassageCandidate(seedId, 0.9)));
+        when(semanticSearch.findTripleCandidates(QUERY_VECTOR, userId, 30)).thenReturn(List.of());
+        when(knowledgeGraphSearch.expandKnowledge(any(GraphSearchRequest.class)))
+                .thenReturn(new GraphSearchResult(List.of(), List.of(activatedTriple)));
+
+        SearchResult result = useCase.execute(new SearchSourceQuery(SEARCH_TERM));
+
+        assertThat(result).isEqualTo(SearchResult.empty());
+        verify(semanticSearch, never()).hydrateAndRankChunks(any(), any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("returns no activated triples when hydration returns no ranked chunks")
+    void returnsNoActivatedTriplesWhenHydrationReturnsNoRankedChunks() {
+        UUID chunkId = UUID.randomUUID();
+        List<ScoredPassage> scoredPassages = List.of(new ScoredPassage(chunkId, 0.82));
+        KnowledgeTriple activatedTriple = triple(chunkId);
+
+        when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
+        when(semanticSearch.findPassageCandidate(QUERY_VECTOR, userId, 10))
+                .thenReturn(List.of(new PassageCandidate(chunkId, 0.9)));
+        when(semanticSearch.findTripleCandidates(QUERY_VECTOR, userId, 30)).thenReturn(List.of());
+        when(knowledgeGraphSearch.expandKnowledge(any(GraphSearchRequest.class)))
+                .thenReturn(new GraphSearchResult(scoredPassages, List.of(activatedTriple)));
+        when(semanticSearch.hydrateAndRankChunks(scoredPassages, userId)).thenReturn(List.of());
+
+        SearchResult result = useCase.execute(new SearchSourceQuery(SEARCH_TERM));
+
+        assertThat(result.chunks()).isEmpty();
+        assertThat(result.knowledgeTriples()).isEmpty();
+    }
+
+    @Test
     @DisplayName("filters activated triples to deduplicated ranked chunks")
     void filtersActivatedTriplesToRankedChunks() {
         UUID keptId = UUID.randomUUID();
@@ -318,6 +492,42 @@ class SearchSourceUseCaseTest {
 
         assertThat(result.chunks()).containsExactlyElementsOf(rankedChunks);
         assertThat(result.knowledgeTriples()).containsExactly(keptTriple);
+    }
+
+    @Test
+    @DisplayName("deduplicates activated triples by subject predicate and object while preserving the first")
+    void deduplicatesActivatedTriplesAndKeepsFirstOccurrence() {
+        UUID firstChunkId = UUID.randomUUID();
+        UUID secondChunkId = UUID.randomUUID();
+        List<ScoredPassage> scoredPassages = List.of(
+                new ScoredPassage(firstChunkId, 0.91),
+                new ScoredPassage(secondChunkId, 0.88)
+        );
+        KnowledgeTriple firstTriple = triple(firstChunkId);
+        KnowledgeTriple duplicateTriple = KnowledgeTriple.create(
+                firstTriple.subject().name(),
+                firstTriple.predicate(),
+                firstTriple.object().name(),
+                Passage.fromChunkId(secondChunkId),
+                0.5
+        );
+        List<RankedChunk> rankedChunks = List.of(
+                rankedChunk(firstChunkId, 1, 0.91),
+                rankedChunk(secondChunkId, 2, 0.88)
+        );
+
+        when(embeddingPort.embed(SEARCH_TERM)).thenReturn(QUERY_VECTOR);
+        when(semanticSearch.findPassageCandidate(QUERY_VECTOR, userId, 10))
+                .thenReturn(List.of(new PassageCandidate(firstChunkId, 0.9)));
+        when(semanticSearch.findTripleCandidates(QUERY_VECTOR, userId, 30)).thenReturn(List.of());
+        when(knowledgeGraphSearch.expandKnowledge(any(GraphSearchRequest.class)))
+                .thenReturn(new GraphSearchResult(scoredPassages, List.of(firstTriple, duplicateTriple)));
+        when(semanticSearch.hydrateAndRankChunks(scoredPassages, userId)).thenReturn(rankedChunks);
+
+        SearchResult result = useCase.execute(new SearchSourceQuery(SEARCH_TERM));
+
+        assertThat(result.chunks()).containsExactlyElementsOf(rankedChunks);
+        assertThat(result.knowledgeTriples()).containsExactly(firstTriple);
     }
 
     @Test

--- a/src/test/java/com/kairos/context_engine/use_case/UploadSourceUseCaseTest.java
+++ b/src/test/java/com/kairos/context_engine/use_case/UploadSourceUseCaseTest.java
@@ -23,8 +23,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -70,6 +72,41 @@ class UploadSourceUseCaseTest {
         assertThat(result).isEqualTo(existingId);
         verify(sourceRepository, never()).save(any(Source.class));
         verifyNoInteractions(chunkerExtractor, chunkRepository, eventPublisher);
+    }
+
+    @Test
+    @DisplayName("execute - creates source when duplicate lookup returns Optional.empty")
+    void execute_emptyDuplicateLookup_createsSourceAndPublishesEvent() {
+        UUID authorId = givenAuthenticatedUser();
+        var command = new UploadSourceCommand("Clean Code", "some content");
+        when(sourceRepository.findByAuthorIdAndTitleAndContent(authorId, "Clean Code", "some content"))
+                .thenReturn(Optional.empty());
+        when(chunkerExtractor.extract("some content", 200, 50)).thenReturn(List.of("some content"));
+
+        UUID result = useCase.execute(command);
+
+        assertThat(result).isNotNull();
+        verify(sourceRepository).findByAuthorIdAndTitleAndContent(authorId, "Clean Code", "some content");
+        verify(sourceRepository).save(any(Source.class));
+        verify(chunkRepository).save(any(Chunk.class));
+        verify(eventPublisher).send(any(CreatedSourceEvent.class));
+    }
+
+    @Test
+    @DisplayName("execute - treats null duplicate lookup result as absent source")
+    void execute_nullDuplicateLookup_createsSourceAndPublishesEvent() {
+        UUID authorId = givenAuthenticatedUser();
+        var command = new UploadSourceCommand("Clean Code", "some content");
+        when(sourceRepository.findByAuthorIdAndTitleAndContent(authorId, "Clean Code", "some content"))
+                .thenReturn(null);
+        when(chunkerExtractor.extract("some content", 200, 50)).thenReturn(List.of("some content"));
+
+        UUID result = useCase.execute(command);
+
+        assertThat(result).isNotNull();
+        verify(sourceRepository).save(any(Source.class));
+        verify(chunkRepository).save(any(Chunk.class));
+        verify(eventPublisher).send(any(CreatedSourceEvent.class));
     }
 
     @Test
@@ -163,6 +200,42 @@ class UploadSourceUseCaseTest {
                     assertThat(chunk.getEmbedding()).isNull();
                     assertThat(chunk.isProcessed()).isFalse();
                 });
+    }
+
+    @Test
+    @DisplayName("execute - propagates chunker failures without publishing event")
+    void execute_chunkerFailure_doesNotPersistChunksOrPublishEvent() {
+        givenAuthenticatedUser();
+        var command = new UploadSourceCommand("Clean Code", "some content");
+        when(chunkerExtractor.extract("some content", 200, 50))
+                .thenThrow(new RuntimeException("Chunker unavailable"));
+
+        assertThatThrownBy(() -> useCase.execute(command))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Chunker unavailable");
+
+        verify(sourceRepository).save(any(Source.class));
+        verifyNoInteractions(chunkRepository, eventPublisher);
+    }
+
+    @Test
+    @DisplayName("execute - propagates publisher failures after source and chunks are saved")
+    void execute_publisherFailure_happensAfterPersistence() {
+        givenAuthenticatedUser();
+        var command = new UploadSourceCommand("Clean Code", "alpha beta gamma");
+        when(chunkerExtractor.extract("alpha beta gamma", 200, 50))
+                .thenReturn(List.of("alpha beta", "beta gamma"));
+        doThrow(new RuntimeException("Event bus unavailable"))
+                .when(eventPublisher).send(any(CreatedSourceEvent.class));
+
+        assertThatThrownBy(() -> useCase.execute(command))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Event bus unavailable");
+
+        var inOrder = inOrder(sourceRepository, chunkRepository, eventPublisher);
+        inOrder.verify(sourceRepository).save(any(Source.class));
+        inOrder.verify(chunkRepository, times(2)).save(any(Chunk.class));
+        inOrder.verify(eventPublisher).send(any(CreatedSourceEvent.class));
     }
 
     private UUID givenAuthenticatedUser() {


### PR DESCRIPTION
## Summary

- expands unit coverage for the core knowledge engine ingestion and enrichment flows
- covers retrieval decision paths for thresholds, seeds, graph expansion, hydration, ordering, and activated triple filtering
- adds retrieval domain model validation tests to improve branch coverage
- strengthens source event publisher/listener tests for success and failure behavior

## Validation

- `mvn test`
- Result: 238 tests run, 0 failures, 0 errors, 1 skipped
- JaCoCo branch coverage increased from 66% to 74%