### PR TITLE
Rewrite README around retrieval decisions and measurable evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,431 +1,212 @@
 # Kairos
 
-<a href="https://openjdk.org/"><img src="https://img.shields.io/badge/Java-21-orange"></a>
-<a href="https://spring.io/projects/spring-boot"><img src="https://img.shields.io/badge/Spring%20Boot-4.0.5-green"></a>
-<a href="https://spring.io/projects/spring-ai"><img src="https://img.shields.io/badge/Spring%20AI-2.0.0--M6-green"></a>
-<a href="https://www.postgresql.org/"><img src="https://img.shields.io/badge/PostgreSQL-16-blue"></a>
-<a href="https://github.com/pgvector/pgvector"><img src="https://img.shields.io/badge/pgvector-HNSW-blue"></a>
-<a href="https://neo4j.com/"><img src="https://img.shields.io/badge/Neo4j-5.26-blue"></a>
-<a href="https://onnxruntime.ai/"><img src="https://img.shields.io/badge/ONNX%20Runtime-1.20.0-black"></a>
-<a href="https://www.docker.com/"><img src="https://img.shields.io/badge/Docker-Ready-blue"></a>
-<img src="https://img.shields.io/badge/tests-237%20passing-brightgreen">
-<img src="https://img.shields.io/badge/line%20coverage-86.77%25-brightgreen">
+> Standard RAG retrieves similar passages. Kairos retrieves passages together with the relationships that connect them.
 
-**Standard RAG retrieves similar passages. Kairos retrieves connected knowledge.**
+[![Java](https://img.shields.io/badge/Java-21-orange)](https://openjdk.org/)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.5-green)](https://spring.io/projects/spring-boot)
+[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-16-blue)](https://www.postgresql.org/)
+[![Neo4j](https://img.shields.io/badge/Neo4j-5.26-blue)](https://neo4j.com/)
+[![Tests](https://img.shields.io/badge/tests-244%20executed-brightgreen)](#verification)
+[![Coverage](https://img.shields.io/badge/branch%20coverage-74.54%25-brightgreen)](#verification)
 
-Kairos is a JVM-native personal knowledge graph engine for graph-augmented retrieval. It ingests source material, splits it into durable chunks, extracts factual subject-predicate-object triples, embeds both passages and triples, and uses PostgreSQL/pgvector plus Neo4j Graph Data Science to retrieve context by meaning and relationship structure.
+Kairos is a JVM-native graph-augmented retrieval backend for personal knowledge systems. It ingests source material, creates durable overlapping chunks, extracts subject-predicate-object triples, embeds passages and triples, and combines PostgreSQL/pgvector recall with user-scoped Neo4j Graph Data Science propagation.
 
-It is built as a retrieval backend for personal knowledge systems: the user feeds sources, and Kairos builds the semantic structure needed to recover related ideas later.
+The project is intentionally a retrieval engine rather than a chatbot or note editor. Its purpose is to expose useful context and relationship evidence before answer generation.
 
-## Contents
+## Evidence at a glance
 
-- [Why Kairos Exists](#why-kairos-exists)
-- [Architecture](#architecture)
-- [Ingestion Flow](#ingestion-flow)
-- [Retrieval Flow](#retrieval-flow)
-- [Quick Start](#quick-start)
-- [Known Limitations](#known-limitations)
-- [Roadmap](#roadmap)
-- [Research And Technical References](#research-and-technical-references)
+| Signal | Current evidence |
+|---|---:|
+| Latest local test execution | 244 tests |
+| Failures / errors | 0 / 0 |
+| Skipped tests | 7 |
+| JaCoCo line coverage | 86.77% |
+| JaCoCo branch coverage | 74.54% |
+| Embeddings | local ONNX, 384 dimensions |
+| Semantic store | PostgreSQL + pgvector |
+| Graph propagation | Neo4j GDS Personalized PageRank |
 
-## At A Glance
+Coverage measures implementation quality. It does not prove retrieval relevance.
 
-| Dimension | Kairos today |
-| --- | --- |
-| Project type | JVM-native graph-augmented retrieval backend |
-| Core idea | Automatic personal knowledge graph construction from ingested sources |
-| Retrieval model | HippoRAG 2-inspired passage recall + triple recall + recognition memory + Personalized PageRank |
-| Semantic store | PostgreSQL 16 with pgvector and HNSW indexes |
-| Graph store | Neo4j 5.26 with Graph Data Science |
-| Embeddings | Local ONNX Runtime inference with `all-MiniLM-L6-v2`, no Python sidecar |
-| LLM boundary | Gemini via Spring AI, limited to triple extraction and recognition-memory seed selection |
-| Quality snapshot | 237 tests passing, 7 skipped, 86,77% line coverage |
+## Problem, failed approach, decision
 
-## Why Kairos Exists
+### Problem
 
-Personal knowledge tools usually depend on manual structure: tags, folders, backlinks, graph links, aliases, and discipline. Kairos is built around a different product idea:
+Dense vector search is effective for semantic similarity, but it can miss context that depends on relationships distributed across passages and extracted facts.
 
-> Feed the system sources. Let the graph build itself.
+### First approach
 
-The goal is not to be a note editor or a chatbot. Kairos is a retrieval engine that turns raw content into an expanding conceptual graph, then uses that graph to surface context the user may not have explicitly connected.
+The first graph-seed implementation retrieved concepts independently by dense similarity. It was mechanically valid, but isolated concept matches lost the subject-predicate-object context in which those concepts appeared.
 
-## Why Not Just Vector Search
+There was no labeled retrieval benchmark, so the quality gap could not be quantified cleanly.
 
-Vector search is excellent at finding passages close to a query embedding. It is weaker when the answer depends on relationships spread across passages, concepts, or facts that do not share the same surface wording.
+### Decision
 
-| Standard vector RAG | Kairos |
-| --- | --- |
-| Retrieves chunks by embedding proximity | Retrieves passages, triples, and graph-expanded context |
-| Treats each chunk mostly independently | Connects chunks through extracted concepts and relationships |
-| Usually returns text that looks semantically similar | Can activate passages connected through graph structure |
-| LLM often carries most reasoning burden at answer time | Retrieval exposes relationship evidence before answer generation |
-| Embedding service is often external | Embeddings run locally in-process on the JVM |
+Keep graph expansion stable and change only how seeds are selected:
 
-## Current State
+1. retrieve passage candidates from pgvector;
+2. retrieve triple candidates from pgvector;
+3. allow Recognition Memory to select only subjects or objects already present in those triples;
+4. combine passage and concept seeds;
+5. run user-scoped Personalized PageRank;
+6. return ranked chunks and activated triples as evidence.
 
-Kairos is an operational V1 retrieval backend. The graph-augmented ingestion and search path is implemented, while product-facing graph views, source status APIs, retry workflows, and persisted retrieval traces are still roadmap work.
+### Result
 
-| Area | Current implementation |
-| --- | --- |
-| Ingestion | `POST /sources` accepts source content, resolves the authenticated author in the use case, stores the source, chunks content, persists chunks, and publishes `CreatedSourceEvent` for async enrichment |
-| Embeddings | In-process ONNX Runtime with `all-MiniLM-L6-v2`, producing `vector(384)` embeddings |
-| Triple extraction | Gemini through Spring AI `ChatClient` with native structured output |
-| Semantic storage | PostgreSQL 16 with pgvector for passage and triple vector search |
-| Graph storage | Neo4j 5.26 with `Passage`, `PhraseNode`, `CONTAINS`, and `TRIPLE` graph projection |
-| Retrieval | User-scoped dense passage recall + triple recall + recognition memory + Neo4j GDS Personalized PageRank |
-| Auth | Registration, email confirmation, login, JWT issuance, roles, request context, and protected source routes |
-| Local infrastructure | Docker Compose services for `postgres`, `neo4j`, and `kairos` |
+The current pipeline exposes both semantically relevant passages and the relationships activated during graph propagation. The architecture is covered by 244 executed tests, with 86.77% line coverage and 74.54% branch coverage.
+
+A relevance improvement is not claimed yet. The next research step is a labeled evaluation set comparing vector-only retrieval, isolated concept seeds, and triple-based Recognition Memory.
 
 ## Architecture
 
-Kairos follows a hexagonal architecture:
-
-| Layer | Responsibility |
-| --- | --- |
-| `domain` | Business models and ports with no framework dependency |
-| `application` | Use cases, commands, queries, and orchestration |
-| `infrastructure` | PostgreSQL, Neo4j, ONNX Runtime, Spring AI/Gemini, email, security, and event adapters |
-| `presentation` | Controllers, request DTOs, response DTOs, and mappers |
-
 ```mermaid
 flowchart TB
-    client["Client"]
+    Client[Client] --> API[Auth and Source APIs]
 
-    subgraph api["API"]
-        auth["AuthController"]
-        sources["SourceController"]
-    end
+    API --> Upload[UploadSourceUseCase]
+    Upload --> Chunker[Overlapping chunking]
+    Upload --> PG[(PostgreSQL + pgvector)]
+    Upload --> Event[CreatedSourceEvent]
 
-    subgraph app["Application"]
-        upload["UploadSourceUseCase"]
-        enrich["GenerateSourceContextUseCase"]
-        search["SearchSourceUseCase"]
-        event["CreatedSourceEvent"]
-    end
+    Event --> Enrich[Async enrichment]
+    Enrich --> ONNX[Local ONNX embeddings]
+    Enrich --> Gemini[Gemini triple extraction]
+    Enrich --> PG
+    Enrich --> Neo[(Neo4j)]
 
-    subgraph ai["AI and Semantic Adapters"]
-        chunker["ChunkerExtractorAdapter"]
-        embedder["OnnxEmbeddingProvider"]
-        extractor["GeminiTripleExtractorAdapter"]
-        recognition["GeminiRecognitionMemoryAdapter"]
-        semantic["SemanticSearchAdapter"]
-    end
-
-    subgraph graph["Graph Adapters"]
-        graphStore["KnowledgeGraphStoreAdapter"]
-        graphSearch["HippoRagKnowledgeGraphSearchAdapter"]
-        gds["Neo4j GDS PageRank"]
-    end
-
-    postgres[("PostgreSQL + pgvector")]
-    neo4j[("Neo4j")]
-
-    client --> auth
-    client --> sources
-    sources --> upload
-    upload --> chunker
-    upload --> postgres
-    upload --> event
-    event --> enrich
-    enrich --> embedder
-    enrich --> extractor
-    enrich --> postgres
-    enrich --> graphStore
-    graphStore --> neo4j
-    sources --> search
-    search --> embedder
-    search --> semantic
-    search --> recognition
-    semantic --> postgres
-    search --> graphSearch
-    graphSearch --> gds
-    gds --> neo4j
-    search --> postgres
+    API --> Search[SearchSourceUseCase]
+    Search --> ONNX
+    Search --> PassageRecall[Passage recall]
+    Search --> TripleRecall[Triple recall]
+    PassageRecall --> PG
+    TripleRecall --> PG
+    TripleRecall --> Recognition[Recognition Memory]
+    PassageRecall --> Seeds[User-scoped seeds]
+    Recognition --> Seeds
+    Seeds --> PPR[Neo4j GDS Personalized PageRank]
+    PPR --> Neo
+    PPR --> Hydrate[Hydrate chunks from PostgreSQL]
+    Hydrate --> Response[Ranked chunks + activated triples]
 ```
 
-The split is intentional:
+## Store responsibilities
 
-- PostgreSQL is the textual and semantic source of truth.
-- pgvector handles dense similarity over stored embeddings.
-- Neo4j stores the structural graph projection.
-- Neo4j GDS runs graph propagation.
-- Gemini is constrained to extraction and recognition decisions, behind domain ports.
-- The embedding model runs locally on the JVM, with no Python sidecar.
-- Authenticated request identity is exposed through `com.kairos.share.security.context`; source ownership is resolved in the application use case, not from client-submitted ids.
+| Component | Responsibility |
+|---|---|
+| PostgreSQL | durable source, chunk, triple, user, and authentication data |
+| pgvector | dense passage and triple retrieval |
+| Neo4j | structural graph projection of passages, concepts, and relationships |
+| Neo4j GDS | graph propagation from selected seeds |
+| ONNX Runtime | local JVM embedding inference |
+| Gemini via Spring AI | triple extraction and constrained recognition decisions |
 
-## Ingestion Flow
+Gemini is behind domain ports and is not used as the primary ranking engine.
 
-`POST /sources` starts the knowledge-building pipeline.
+## Ingestion flow
 
-1. Accept only source `title` and `content` from the request body.
-2. Resolve the authenticated author inside `UploadSourceUseCase` through `RequestContextProvider`.
-3. Return an existing source when the same authenticated author, title, and content were already ingested.
-4. Create and persist a `Source` with `author_id` in PostgreSQL.
-5. Split source content into overlapping chunks.
-6. Persist chunks immediately for durability.
-7. Publish `CreatedSourceEvent`.
-8. Enrich unprocessed chunks asynchronously.
-9. Embed each chunk with ONNX Runtime.
-10. Extract factual triples with Gemini through Spring AI.
-11. Embed each triple key for triple-level recall.
-12. Store extracted triples and embeddings in PostgreSQL.
-13. Merge user-scoped `Passage` nodes, `PhraseNode` concepts, `CONTAINS` edges, and `TRIPLE` edges into Neo4j.
-14. Mark processed chunks as complete.
+`POST /sources` starts a durable-then-asynchronous pipeline:
 
-```mermaid
-sequenceDiagram
-    participant C as Client
-    participant API as SourceController
-    participant U as UploadSourceUseCase
-    participant PG as PostgreSQL
-    participant E as CreatedSourceEvent
-    participant G as GenerateSourceContextUseCase
-    participant ORT as ONNX Runtime
-    participant LLM as Gemini via Spring AI
-    participant NEO as Neo4j
+1. Accept source title and content.
+2. Resolve the authenticated author from request context.
+3. Detect duplicate content for the same author.
+4. Persist the source and overlapping chunks in PostgreSQL.
+5. Publish `CreatedSourceEvent`.
+6. Embed chunks locally with ONNX Runtime.
+7. Extract factual triples through Spring AI/Gemini.
+8. Embed triple keys for triple-level recall.
+9. Persist embeddings and triples in PostgreSQL.
+10. Merge user-scoped passages, concepts, and relationships into Neo4j.
+11. Mark processed chunks as complete.
 
-    C->>API: POST /sources {title, content}
-    API->>U: UploadSourceCommand(title, content)
-    U->>U: resolve RequestContext.userId()
-    U->>PG: find source by author, title, and content
-    U->>PG: save source(author_id) and chunks
-    U->>E: publish source id
-    API-->>C: 201 Created
-    E->>G: async enrichment
-    G->>ORT: embed chunks
-    G->>LLM: extract triples
-    G->>ORT: embed triple keys
-    G->>PG: save embeddings and triples
-    G->>NEO: merge passages, concepts, and relationships
-```
+Durable chunks are stored before external enrichment. This separates source acceptance from later model and graph work.
 
-## Retrieval Flow
+## Retrieval flow
 
-`POST /sources/search` accepts a `termQuery` and returns ranked chunks plus activated triples.
+`POST /sources/search` accepts a query and returns ranked chunks plus relationship evidence.
 
-The current search path reflects the newer HippoRAG 2-style flow implemented in [PR #59](https://github.com/Luca5Eckert/Kairos/pull/59):
-
-1. Resolve the authenticated user from `RequestContextProvider`.
-2. Embed the user query with the same ONNX model used during ingestion.
-3. Retrieve passage candidates from pgvector using cosine similarity, filtered by `sources.author_id`.
-4. Retrieve triple candidates from pgvector using triple-key embeddings, filtered by `sources.author_id`.
-5. Ask the recognition-memory adapter to select relevant triple subjects or objects as concept seeds.
-6. Combine passage seeds and recognition-derived concept seeds.
-7. Filter seeds using absolute and relative score thresholds.
-8. Project only the authenticated user's Neo4j subgraph and run Personalized PageRank from the selected passage and concept seeds.
+1. Resolve the authenticated user.
+2. Generate the query embedding with the same local ONNX model used for ingestion.
+3. Retrieve user-scoped passage candidates from pgvector.
+4. Retrieve user-scoped triple candidates from pgvector.
+5. Ask Recognition Memory to select relevant subjects or objects from the retrieved triples.
+6. Apply absolute and relative seed thresholds.
+7. Project only the authenticated user's Neo4j subgraph.
+8. Run Personalized PageRank from passage and concept seeds.
 9. Rank passage nodes by graph score.
-10. Rehydrate final chunk text from PostgreSQL, filtered again by `sources.author_id`.
-11. Return ranked chunks and activated triples as explanatory evidence.
+10. Rehydrate chunk text from PostgreSQL under the same ownership constraint.
+11. Return chunks and activated triples.
 
 ```mermaid
 flowchart LR
-    query["User query"] --> embed["ONNX query embedding"]
-    embed --> passageSearch["pgvector passage candidates"]
-    embed --> tripleSearch["pgvector triple candidates"]
-    tripleSearch --> recog["RecognitionMemory selects concept seeds"]
-    passageSearch --> seeds["Graph seeds"]
-    recog --> seeds
-    seeds --> ppr["Neo4j GDS Personalized PageRank"]
-    ppr --> scored["Scored passages"]
-    ppr --> triples["Activated triples"]
-    scored --> hydrate["Hydrate chunks from PostgreSQL"]
-    hydrate --> response["ContextResponse"]
-    triples --> response
+    Query[User query] --> Embed[ONNX embedding]
+    Embed --> Passages[pgvector passage recall]
+    Embed --> Triples[pgvector triple recall]
+    Triples --> Recognition[Constrained Recognition Memory]
+    Passages --> Seeds[User-scoped seeds]
+    Recognition --> Seeds
+    Seeds --> PPR[Personalized PageRank]
+    PPR --> Chunks[Ranked passages]
+    PPR --> Evidence[Activated triples]
+    Chunks --> Response[Context response]
+    Evidence --> Response
 ```
 
-Retrieval defaults:
+## Security and ownership
 
-| Property | Default | Purpose |
-| --- | --- | --- |
-| `KAIROS_SEMANTIC_ANCHOR_LIMIT` | `10` | Passage candidates retrieved from pgvector |
-| `KAIROS_TRIPLE_CANDIDATE_LIMIT` | `30` | Triple candidates retrieved before recognition memory |
-| `KAIROS_RECOGNITION_SEED_LIMIT` | `10` | Maximum concept seeds accepted from recognition memory |
-| `KAIROS_GRAPH_PASSAGE_LIMIT` | `20` | Maximum graph-ranked passages returned |
-| `KAIROS_SEED_MIN_SCORE` | `0.45` | Minimum score required for a seed |
-| `KAIROS_SEED_RELATIVE_THRESHOLD` | `0.85` | Seed must be within this fraction of the best score |
-| `hipporag.ppr.max-iterations` | `20` | PageRank iteration cap |
-| `hipporag.ppr.damping-factor` | `0.85` | PageRank damping factor |
-| `hipporag.ppr.score-threshold` | `0.001` | Minimum activated node score |
+User isolation is treated as a first-class retrieval constraint:
 
-## Data Model
+- source ownership is resolved from authenticated request context, not client-submitted IDs;
+- passage and triple recall filter by source author;
+- Neo4j projections include only the authenticated user's graph;
+- final chunk hydration applies the ownership filter again;
+- JWT-protected routes cover source ingestion and retrieval.
 
-PostgreSQL stores durable application data:
+This boundary is applied across both stores rather than added only at the API layer.
 
-- `sources`: source title, content, and authenticated author id (`author_id`).
-- `chunks`: source chunks, chunk order, processed flag, and `vector(384)` embeddings.
-- `triples`: extracted subject-predicate-object facts, triple key, source chunk, and `vector(384)` embeddings.
-- user/auth tables: registration, email confirmation, roles, password hash, and session identity.
+## Architecture style
 
-Neo4j stores the retrieval graph projection:
+Kairos uses ports and adapters to isolate volatile infrastructure:
 
-- `Passage`: one node per chunk, keyed by `chunkId`, with `user_id` for retrieval ownership.
-- `PhraseNode`: concepts extracted from triples.
-- `CONTAINS`: passage-to-concept relationship with `user_id` and weight.
-- `TRIPLE`: concept-to-concept relationship with predicate, `chunk_id`, `user_id`, and weight.
+| Layer | Responsibility |
+|---|---|
+| `domain` | models and ports without framework dependencies |
+| `application` | ingestion, retrieval, authentication, and orchestration use cases |
+| `infrastructure` | PostgreSQL, Neo4j, ONNX, Gemini, email, and security adapters |
+| `presentation` | controllers and HTTP DTO mapping |
 
-The retrieval result is passage-first. `KnowledgeTriple` values are returned as evidence explaining what the graph activated; they are not the primary ranking unit.
+The design allows embedding, graph, semantic-search, and LLM implementations to change without moving their concerns into domain logic.
 
-## API
+## Verification
 
-OpenAPI/Swagger UI is not configured in the current build.
+Latest recorded local run:
 
-### Auth
+| Date | Command | Result |
+|---|---|---|
+| 2026-07-20 | `.\mvnw.cmd test` | 244 tests, 0 failures, 0 errors, 7 skipped |
 
-| Method | Path | Description |
-| --- | --- | --- |
-| `POST` | `/auth/register` | Creates a pending user and sends an email confirmation code |
-| `POST` | `/auth/confirm-email` | Confirms a pending user and returns a JWT |
-| `POST` | `/auth/login` | Authenticates by username/email and returns a JWT |
+Additional evidence:
 
-### Sources
+| Check | Result |
+|---|---|
+| JaCoCo line coverage | 86.77% |
+| JaCoCo branch coverage | 74.54% |
+| Surefire reports | 34 XML reports |
+| `git diff --check` | passing |
 
-All `/sources/**` endpoints require a valid JWT bearer token.
+The suite covers:
 
-| Method | Path | Body | Description |
-| --- | --- | --- | --- |
-| `POST` | `/sources` | `{ "title", "content" }` | Ingests a source for the authenticated user and starts async graph enrichment |
-| `POST` | `/sources/search` | `{ "termQuery" }` | Searches the authenticated user's knowledge base and returns graph-augmented context |
+- registration, email confirmation, login, JWT, and request context;
+- source upload, duplicate handling, event publication, and asynchronous enrichment;
+- chunking, ONNX inference, tokenization, pooling, normalization, and error paths;
+- passage recall, triple recall, recognition selection, seed thresholds, and empty results;
+- user-scoped Neo4j mutation, GDS projection, Personalized PageRank, and cleanup;
+- PostgreSQL mapping, score handling, chunk hydration, and ordering.
 
-`authorId` is intentionally not part of the upload contract. If a client sends it anyway, the field is ignored; `UploadSourceUseCase` uses the authenticated request context as the only source of author identity.
-
-Search is also scoped by the authenticated request context. Clients do not send a user id in `/sources/search`; `SearchSourceUseCase` resolves `RequestContext.userId()` and applies it to semantic candidate lookup, graph projection, graph expansion, and final chunk hydration.
-
-Search response shape:
-
-```json
-{
-  "knowledgeGraph": [
-    {
-      "subject": "retrieval augmented generation",
-      "predicate": "COMBINES",
-      "object": "retrieval and generation",
-      "chunkId": "00000000-0000-0000-0000-000000000000"
-    }
-  ],
-  "chunkContexts": [
-    {
-      "chunkId": "00000000-0000-0000-0000-000000000000",
-      "content": "...",
-      "rank": 1,
-      "score": 0.87,
-      "source": "GRAPH"
-    }
-  ]
-}
-```
-
-## Quick Start
-
-### Prerequisites
-
-- Docker and Docker Compose
-- Java 21 if running Maven locally
-- A Gemini API key
-- SMTP credentials for the Docker Compose app service
-
-### 1. Create the environment file
-
-PowerShell:
-
-```powershell
-Copy-Item .env.example .env
-```
-
-Bash:
+Run tests:
 
 ```bash
-cp .env.example .env
+./mvnw test
 ```
-
-### 2. Fill required values
-
-Docker Compose requires database, Neo4j, Gemini, auth, and mail settings. Full configuration reference for YAML keys, environment variables, retrieval tunables, and Spring AI options lives in [docs/configuration.md](docs/configuration.md).
-
-### 3. Start the stack
-
-```bash
-docker compose up --build
-```
-
-The app binds to `127.0.0.1:8080` by default. PostgreSQL and Neo4j are also bound to localhost only.
-The Docker profile creates a confirmed admin user for local testing unless `KAIROS_ADMIN_BOOTSTRAP_ENABLED=false`.
-
-### 4. Check health
-
-```bash
-curl http://localhost:8080/actuator/health
-```
-
-## Try It Locally
-
-The source API is protected. The Docker profile creates a local admin user by default:
-
-```bash
-curl -X POST http://localhost:8080/auth/login \
-  -H "Content-Type: application/json" \
-  -d '{ "identifier": "admin", "password": "Admin123!" }'
-```
-
-Use the returned access token as `TOKEN` before calling `/sources`. Override the default admin credentials through the `KAIROS_ADMIN_*` environment variables in `.env`.
-
-### Ingest a source
-
-```bash
-curl -X POST http://localhost:8080/sources \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
-  -d '{
-    "title": "RAG and knowledge graphs",
-    "content": "Retrieval augmented generation combines a retriever with a language model. The retriever finds relevant passages before the model generates an answer. Knowledge graphs improve retrieval by representing entities and relationships explicitly. Personalized PageRank can start from relevant passages and propagate importance through connected concepts."
-  }'
-```
-
-`POST /sources` returns `201 Created`. Enrichment is asynchronous, so wait a few seconds before querying.
-
-### Query the knowledge base
-
-```bash
-curl -X POST http://localhost:8080/sources/search \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
-  -d '{ "termQuery": "How can a knowledge graph improve retrieval augmented generation?" }'
-```
-
-Example response:
-
-```json
-{
-  "knowledgeGraph": [
-    {
-      "subject": "Personalized PageRank",
-      "predicate": "PROPAGATES_IMPORTANCE_THROUGH",
-      "object": "connected concepts",
-      "chunkId": "00000000-0000-0000-0000-000000000000"
-    }
-  ],
-  "chunkContexts": [
-    {
-      "chunkId": "00000000-0000-0000-0000-000000000000",
-      "content": "Personalized PageRank can start from relevant passages and propagate importance through connected concepts.",
-      "rank": 1,
-      "score": 0.91,
-      "source": "GRAPH"
-    }
-  ]
-}
-```
-
-Other useful queries:
-
-```json
-{ "termQuery": "What connects embeddings with semantic search?" }
-{ "termQuery": "Why is Personalized PageRank useful for retrieval?" }
-{ "termQuery": "How does graph retrieval find related concepts across passages?" }
-```
-
-## Quality And Verification
-
-Run the test suite:
 
 Windows:
 
@@ -433,123 +214,83 @@ Windows:
 .\mvnw.cmd test
 ```
 
-Unix-like shells:
+## Running locally
+
+### Requirements
+
+- Docker and Docker Compose
+- Java 21 for direct Maven execution
+- Gemini API key
+- SMTP configuration for account confirmation
+
+Create the environment file:
 
 ```bash
-./mvnw test
+cp .env.example .env
 ```
 
-Latest verified local run:
+Start the stack:
 
-| Date | Command | Result | Maven time |
-| --- | --- | --- | --- |
-| 2026-07-20 16:22 BRT | `.\mvnw.cmd test` | 244 tests, 0 failures, 0 errors, 7 skipped | 25.823 s |
+```bash
+docker compose up --build
+```
 
-Additional verification:
+Check health:
 
-| Check | Result |
-| --- | --- |
-| `git diff --check` | Passes |
-| Surefire report files | 34 XML reports generated under `target/surefire-reports` |
-| JaCoCo report | Generated under `target/site/jacoco` |
-| JaCoCo line coverage | 86.77% |
-| JaCoCo branch coverage | 74.54% |
+```bash
+curl http://localhost:8080/actuator/health
+```
 
-Static inventory from the current workspace:
+The local stack contains PostgreSQL, Neo4j, and the Kairos application.
 
-| Metric | Count |
-| --- | ---: |
-| Main Java files | 135 |
-| Test Java files | 33 |
-| REST controllers | 2 |
-| Public API endpoints documented | 5 |
-| Application use cases | 6 |
-| Domain ports | 17 |
-| Infrastructure adapters | 15 |
-| Repository interfaces/adapters | 14 |
-| Persistence/graph entity classes | 7 |
-| Configuration/properties classes | 4 |
+## Example flow
 
-Test coverage by behavior includes:
+1. Authenticate and obtain a JWT.
+2. Submit a source to `POST /sources`.
+3. Wait for asynchronous enrichment.
+4. Query `POST /sources/search`.
+5. Inspect ranked chunks and activated triples in the response.
 
-- Auth flows: registration, email confirmation, login, password encoding, JWT issuance, Spring Security configuration, and SMTP adapter behavior.
-- Ingestion flows: source upload, event publishing, async source-event listener, chunking, chunk embedding, triple extraction, and graph persistence orchestration.
-- Retrieval flows: authenticated user scoping, query embedding orchestration, passage candidate retrieval, triple candidate retrieval, recognition-memory seed selection, seed thresholding, graph expansion, ranked chunk hydration, and empty-result behavior.
-- Graph adapters: user-scoped Neo4j mutation execution, GDS projection, Personalized PageRank query parameter mapping, activated triple mapping, projection cleanup, and missing-GDS fallback paths.
-- Embedding pipeline: ONNX session behavior, tokenizer handling, `token_type_ids` fallback, truncation, mean pooling, normalization, inference failures, and input validation.
-- Source API contract: upload route without client-provided `authorId`, ignored extra author fields, `POST /sources/search`, and removal of `GET /sources` with request body.
-- Relational adapters: source author persistence, chunk hydration, semantic candidate mapping, triple candidate filtering, missing/null vector-score handling, and repository ordering.
+Detailed configuration is documented in [`docs/configuration.md`](docs/configuration.md).
 
-## Troubleshooting
+## Design decisions
 
-| Symptom | Likely cause | What to check |
-| --- | --- | --- |
-| `docker compose config` or `docker compose up` fails with a missing variable | Compose marks some values as required | Fill `POSTGRES_PASSWORD`, `NEO4J_PASSWORD`, `MAIL_HOST`, `MAIL_USERNAME`, `MAIL_PASSWORD`, and `MAIL_FROM` in `.env` |
-| `POST /sources` or `POST /sources/search` returns `401` | Source routes require authentication | Login or confirm email first, then send `Authorization: Bearer $TOKEN` |
-| `POST /sources` fails with a `sources.status` or `sources.author_id` schema error | Existing Postgres volume was initialized with an older schema | For local dev, recreate volumes with `docker compose down -v`; for preserved data, migrate manually by dropping obsolete `status`, adding/backfilling `author_id`, and setting it `NOT NULL` |
-| Source upload returns `201`, but search returns little or nothing | Enrichment runs asynchronously | Wait a few seconds after `POST /sources` before querying |
-| Graph results are empty | Neo4j GDS may be unavailable, the graph has not been enriched yet, or the local Neo4j volume was populated before user-scoped graph properties existed | Check Neo4j plugin loading and the warning `Neo4j Graph Data Science procedures are unavailable. Returning empty graph expansion.`; for old local data, reprocess sources or recreate volumes with `docker compose down -v` |
-| Gemini extraction or recognition fails | Missing or invalid Gemini key/model configuration | Check `GEMINI_API_KEY`, `KAIROS_LLM_MODEL`, and Spring AI Google GenAI settings |
-| Logs mention `token_type_ids: not declared` | The ONNX model does not require that input | This is expected for the current model path and is covered by tests |
+| Decision | Trade-off |
+|---|---|
+| PostgreSQL as textual source of truth | Keeps durable text and vectors together, while requiring Neo4j projection maintenance |
+| Neo4j as derived structural graph | Enables graph algorithms without making it the durable source for source text |
+| Local ONNX embeddings | Removes a Python sidecar and external embedding call, but adds model memory to the JVM process |
+| LLM only for extraction and recognition | Limits model authority and keeps ranking deterministic around stored evidence, while retaining model cost and variability |
+| Durable chunks before enrichment | Protects accepted source content from external model failures, while requiring retry and reprocessing workflows |
+| User-scoped graph projection | Enforces isolation during propagation, at the cost of per-query projection work |
+| Activated triples in the response | Improves inspectability, while not constituting a formal explanation guarantee |
 
-## Known Limitations
+## Known limitations
 
-- Source enrichment is asynchronous. Querying immediately after ingestion can return empty or incomplete graph context.
-- Neo4j graph data created before user-scoped `user_id` properties on `Passage`, `CONTAINS`, and `TRIPLE` is excluded from new retrievals. Reprocess sources or recreate local volumes to rebuild the graph.
-- Failed chunk reprocessing is not implemented yet. See [issue #52](https://github.com/Luca5Eckert/Kairos/issues/52).
-- If Neo4j GDS procedures are unavailable, graph expansion returns empty results instead of a dense fallback.
-- OpenAPI/Swagger UI is not configured.
+- No labeled retrieval benchmark currently proves higher Recall@K, MRR, NDCG, or answer quality.
+- Failed chunk reprocessing is not fully implemented.
+- If Neo4j GDS is unavailable, graph expansion returns no graph result rather than a dense fallback.
+- Enrichment is asynchronous; immediate queries may see incomplete context.
+- Persisted retrieval traces and user-facing graph views remain roadmap work.
+- OpenAPI/Swagger UI is not configured in the current build.
 
-## Roadmap
+## Evaluation roadmap
 
-Recently completed:
+The next evidence milestone is a reproducible retrieval benchmark:
 
-- Authenticated source ingestion now resolves author identity in `UploadSourceUseCase` and persists `sources.author_id`; client-submitted `authorId` is ignored.
-- Authenticated retrieval now scopes semantic candidates, chunk hydration, Neo4j graph projection, and PageRank expansion to `RequestContext.userId()`.
-- [#41](https://github.com/Luca5Eckert/Kairos/issues/41): implemented passage-aware weighted Personalized PageRank with per-seed bias and relationship weights.
-- [#40](https://github.com/Luca5Eckert/Kairos/issues/40): triple recall and recognition memory filtering.
-- [PR #59](https://github.com/Luca5Eckert/Kairos/pull/59): replaced direct concept-candidate retrieval with triple-based recognition-memory seed selection.
-- [PR #51](https://github.com/Luca5Eckert/Kairos/pull/51): finalized the passage-first graph retrieval response with ranked chunks and activated triples.
-- [PR #55](https://github.com/Luca5Eckert/Kairos/pull/55): migrated Gemini extraction to Spring AI `ChatClient` and native structured output.
+1. build a labeled set of queries and relevant passages;
+2. compare vector-only, isolated-concept, and triple-recognition variants;
+3. report Recall@K, MRR or NDCG;
+4. record p50/p95 latency;
+5. measure model calls and cost;
+6. publish failure cases, not only aggregate scores.
 
-Active or planned:
+## Relevant design documents
 
-| Issue | Description | Expected impact |
-| --- | --- | --- |
-| [#50](https://github.com/Luca5Eckert/Kairos/issues/50) | Continue the HippoRAG 2 retrieval refactor | Aligns retrieval more closely with the reference paper and adds stronger fallback behavior |
-| [#52](https://github.com/Luca5Eckert/Kairos/issues/52) | Reprocess failed chunks without re-uploading the full source | Improves ingestion resilience and recovery |
-| [#31](https://github.com/Luca5Eckert/Kairos/issues/31) | Expand the user module beyond auth | Prepares the system for user-scoped knowledge operations |
-| [#25](https://github.com/Luca5Eckert/Kairos/issues/25) | Persist question/answer history and retrieval traces | Creates the audit trail needed for explainability and future ranking-quality analysis |
+- [PR #59 - triple-based recognition-memory seeds](https://github.com/Luca5Eckert/Kairos/pull/59)
+- [`ADR-003 - Retrieval Framework`](docs/adr/ADR-003-retrieval-framework.md)
+- Additional planning and ADR material is maintained with the project documentation and engineering notes.
 
-## Technology Stack
+## Author
 
-| Concern | Implementation |
-| --- | --- |
-| Runtime | Java 21 |
-| Framework | Spring Boot 4.0.5 |
-| LLM integration | Spring AI 2.0.0-M6 + Google GenAI |
-| LLM model | Gemini, `gemini-2.5-flash` by default |
-| Embeddings | ONNX Runtime + `all-MiniLM-L6-v2` |
-| Tokenization | DJL Hugging Face tokenizers |
-| Vector search | PostgreSQL 16 + pgvector |
-| Graph search | Neo4j 5.26 + Graph Data Science |
-| Security | Spring Security + JWT |
-| Email | Spring Mail / JavaMailSender |
-| Infrastructure | Docker Compose |
-
-## Research And Technical References
-
-These references informed the design and README positioning:
-
-- [GitHub Docs: repository READMEs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes)
-- [HippoRAG 2: From RAG to Memory](https://arxiv.org/abs/2502.14802)
-- [pgvector documentation](https://access.crunchydata.com/documentation/pgvector/latest/)
-- [Neo4j Graph Data Science PageRank](https://neo4j.com/docs/graph-data-science/current/algorithms/page-rank/)
-- [Spring AI structured output](https://docs.spring.io/spring-ai/reference/api/structured-output-converter.html)
-- [Spring AI Google GenAI Chat](https://docs.spring.io/spring-ai/reference/api/chat/google-genai-chat.html)
-- [ONNX Runtime for Java](https://onnxruntime.ai/docs/get-started/with-java.html)
-- [sentence-transformers/all-MiniLM-L6-v2 model card](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2)
-
----
-
-Built by [Lucas Eckert](https://luca5eckert.github.io)
+Built by [Lucas Eckert](https://lucas-eckert.vercel.app).

--- a/docs/adr/ADR-003-retrieval-framework.md
+++ b/docs/adr/ADR-003-retrieval-framework.md
@@ -1,0 +1,131 @@
+# ADR-003 - Graph-Augmented Retrieval Framework
+
+- Status: Accepted
+- Scope: Kairos V1 retrieval
+- Decision owner: Lucas Eckert
+- Last reviewed: 2026-07-26
+
+## Context
+
+Kairos needs to retrieve useful context from personal source material when the relevant information is not contained in a single semantically similar passage.
+
+Dense vector search is a strong baseline for lexical and semantic similarity, but it treats passages mostly independently. Some questions depend on relationships distributed across extracted facts, concepts, and passages.
+
+The first graph-seed implementation retrieved concepts directly by dense similarity. That approach produced valid candidates, but isolated concept matches lost the subject-predicate-object context in which the concepts appeared.
+
+## Decision
+
+Use a multi-stage retrieval pipeline inspired by HippoRAG 2:
+
+1. generate the query embedding locally with ONNX Runtime;
+2. retrieve user-scoped passage candidates from PostgreSQL/pgvector;
+3. retrieve user-scoped triple candidates from PostgreSQL/pgvector;
+4. constrain Recognition Memory to selecting subjects or objects already present in the retrieved triples;
+5. combine passage and concept seeds;
+6. apply absolute and relative score thresholds;
+7. project only the authenticated user's Neo4j subgraph;
+8. run Personalized PageRank through Neo4j Graph Data Science;
+9. rank passage nodes by graph score;
+10. rehydrate final chunks from PostgreSQL under the same ownership boundary;
+11. return activated triples beside ranked chunks as relationship evidence.
+
+Graph expansion remains separate from seed selection. The redesign changes which anchors enter the graph rather than rewriting the propagation algorithm.
+
+## Store responsibilities
+
+- PostgreSQL is the durable source of truth for source text, chunks, triples, users, and authentication data.
+- pgvector performs passage and triple dense retrieval.
+- Neo4j stores a derived structural graph of passages, concepts, and relationships.
+- Neo4j GDS performs Personalized PageRank.
+- ONNX Runtime produces local JVM embeddings.
+- Gemini, behind Spring AI ports, performs triple extraction and constrained recognition decisions.
+
+## Alternatives considered
+
+### Vector-only retrieval
+
+Advantages:
+
+- simpler architecture;
+- deterministic serving path;
+- no graph projection or propagation cost.
+
+Rejected as the only retrieval mode because it cannot explicitly traverse relationships between passages and extracted facts.
+
+### Direct concept-candidate retrieval
+
+Advantages:
+
+- simpler than triple retrieval;
+- concepts can be embedded and selected directly.
+
+Replaced because isolated concept candidates lose the relational context provided by complete triples.
+
+### LLM-generated graph seeds without candidate constraints
+
+Advantages:
+
+- flexible interpretation of the query;
+- potentially broad conceptual recall.
+
+Rejected because the model could invent or normalize concepts that do not exist in the stored graph. Recognition Memory is therefore constrained to values present in retrieved triples.
+
+### Neo4j as the only source of truth
+
+Advantages:
+
+- one store for graph traversal and source relationships.
+
+Rejected because PostgreSQL is better suited to durable source text, authentication data, relational constraints, and vector search in the current system. Neo4j remains a derived graph projection.
+
+## Consequences
+
+### Positive
+
+- Retrieval can combine semantic similarity and relationship structure.
+- User isolation is applied during dense recall, graph projection, propagation, and hydration.
+- LLM authority is limited to extraction and candidate selection rather than final ranking.
+- Activated triples make the graph contribution inspectable.
+- Each infrastructure concern remains behind a domain port.
+
+### Negative
+
+- The query path spans PostgreSQL, pgvector, an LLM recognition step, and Neo4j GDS.
+- Per-user graph projection adds latency and operational complexity.
+- Asynchronous enrichment means newly uploaded sources may not be immediately searchable through the graph.
+- A missing GDS installation currently results in an empty graph expansion rather than a dense-only fallback.
+- Triple extraction quality affects downstream graph quality.
+
+## Verification
+
+The current implementation is protected by tests covering:
+
+- passage and triple candidate retrieval;
+- recognition-memory selection;
+- seed thresholding;
+- user-scoped graph projection;
+- Personalized PageRank parameter mapping;
+- activated-triple mapping;
+- PostgreSQL chunk hydration;
+- missing-GDS and empty-result behavior.
+
+Latest local verification executed 244 tests with 0 failures and 0 errors. JaCoCo reports 86.77% line coverage and 74.54% branch coverage.
+
+These metrics validate implementation behavior, not retrieval relevance.
+
+## Evaluation gap
+
+No labeled retrieval dataset currently proves that this decision improves Recall@K, MRR, NDCG, or answer quality over vector-only retrieval or direct concept candidates.
+
+The next evidence milestone is a reproducible evaluation comparing:
+
+1. vector-only passage retrieval;
+2. passage plus direct concept seeds;
+3. passage plus triple recall and Recognition Memory.
+
+The evaluation should publish relevance metrics, p50/p95 latency, model calls, cost, and representative failure cases.
+
+## Related implementation
+
+- [PR #59 - replace direct concept candidates with triple-based recognition seeds](https://github.com/Luca5Eckert/Kairos/pull/59)
+- [Kairos README](../../README.md)


### PR DESCRIPTION
## What changed

- Reframed the README around the retrieval problem, the first approach that did not preserve relationship context, and the current triple-based Recognition Memory design.
- Updated verification to the latest documented local run: **244 tests, 0 failures, 0 errors**, with **86.77% line coverage** and **74.54% branch coverage**.
- Separated implementation-quality evidence from retrieval-quality claims; the README no longer implies relevance gains without a labeled evaluation set.
- Documented ingestion, retrieval, user isolation, store responsibilities, trade-offs, limitations, and an evaluation roadmap.
- Added a sanitized public ADR for the graph-augmented retrieval framework, including rejected alternatives and consequences.

## Why

The project has strong implementation evidence, but the previous narrative did not clearly separate test coverage from retrieval relevance. This version makes the design reasoning defensible and states the evaluation gap explicitly.

## Scope

Documentation only. No runtime behavior was changed.

This PR remains draft for technical accuracy review.