### PR TITLE
#52 feat: implement get all source progress endpoint

### DIFF
--- a/src/main/java/com/kairos/module/context_engine/application/use_case/GenerateSourceContextUseCase.java
+++ b/src/main/java/com/kairos/module/context_engine/application/use_case/GenerateSourceContextUseCase.java
@@ -25,9 +25,10 @@ import java.util.UUID;
 public class GenerateSourceContextUseCase {
 
     private final TripleExtractor tripleExtractor;
+    private final KnowledgeGraphStore knowledgeGraphStore;
+
     private final EmbeddingProvider embeddingProvider;
 
-    private final KnowledgeGraphStore knowledgeGraphStore;
     private final ChunkRepository chunkRepository;
     private final SourceRepository sourceRepository;
     private final TripleRepository tripleRepository;

--- a/src/main/java/com/kairos/module/context_engine/application/use_case/GetAllSourceProgressUploadUseCase.java
+++ b/src/main/java/com/kairos/module/context_engine/application/use_case/GetAllSourceProgressUploadUseCase.java
@@ -1,0 +1,29 @@
+package com.kairos.module.context_engine.application.use_case;
+
+import com.kairos.module.context_engine.domain.model.progress.SourceProgressUpload;
+import com.kairos.module.context_engine.domain.port.repository.ChunkRepository;
+import com.kairos.module.context_engine.domain.port.repository.SourceRepository;
+import com.kairos.share.security.context.RequestContextProvider;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class GetAllSourceProgressUploadUseCase {
+
+    private final SourceRepository sourceRepository;
+
+    private final RequestContextProvider contextProvider;
+
+    public GetAllSourceProgressUploadUseCase(SourceRepository sourceRepository, RequestContextProvider contextProvider) {
+        this.sourceRepository = sourceRepository;
+        this.contextProvider = contextProvider;
+    }
+
+    public List<SourceProgressUpload> execute() {
+        var request = contextProvider.getRequestContext();
+
+        return sourceRepository.findAllSourcesProgressByAuthorId(request.userId());
+    }
+
+}

--- a/src/main/java/com/kairos/module/context_engine/application/use_case/GetAllSourceProgressUploadUseCase.java
+++ b/src/main/java/com/kairos/module/context_engine/application/use_case/GetAllSourceProgressUploadUseCase.java
@@ -1,7 +1,6 @@
 package com.kairos.module.context_engine.application.use_case;
 
 import com.kairos.module.context_engine.domain.model.progress.SourceProgressUpload;
-import com.kairos.module.context_engine.domain.port.repository.ChunkRepository;
 import com.kairos.module.context_engine.domain.port.repository.SourceRepository;
 import com.kairos.share.security.context.RequestContextProvider;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/kairos/module/context_engine/domain/model/progress/SourceProgressUpload.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/model/progress/SourceProgressUpload.java
@@ -1,0 +1,10 @@
+package com.kairos.module.context_engine.domain.model.progress;
+
+import com.kairos.module.context_engine.domain.model.content.Source;
+
+public record SourceProgressUpload(
+        Source source,
+        int totalChunks,
+        int processedChunks
+) {
+}

--- a/src/main/java/com/kairos/module/context_engine/domain/port/repository/SourceRepository.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/port/repository/SourceRepository.java
@@ -1,6 +1,7 @@
 package com.kairos.module.context_engine.domain.port.repository;
 
 import com.kairos.module.context_engine.domain.model.content.Source;
+import com.kairos.module.context_engine.domain.model.progress.SourceProgressUpload;
 
 import java.util.List;
 import java.util.Optional;
@@ -30,4 +31,10 @@ public interface SourceRepository {
      */
     List<Source> findAll(int k);
 
+    /**
+     * Retrieve a list of source progress for a specific author.
+     * @param authorId The unique identifier of the author.
+     * @return A list of source progress for the specified author.
+     */
+    List<SourceProgressUpload> findAllSourcesProgressByAuthorId(UUID authorId);
 }

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/projection/SourceProgressProjection.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/projection/SourceProgressProjection.java
@@ -1,0 +1,11 @@
+package com.kairos.module.context_engine.infrastructure.relational.projection;
+
+public interface SourceProgressProjection {
+
+    String getTitle();
+    String getContent();
+    int getTotalChunks();
+    int getProcessedChunks();
+
+
+}

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/source/JpaSourceRepository.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/source/JpaSourceRepository.java
@@ -1,8 +1,10 @@
 package com.kairos.module.context_engine.infrastructure.relational.repository.source;
 
 import com.kairos.module.context_engine.infrastructure.relational.entity.SourceEntity;
+import com.kairos.module.context_engine.infrastructure.relational.projection.SourceProgressProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -10,4 +12,5 @@ public interface JpaSourceRepository extends JpaRepository<SourceEntity, UUID> {
 
     Optional<SourceEntity> findFirstByAuthorIdAndTitleAndContent(UUID authorId, String title, String content);
 
+    List<SourceProgressProjection> findAllSourcesProgressByAuthorId(UUID authorId);
 }

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/source/SpringSourceRepositoryAdapter.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/source/SpringSourceRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package com.kairos.module.context_engine.infrastructure.relational.repository.source;
 
 import com.kairos.module.context_engine.domain.model.content.Source;
+import com.kairos.module.context_engine.domain.model.progress.SourceProgressUpload;
 import com.kairos.module.context_engine.domain.port.repository.SourceRepository;
 import com.kairos.module.context_engine.infrastructure.relational.entity.SourceEntity;
 import org.springframework.data.domain.PageRequest;
@@ -48,4 +49,16 @@ public class SpringSourceRepositoryAdapter implements SourceRepository {
                 .toList();
     }
 
+    @Override
+    public List<SourceProgressUpload> findAllSourcesProgressByAuthorId(UUID authorId) {
+        var sourceProgressEntities = jpaSourceRepository.findAllSourcesProgressByAuthorId(authorId);
+
+        return sourceProgressEntities.stream()
+                .map(projection -> new SourceProgressUpload(
+                        new Source(projection.getTitle(), projection.getContent()),
+                        projection.getTotalChunks(),
+                        projection.getProcessedChunks()
+                ))
+                .toList();
+    }
 }

--- a/src/main/java/com/kairos/module/context_engine/presentation/controller/SourceController.java
+++ b/src/main/java/com/kairos/module/context_engine/presentation/controller/SourceController.java
@@ -2,11 +2,13 @@ package com.kairos.module.context_engine.presentation.controller;
 
 import com.kairos.module.context_engine.application.command.UploadSourceCommand;
 import com.kairos.module.context_engine.application.query.SearchSourceQuery;
+import com.kairos.module.context_engine.application.use_case.GetAllSourceProgressUploadUseCase;
 import com.kairos.module.context_engine.application.use_case.SearchSourceUseCase;
 import com.kairos.module.context_engine.application.use_case.UploadSourceUseCase;
 import com.kairos.module.context_engine.presentation.dto.request.GenerateSourceContextRequest;
 import com.kairos.module.context_engine.presentation.dto.request.UploadSourceRequest;
 import com.kairos.module.context_engine.presentation.dto.response.ContextResponse;
+import com.kairos.module.context_engine.presentation.dto.response.ProgressUploadResponse;
 import com.kairos.module.context_engine.presentation.mapper.SourceMapper;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -19,12 +21,14 @@ public class SourceController {
 
     private final UploadSourceUseCase uploadSourceUseCase;
     private final SearchSourceUseCase searchSourceUseCase;
+    private final GetAllSourceProgressUploadUseCase getAllSourceProgressUploadUseCase;
 
     private final SourceMapper mapper;
 
-    public SourceController(UploadSourceUseCase uploadSourceUseCase, SearchSourceUseCase searchSourceUseCase, SourceMapper mapper) {
+    public SourceController(UploadSourceUseCase uploadSourceUseCase, SearchSourceUseCase searchSourceUseCase, GetAllSourceProgressUploadUseCase getAllSourceProgressUploadUseCase, SourceMapper mapper) {
         this.uploadSourceUseCase = uploadSourceUseCase;
         this.searchSourceUseCase = searchSourceUseCase;
+        this.getAllSourceProgressUploadUseCase = getAllSourceProgressUploadUseCase;
         this.mapper = mapper;
     }
 
@@ -53,5 +57,11 @@ public class SourceController {
         return ResponseEntity.ok(mapper.toContextResponse(result));
     }
 
+    @GetMapping("/progress")
+    public ResponseEntity<ProgressUploadResponse> getAllSourceProgressUpload() {
+        var result = getAllSourceProgressUploadUseCase.execute();
+
+        return ResponseEntity.ok(mapper.toProgressUploadResponse(result));
+    }
 
 }

--- a/src/main/java/com/kairos/module/context_engine/presentation/dto/response/ProgressUploadResponse.java
+++ b/src/main/java/com/kairos/module/context_engine/presentation/dto/response/ProgressUploadResponse.java
@@ -1,0 +1,36 @@
+package com.kairos.module.context_engine.presentation.dto.response;
+
+import com.kairos.module.context_engine.domain.model.progress.SourceProgressUpload;
+
+import java.util.List;
+
+public record ProgressUploadResponse(
+        List<SourceProgressUploadResponse> sourceProgressUploads
+) {
+    public static ProgressUploadResponse of(List<SourceProgressUpload> uploads) {
+        return new ProgressUploadResponse(
+                uploads.stream()
+                        .map(SourceProgressUploadResponse::of)
+                        .toList()
+        );
+    }
+
+    record SourceProgressUploadResponse(
+            String sourceId,
+            String sourceTitle,
+            int totalChunks,
+            int processedChunks
+    ) {
+
+        public static SourceProgressUploadResponse of(SourceProgressUpload upload) {
+            return new SourceProgressUploadResponse(
+                    upload.source().getId().toString(),
+                    upload.source().getTitle(),
+                    upload.totalChunks(),
+                    upload.processedChunks()
+            );
+        }
+
+    }
+
+}

--- a/src/main/java/com/kairos/module/context_engine/presentation/mapper/SourceMapper.java
+++ b/src/main/java/com/kairos/module/context_engine/presentation/mapper/SourceMapper.java
@@ -1,8 +1,12 @@
 package com.kairos.module.context_engine.presentation.mapper;
 
 import com.kairos.module.context_engine.domain.model.SearchResult;
+import com.kairos.module.context_engine.domain.model.progress.SourceProgressUpload;
 import com.kairos.module.context_engine.presentation.dto.response.ContextResponse;
+import com.kairos.module.context_engine.presentation.dto.response.ProgressUploadResponse;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 public class SourceMapper {
@@ -12,6 +16,10 @@ public class SourceMapper {
                 searchResult.knowledgeTriples(),
                 searchResult.chunks()
         );
+    }
+
+    public ProgressUploadResponse toProgressUploadResponse(List<SourceProgressUpload> sourceProgressUploads) {
+        return ProgressUploadResponse.of(sourceProgressUploads);
     }
 
 

--- a/src/test/java/com/kairos/module/context_engine/infrastructure/relational/repository/source/SpringSourceRepositoryAdapterTest.java
+++ b/src/test/java/com/kairos/module/context_engine/infrastructure/relational/repository/source/SpringSourceRepositoryAdapterTest.java
@@ -1,0 +1,61 @@
+package com.kairos.module.context_engine.infrastructure.relational.repository.source;
+
+import com.kairos.module.context_engine.domain.model.progress.SourceProgressUpload;
+import com.kairos.module.context_engine.infrastructure.relational.projection.SourceProgressProjection;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SpringSourceRepositoryAdapterTest {
+
+    @Mock private JpaSourceRepository jpaSourceRepository;
+    @Mock private SourceProgressProjection firstProjection;
+    @Mock private SourceProgressProjection secondProjection;
+
+    @Test
+    void findAllSourcesProgressByAuthorId_mapsEveryProjectionFieldInOrder() {
+        UUID authorId = UUID.randomUUID();
+        when(firstProjection.getTitle()).thenReturn("First source");
+        when(firstProjection.getContent()).thenReturn("first content");
+        when(firstProjection.getTotalChunks()).thenReturn(5);
+        when(firstProjection.getProcessedChunks()).thenReturn(3);
+        when(secondProjection.getTitle()).thenReturn("Second source");
+        when(secondProjection.getContent()).thenReturn("second content");
+        when(secondProjection.getTotalChunks()).thenReturn(2);
+        when(secondProjection.getProcessedChunks()).thenReturn(2);
+        when(jpaSourceRepository.findAllSourcesProgressByAuthorId(authorId))
+                .thenReturn(List.of(firstProjection, secondProjection));
+
+        var adapter = new SpringSourceRepositoryAdapter(jpaSourceRepository);
+        List<SourceProgressUpload> result = adapter.findAllSourcesProgressByAuthorId(authorId);
+
+        assertThat(result)
+                .extracting(upload -> upload.source().getTitle(), upload -> upload.source().getContent(), SourceProgressUpload::totalChunks, SourceProgressUpload::processedChunks)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple("First source", "first content", 5, 3),
+                        org.assertj.core.groups.Tuple.tuple("Second source", "second content", 2, 2)
+                );
+        assertThat(result).extracting(upload -> upload.source().getId()).doesNotHaveDuplicates();
+        verify(jpaSourceRepository).findAllSourcesProgressByAuthorId(authorId);
+    }
+
+    @Test
+    void findAllSourcesProgressByAuthorId_returnsEmptyListWhenJpaHasNoMatches() {
+        UUID authorId = UUID.randomUUID();
+        when(jpaSourceRepository.findAllSourcesProgressByAuthorId(authorId)).thenReturn(List.of());
+
+        var adapter = new SpringSourceRepositoryAdapter(jpaSourceRepository);
+
+        assertThat(adapter.findAllSourcesProgressByAuthorId(authorId)).isEmpty();
+        verify(jpaSourceRepository).findAllSourcesProgressByAuthorId(authorId);
+    }
+}

--- a/src/test/java/com/kairos/module/context_engine/presentation/controller/SourceControllerTest.java
+++ b/src/test/java/com/kairos/module/context_engine/presentation/controller/SourceControllerTest.java
@@ -1,8 +1,11 @@
 package com.kairos.module.context_engine.presentation.controller;
 
 import com.kairos.module.context_engine.application.use_case.SearchSourceUseCase;
+import com.kairos.module.context_engine.application.use_case.GetAllSourceProgressUploadUseCase;
 import com.kairos.module.context_engine.application.use_case.UploadSourceUseCase;
 import com.kairos.module.context_engine.domain.model.SearchResult;
+import com.kairos.module.context_engine.domain.model.content.Source;
+import com.kairos.module.context_engine.domain.model.progress.SourceProgressUpload;
 import com.kairos.module.context_engine.presentation.controller.SourceController;
 import com.kairos.module.context_engine.presentation.dto.response.ContextResponse;
 import com.kairos.module.context_engine.presentation.mapper.SourceMapper;
@@ -37,13 +40,21 @@ class SourceControllerTest {
     private SearchSourceUseCase searchSourceUseCase;
 
     @Mock
+    private GetAllSourceProgressUploadUseCase getAllSourceProgressUploadUseCase;
+
+    @Mock
     private SourceMapper mapper;
 
     private MockMvc mockMvc;
 
     @BeforeEach
     void setUp() {
-        mockMvc = standaloneSetup(new SourceController(uploadSourceUseCase, searchSourceUseCase, mapper))
+        mockMvc = standaloneSetup(new SourceController(
+                uploadSourceUseCase,
+                searchSourceUseCase,
+                getAllSourceProgressUploadUseCase,
+                mapper
+        ))
                 .setControllerAdvice(new GlobalHandlerException())
                 .build();
     }
@@ -182,5 +193,25 @@ class SourceControllerTest {
                 .andExpect(jsonPath("$.path").value("/sources"));
 
         verifyNoInteractions(searchSourceUseCase, mapper);
+    }
+
+    @Test
+    void getAllSourceProgressUpload_returnsMappedProgressForAuthenticatedUser() throws Exception {
+        Source source = new Source(UUID.fromString("a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"), "RAG notes", "content");
+        List<SourceProgressUpload> progress = List.of(new SourceProgressUpload(source, 5, 3));
+        var response = com.kairos.module.context_engine.presentation.dto.response.ProgressUploadResponse.of(progress);
+        when(getAllSourceProgressUploadUseCase.execute()).thenReturn(progress);
+        when(mapper.toProgressUploadResponse(progress)).thenReturn(response);
+
+        mockMvc.perform(get("/sources/progress"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sourceProgressUploads.length()").value(1))
+                .andExpect(jsonPath("$.sourceProgressUploads[0].sourceId").value(source.getId().toString()))
+                .andExpect(jsonPath("$.sourceProgressUploads[0].sourceTitle").value("RAG notes"))
+                .andExpect(jsonPath("$.sourceProgressUploads[0].totalChunks").value(5))
+                .andExpect(jsonPath("$.sourceProgressUploads[0].processedChunks").value(3));
+
+        verify(getAllSourceProgressUploadUseCase).execute();
+        verify(mapper).toProgressUploadResponse(progress);
     }
 }

--- a/src/test/java/com/kairos/module/context_engine/presentation/mapper/SourceMapperTest.java
+++ b/src/test/java/com/kairos/module/context_engine/presentation/mapper/SourceMapperTest.java
@@ -1,8 +1,10 @@
 package com.kairos.module.context_engine.presentation.mapper;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kairos.module.context_engine.domain.model.SearchResult;
 import com.kairos.module.context_engine.domain.model.content.Chunk;
 import com.kairos.module.context_engine.domain.model.content.Source;
+import com.kairos.module.context_engine.domain.model.progress.SourceProgressUpload;
 import com.kairos.module.context_engine.domain.model.knowledge.KnowledgeTriple;
 import com.kairos.module.context_engine.domain.model.knowledge.Passage;
 import com.kairos.module.context_engine.domain.model.retrieval.ranking.RankedChunk;
@@ -19,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SourceMapperTest {
 
     private final SourceMapper mapper = new SourceMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
     void toContextResponse_preservesKnowledgeGraphAndChunkContextFields() {
@@ -51,5 +54,36 @@ class SourceMapperTest {
         assertThat(response.chunkContexts().getFirst().rank()).isEqualTo(1);
         assertThat(response.chunkContexts().getFirst().score()).isEqualTo(0.95);
         assertThat(response.chunkContexts().getFirst().source()).isEqualTo(RetrievalSource.HYBRID);
+    }
+
+    @Test
+    void toProgressUploadResponse_mapsEverySourceProgressField() {
+        UUID firstSourceId = UUID.randomUUID();
+        UUID secondSourceId = UUID.randomUUID();
+        List<SourceProgressUpload> uploads = List.of(
+                new SourceProgressUpload(new Source(firstSourceId, "First source", "first", UUID.randomUUID()), 4, 1),
+                new SourceProgressUpload(new Source(secondSourceId, "Second source", "second", UUID.randomUUID()), 7, 7)
+        );
+
+        var response = mapper.toProgressUploadResponse(uploads);
+
+        var uploadsJson = objectMapper.valueToTree(response).path("sourceProgressUploads");
+
+        assertThat(uploadsJson).hasSize(2);
+        assertThat(uploadsJson.get(0).path("sourceId").asText()).isEqualTo(firstSourceId.toString());
+        assertThat(uploadsJson.get(0).path("sourceTitle").asText()).isEqualTo("First source");
+        assertThat(uploadsJson.get(0).path("totalChunks").asInt()).isEqualTo(4);
+        assertThat(uploadsJson.get(0).path("processedChunks").asInt()).isEqualTo(1);
+        assertThat(uploadsJson.get(1).path("sourceId").asText()).isEqualTo(secondSourceId.toString());
+        assertThat(uploadsJson.get(1).path("sourceTitle").asText()).isEqualTo("Second source");
+        assertThat(uploadsJson.get(1).path("totalChunks").asInt()).isEqualTo(7);
+        assertThat(uploadsJson.get(1).path("processedChunks").asInt()).isEqualTo(7);
+    }
+
+    @Test
+    void toProgressUploadResponse_mapsEmptyProgressList() {
+        var response = mapper.toProgressUploadResponse(List.of());
+
+        assertThat(objectMapper.valueToTree(response).path("sourceProgressUploads")).isEmpty();
     }
 }

--- a/src/test/java/com/kairos/module/context_engine/use_case/GetAllSourceProgressUploadUseCaseTest.java
+++ b/src/test/java/com/kairos/module/context_engine/use_case/GetAllSourceProgressUploadUseCaseTest.java
@@ -1,0 +1,58 @@
+package com.kairos.module.context_engine.use_case;
+
+import com.kairos.module.context_engine.application.use_case.GetAllSourceProgressUploadUseCase;
+import com.kairos.module.context_engine.domain.model.content.Source;
+import com.kairos.module.context_engine.domain.model.progress.SourceProgressUpload;
+import com.kairos.module.context_engine.domain.port.repository.SourceRepository;
+import com.kairos.share.security.context.RequestContext;
+import com.kairos.share.security.context.RequestContextProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetAllSourceProgressUploadUseCaseTest {
+
+    @Mock private SourceRepository sourceRepository;
+    @Mock private RequestContextProvider contextProvider;
+
+    @InjectMocks
+    private GetAllSourceProgressUploadUseCase useCase;
+
+    @Test
+    void execute_retrievesProgressForTheCurrentUser() {
+        UUID authorId = UUID.randomUUID();
+        List<SourceProgressUpload> expected = List.of(
+                new SourceProgressUpload(new Source("RAG notes", "content"), 3, 2)
+        );
+        when(contextProvider.getRequestContext()).thenReturn(new RequestContext(authorId, "lucas@example.com", List.of()));
+        when(sourceRepository.findAllSourcesProgressByAuthorId(authorId)).thenReturn(expected);
+
+        List<SourceProgressUpload> result = useCase.execute();
+
+        assertThat(result).isSameAs(expected);
+        verify(contextProvider).getRequestContext();
+        verify(sourceRepository).findAllSourcesProgressByAuthorId(authorId);
+    }
+
+    @Test
+    void execute_returnsEmptyListWhenCurrentUserHasNoSources() {
+        UUID authorId = UUID.randomUUID();
+        when(contextProvider.getRequestContext()).thenReturn(new RequestContext(authorId, "lucas@example.com", List.of()));
+        when(sourceRepository.findAllSourcesProgressByAuthorId(authorId)).thenReturn(List.of());
+
+        List<SourceProgressUpload> result = useCase.execute();
+
+        assertThat(result).isEmpty();
+        verify(sourceRepository).findAllSourcesProgressByAuthorId(authorId);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature to track and retrieve the progress of source uploads for a given author. It adds the necessary domain model, repository methods, use case, and API endpoint to expose this functionality. The changes are grouped below by theme.

**New Feature: Source Upload Progress Tracking**

* Added `SourceProgressUpload` domain model to represent the progress of chunk processing for each source.
* Introduced `findAllSourcesProgressByAuthorId(UUID authorId)` method in the `SourceRepository` interface and implemented it in the relational adapter and JPA repository, including a projection for efficient retrieval. [[1]](diffhunk://#diff-d058f2faccc65df1a67bc62efee79c5cfb14ff82ead33242c03d34b4896d529dR34-R39) [[2]](diffhunk://#diff-6a8527b8b7a60330b88ac6f9440c3dc8ad1870edd968fb6a7e2b45da3d0c6a29R52-R63) [[3]](diffhunk://#diff-5a0b26648a4944e71678b441bdb2565b90cdd8eef8ad76a05a576bb511ee7e15R4-R15) [[4]](diffhunk://#diff-e0398c32cf22227e42b9f01ad01f9acb6f3abfea79a1001607e196e2f5d31bb9R1-R11)

**Application Logic and API Layer**

* Added `GetAllSourceProgressUploadUseCase` to encapsulate the logic for retrieving all source upload progress for the current user.
* Extended `SourceController` with a new `/progress` GET endpoint to expose the upload progress, and updated its constructor to inject the new use case. [[1]](diffhunk://#diff-180f523574d11ba8b69552905f801a9c7bc88b40333ec387a2bc53d9d3fdf112R24-R31) [[2]](diffhunk://#diff-180f523574d11ba8b69552905f801a9c7bc88b40333ec387a2bc53d9d3fdf112R60-R65)
* Added mapping logic and response DTO (`ProgressUploadResponse`) to present the progress data in the API response. [[1]](diffhunk://#diff-2597f31cff0cec9fa372b51f7ac3da316589f6bbae57a1e500aae177a34454ecR1-R36) [[2]](diffhunk://#diff-4975fa72444eae5c3f046087d381b3700be677078b432f7db98e243fc0b3df15R21-R24)

**Minor Refactoring**

* Adjusted the order of constructor parameters in `GenerateSourceContextUseCase` for consistency.