### PR TITLE
#25 feat: implement history of retrieval search

### DIFF
--- a/docs/adr/ADR-010 — Retrieval Answer History as Versioned JSONB Snapshots.md
+++ b/docs/adr/ADR-010 — Retrieval Answer History as Versioned JSONB Snapshots.md
@@ -1,0 +1,81 @@
+# ADR-010 — Retrieval Answer History as Versioned JSONB Snapshots
+
+- **Status:** Accepted
+- **Date:** 2026-07-29
+- **Context:** Kairos V1 retrieval history
+
+---
+
+## Context
+
+Kairos V1 needs to preserve retrieval executions for auditability, explainability, and future quality-analysis workflows. A persisted result must retain the passages, scores, graph seeds, activated triples, and execution parameters that explain the outcome at the time it was produced.
+
+These values are execution data. They are not the current relational state of `Chunk`, `Source`, `Triple`, or the Neo4j graph. Reconstructing them later through strong foreign-key relationships would require extra queries and could produce a different result after reindexing, deletion, or graph evolution.
+
+The existing `SearchResult` is a runtime domain object. It contains full domain objects such as `Chunk` and must not be serialized as history because that can include embeddings, full source content, and implementation details.
+
+## Decision
+
+History remains inside the `context_engine` module, under the history domain.
+
+```text
+User 1 ── N Question 1 ── N Answer
+```
+
+`Question` represents a user query. `Answer` represents one complete retrieval execution for that question. Re-executing or regenerating a question creates a new answer instead of overwriting historical data.
+
+An answer persists the following relational fields:
+
+- `id: UUID`
+- `questionId: UUID`
+- `schemaVersion: int`
+- `snapshot: AnswerSnapshot` as PostgreSQL `JSONB`
+- `createdAt: Instant`
+
+There is no separate `RetrievalTrace` entity or table.
+
+`AnswerSnapshot` is a typed persistence model, similar in shape to `SearchResult` but independent of runtime domain objects. It contains:
+
+- retrieval version and parameters;
+- graph seeds and their weights;
+- selected ranked passages with correlation IDs, selected content, rank, final score, dense score, graph score, and source;
+- activated triples with correlation data, structural relation weight, and activation score when available.
+
+The snapshot is immutable after creation. Its embedded IDs are correlation values, not mandatory FKs to the current chunks, sources, or triples. An answer is readable as a complete historical result without querying PostgreSQL content tables or Neo4j.
+
+Snapshots must exclude query and passage embeddings and full source documents.
+
+`schemaVersion` is mandatory so readers can handle future changes to the JSON structure.
+
+## Consequences
+
+### Positive
+
+- One answer read returns the complete historical retrieval result without joins or graph lookups.
+- History remains interpretable even if knowledge is reprocessed or graph state evolves.
+- The shape of retrieval evidence can evolve without creating a normalized table for every intermediate algorithm stage.
+- V1 writes stay simple; JSON indexes are deferred until a real analytical query requires them.
+- The model keeps `User` as an identity boundary and keeps retrieval history in `context_engine`.
+
+### Negative
+
+- The database cannot enforce referential integrity for IDs inside the snapshot.
+- Frequent analytical filtering over JSON fields may require expression indexes or a separate analytical projection later.
+- The application must validate the typed snapshot and maintain compatibility by `schemaVersion`.
+- Selected passage content is duplicated intentionally to make the historical answer self-contained.
+
+## Alternatives Considered
+
+| Alternative | Reason rejected |
+|---|---|
+| Separate `RetrievalTrace` entity | The trace is the answer's result, not an independent aggregate for V1. |
+| Normalized passage, seed, and triple trace tables | Adds joins and rigid relationships for data that is an execution snapshot. |
+| Serialize `SearchResult` directly | Risks serializing `Chunk`, embeddings, source content, and runtime implementation details. |
+| Keep only IDs and rebuild the answer on read | Reprocessing or deletion can make historical results non-reproducible and requires additional lookups. |
+
+## Related
+
+- [[05 - Histórico de perguntas, respostas e rastros]]
+- [[ADR-009 — HippoRAG 2 Retrieval Domain Model]]
+- [[06 - Modelo de domínio de retrieval para HippoRAG 2]]
+- [[Reforço de aprendizado por uso]]

--- a/src/main/java/com/kairos/module/context_engine/application/query/SearchSourceQuery.java
+++ b/src/main/java/com/kairos/module/context_engine/application/query/SearchSourceQuery.java
@@ -1,9 +1,16 @@
 package com.kairos.module.context_engine.application.query;
 
+import java.util.UUID;
+
 public record SearchSourceQuery(
-        String searchTerm
+        String searchTerm,
+        UUID questionId
 ) {
+    public SearchSourceQuery(String searchTerm) {
+        this(searchTerm, null);
+    }
+
     public static SearchSourceQuery of(String searchTerm) {
-        return new SearchSourceQuery(searchTerm);
+        return new SearchSourceQuery(searchTerm, null);
     }
 }

--- a/src/main/java/com/kairos/module/context_engine/application/use_case/SearchSourceUseCase.java
+++ b/src/main/java/com/kairos/module/context_engine/application/use_case/SearchSourceUseCase.java
@@ -17,9 +17,9 @@ import com.kairos.module.context_engine.domain.port.graph.KnowledgeGraphSearch;
 import com.kairos.module.context_engine.domain.port.repository.HistoryRepository;
 import com.kairos.module.context_engine.domain.port.recognition.RecognitionMemory;
 import com.kairos.module.context_engine.domain.port.semantic.SemanticSearch;
+import com.kairos.module.context_engine.infrastructure.config.RetrievalProperties;
 import com.kairos.share.security.context.RequestContextProvider;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.LinkedHashMap;
@@ -40,24 +40,7 @@ public class SearchSourceUseCase {
     private final RecognitionMemory recognitionMemory;
     private final RequestContextProvider requestContextProvider;
     private final HistoryRepository historyRepository;
-
-    @Value("${kairos.retrieval.semantic-anchor-limit:10}")
-    private int semanticAnchorLimit = 10;
-
-    @Value("${kairos.retrieval.graph-passage-limit:20}")
-    private int graphPassageLimit = 20;
-
-    @Value("${kairos.retrieval.triple-candidate-limit:30}")
-    private int tripleCandidateLimit = 30;
-
-    @Value("${kairos.retrieval.recognition-seed-limit:10}")
-    private int recognitionSeedLimit = 10;
-
-    @Value("${kairos.retrieval.seed-min-score:0.45}")
-    private double seedMinScore = 0.45d;
-
-    @Value("${kairos.retrieval.seed-relative-threshold:0.85}")
-    private double seedRelativeThreshold = 0.85d;
+    private final RetrievalProperties retrievalProperties;
 
     public SearchResult execute(SearchSourceQuery query) {
         UUID userId = requestContextProvider.getRequestContext().userId();
@@ -66,13 +49,16 @@ public class SearchSourceUseCase {
 
         float[] queryVector = embeddingPort.embed(query.searchTerm());
 
-        List<PassageCandidate> passageCandidates = semanticSearch.findPassageCandidate(queryVector, userId, semanticAnchorLimit);
-        List<TripleCandidate> tripleCandidates = semanticSearch.findTripleCandidates(queryVector, userId, tripleCandidateLimit);
+        List<PassageCandidate> passageCandidates = semanticSearch.findPassageCandidate(
+                queryVector, userId, retrievalProperties.semanticAnchorLimit());
+        List<TripleCandidate> tripleCandidates = semanticSearch.findTripleCandidates(
+                queryVector, userId, retrievalProperties.tripleCandidateLimit());
 
         List<GraphSeed> conceptSeeds = tripleCandidates.isEmpty()
                 ? List.of()
                 : List.copyOf(Optional.ofNullable(
-                        recognitionMemory.recognize(query.searchTerm(), tripleCandidates, recognitionSeedLimit)).orElse(List.of()));
+                        recognitionMemory.recognize(query.searchTerm(), tripleCandidates,
+                                retrievalProperties.recognitionSeedLimit())).orElse(List.of()));
 
         List<GraphSeed> seeds = instanceSeedsFromCandidates(passageCandidates, conceptSeeds);
         SearchResult result = retrieve(userId, seeds);
@@ -88,7 +74,7 @@ public class SearchSourceUseCase {
         }
 
         GraphSearchResult graphResult = knowledgeGraphSearch.expandKnowledge(
-                GraphSearchRequest.from(userId, seeds, graphPassageLimit)
+                GraphSearchRequest.from(userId, seeds, retrievalProperties.graphPassageLimit())
         );
         List<RankedChunk> chunks = graphResult.scoredPassages().isEmpty()
                 ? List.of()
@@ -108,8 +94,14 @@ public class SearchSourceUseCase {
     }
 
     private AnswerSnapshot.RetrievalParameters parameters() {
-        return new AnswerSnapshot.RetrievalParameters(semanticAnchorLimit, tripleCandidateLimit, recognitionSeedLimit,
-                graphPassageLimit, seedMinScore, seedRelativeThreshold);
+        return new AnswerSnapshot.RetrievalParameters(
+                retrievalProperties.semanticAnchorLimit(),
+                retrievalProperties.tripleCandidateLimit(),
+                retrievalProperties.recognitionSeedLimit(),
+                retrievalProperties.graphPassageLimit(),
+                retrievalProperties.seedMinScore(),
+                retrievalProperties.seedRelativeThreshold()
+        );
     }
 
     private Question questionFor(SearchSourceQuery query, UUID userId) {
@@ -144,7 +136,8 @@ public class SearchSourceUseCase {
             return Double.POSITIVE_INFINITY;
         }
 
-        return Math.max(seedMinScore, bestScore * seedRelativeThreshold);
+        return Math.max(retrievalProperties.seedMinScore(),
+                bestScore * retrievalProperties.seedRelativeThreshold());
     }
 
     private List<KnowledgeTriple> filterActivatedTriples(List<KnowledgeTriple> triples, List<RankedChunk> rankedChunks) {

--- a/src/main/java/com/kairos/module/context_engine/application/use_case/SearchSourceUseCase.java
+++ b/src/main/java/com/kairos/module/context_engine/application/use_case/SearchSourceUseCase.java
@@ -1,6 +1,10 @@
 package com.kairos.module.context_engine.application.use_case;
 
 import com.kairos.module.context_engine.application.query.SearchSourceQuery;
+import com.kairos.module.context_engine.domain.model.SearchResult;
+import com.kairos.module.context_engine.domain.model.history.Answer;
+import com.kairos.module.context_engine.domain.model.history.AnswerSnapshot;
+import com.kairos.module.context_engine.domain.model.history.Question;
 import com.kairos.module.context_engine.domain.model.knowledge.KnowledgeTriple;
 import com.kairos.module.context_engine.domain.model.retrieval.candidate.PassageCandidate;
 import com.kairos.module.context_engine.domain.model.retrieval.candidate.TripleCandidate;
@@ -10,7 +14,7 @@ import com.kairos.module.context_engine.domain.model.retrieval.ranking.RankedChu
 import com.kairos.module.context_engine.domain.model.retrieval.seed.GraphSeed;
 import com.kairos.module.context_engine.domain.port.embedding.EmbeddingProvider;
 import com.kairos.module.context_engine.domain.port.graph.KnowledgeGraphSearch;
-import com.kairos.module.context_engine.domain.model.SearchResult;
+import com.kairos.module.context_engine.domain.port.repository.HistoryRepository;
 import com.kairos.module.context_engine.domain.port.recognition.RecognitionMemory;
 import com.kairos.module.context_engine.domain.port.semantic.SemanticSearch;
 import com.kairos.share.security.context.RequestContextProvider;
@@ -21,25 +25,11 @@ import org.springframework.stereotype.Component;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-/**
- * Orchestrates the HippoRAG 2 retrieval flow, combining dense vector search with
- * knowledge graph expansion to achieve multi-hop reasoning.
- * <p>
- * This use case follows a multiphase retrieval strategy:
- * <ol>
- * <li><b>Semantic Anchor Lookup:</b> Uses dense embeddings to find the most semantically relevant chunks in the vector store.</li>
- * <li><b>Graph Seeding & Expansion:</b> Uses the identified chunks as seeds for a Personalized PageRank (PPR) algorithm
- * over the knowledge graph, discovering structurally connected concepts and passages.</li>
- * <li><b>Hydration & Re-ranking:</b> Retrieves the full text payloads from the relational store while strictly preserving
- * the relevance ranking dictated by the graph's PPR convergence scores.</li>
- * </ol>
- * </p>
- */
 @Component
 @RequiredArgsConstructor
 public class SearchSourceUseCase {
@@ -49,6 +39,7 @@ public class SearchSourceUseCase {
     private final SemanticSearch semanticSearch;
     private final RecognitionMemory recognitionMemory;
     private final RequestContextProvider requestContextProvider;
+    private final HistoryRepository historyRepository;
 
     @Value("${kairos.retrieval.semantic-anchor-limit:10}")
     private int semanticAnchorLimit = 10;
@@ -68,66 +59,84 @@ public class SearchSourceUseCase {
     @Value("${kairos.retrieval.seed-relative-threshold:0.85}")
     private double seedRelativeThreshold = 0.85d;
 
-    /**
-     * Executes a search query against the knowledge graph, returning a ranked list of relevant chunks and activated triples.
-     * @param query the search query containing the search term and any additional parameters
-     * @return a SearchResult containing the activated triples from the knowledge graph and a ranked list of relevant chunks based on the search query
-     */
     public SearchResult execute(SearchSourceQuery query) {
         UUID userId = requestContextProvider.getRequestContext().userId();
+
+        Question question = questionFor(query, userId);
+
         float[] queryVector = embeddingPort.embed(query.searchTerm());
 
         List<PassageCandidate> passageCandidates = semanticSearch.findPassageCandidate(queryVector, userId, semanticAnchorLimit);
         List<TripleCandidate> tripleCandidates = semanticSearch.findTripleCandidates(queryVector, userId, tripleCandidateLimit);
+
         List<GraphSeed> conceptSeeds = tripleCandidates.isEmpty()
                 ? List.of()
-                : recognitionMemory.recognize(query.searchTerm(), tripleCandidates, recognitionSeedLimit);
+                : List.copyOf(Optional.ofNullable(
+                        recognitionMemory.recognize(query.searchTerm(), tripleCandidates, recognitionSeedLimit)).orElse(List.of()));
 
-        var seeds = instanceSeedsFromCandidates(passageCandidates, conceptSeeds);
+        List<GraphSeed> seeds = instanceSeedsFromCandidates(passageCandidates, conceptSeeds);
+        SearchResult result = retrieve(userId, seeds);
 
+        saveAnswer(question, seeds, passageCandidates, result);
+
+        return result;
+    }
+
+    private SearchResult retrieve(UUID userId, List<GraphSeed> seeds) {
         if (seeds.isEmpty()) {
             return SearchResult.empty();
         }
 
-        var graphSearchRequest = GraphSearchRequest.from(userId, seeds, graphPassageLimit);
-
-        GraphSearchResult result = knowledgeGraphSearch.expandKnowledge(graphSearchRequest);
-
-        List<RankedChunk> rankedChunks = result.scoredPassages().isEmpty()
+        GraphSearchResult graphResult = knowledgeGraphSearch.expandKnowledge(
+                GraphSearchRequest.from(userId, seeds, graphPassageLimit)
+        );
+        List<RankedChunk> chunks = graphResult.scoredPassages().isEmpty()
                 ? List.of()
-                : semanticSearch.hydrateAndRankChunks(result.scoredPassages(), userId);
+                : semanticSearch.hydrateAndRankChunks(graphResult.scoredPassages(), userId);
 
-        return SearchResult.from(filterActivatedTriples(result.activatedTriples(), rankedChunks), rankedChunks);
+        return SearchResult.from(filterActivatedTriples(graphResult.activatedTriples(), chunks), chunks);
     }
 
-
-    private List<GraphSeed> instanceSeedsFromCandidates(List<PassageCandidate> passageCandidates, List<GraphSeed> conceptSeeds) {
-        double passageThreshold = seedThreshold(
-                passageCandidates.stream()
-                        .mapToDouble(PassageCandidate::denseScore)
-                        .max()
-                        .orElse(0d)
+    private void saveAnswer(Question question, List<GraphSeed> seeds, List<PassageCandidate> candidates, SearchResult result) {
+        Map<UUID, Double> denseScores = candidates.stream()
+                .collect(Collectors.toMap(PassageCandidate::chunkId, PassageCandidate::denseScore, (first, ignored) -> first));
+        AnswerSnapshot snapshot = AnswerSnapshot.from(
+                parameters(), seeds, result.chunks(), denseScores, result.knowledgeTriples()
         );
 
-        var passageSeed = passageCandidates.stream()
+        historyRepository.saveAnswer(Answer.create(question.id(), snapshot));
+    }
+
+    private AnswerSnapshot.RetrievalParameters parameters() {
+        return new AnswerSnapshot.RetrievalParameters(semanticAnchorLimit, tripleCandidateLimit, recognitionSeedLimit,
+                graphPassageLimit, seedMinScore, seedRelativeThreshold);
+    }
+
+    private Question questionFor(SearchSourceQuery query, UUID userId) {
+        if (query.questionId() != null) {
+            return historyRepository.findQuestionByIdAndUserId(query.questionId(), userId)
+                    .orElseThrow(() -> new IllegalArgumentException("Question does not belong to the authenticated user"));
+        }
+
+        Question question = Question.create(userId, query.searchTerm());
+        historyRepository.saveQuestion(question);
+
+        return question;
+    }
+
+    private List<GraphSeed> instanceSeedsFromCandidates(List<PassageCandidate> passageCandidates, List<GraphSeed> conceptSeeds) {
+        double passageThreshold = seedThreshold(passageCandidates.stream()
+                .mapToDouble(PassageCandidate::denseScore).max().orElse(0d));
+        var passageSeeds = passageCandidates.stream()
                 .filter(candidate -> candidate.denseScore() >= passageThreshold)
                 .map(candidate -> GraphSeed.passage(candidate.chunkId(), candidate.denseScore()));
 
-        double conceptThreshold = seedThreshold(
-                conceptSeeds == null
-                        ? 0d
-                        : conceptSeeds.stream()
-                                .mapToDouble(GraphSeed::weight)
-                                .max()
-                                .orElse(0d)
-        );
+        double conceptThreshold = seedThreshold(conceptSeeds.stream()
+                .mapToDouble(GraphSeed::weight).max().orElse(0d));
+        var filteredConceptSeeds = conceptSeeds.stream()
+                .filter(seed -> seed.weight() >= conceptThreshold);
 
-        var conceptSeed = conceptSeeds == null
-                ? Stream.<GraphSeed>empty()
-                : conceptSeeds.stream()
-                        .filter(seed -> seed.weight() >= conceptThreshold);
-
-        return Stream.concat(passageSeed, conceptSeed).toList();
+        return Stream.concat(passageSeeds, filteredConceptSeeds).toList();
     }
 
     private double seedThreshold(double bestScore) {
@@ -143,7 +152,7 @@ public class SearchSourceUseCase {
             return List.of();
         }
 
-        Set<UUID> selectedChunkIds = rankedChunks.stream()
+        var selectedChunkIds = rankedChunks.stream()
                 .map(rankedChunk -> rankedChunk.chunk().getId())
                 .collect(Collectors.toSet());
 

--- a/src/main/java/com/kairos/module/context_engine/domain/model/history/Answer.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/model/history/Answer.java
@@ -1,0 +1,16 @@
+package com.kairos.module.context_engine.domain.model.history;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record Answer(UUID id, UUID questionId, int schemaVersion, AnswerSnapshot snapshot, Instant createdAt) {
+    public Answer {
+        if (id == null || questionId == null || schemaVersion <= 0 || snapshot == null || createdAt == null) {
+            throw new IllegalArgumentException("Answer id, question id, schema version, snapshot and creation time are required");
+        }
+    }
+
+    public static Answer create(UUID questionId, AnswerSnapshot snapshot) {
+        return new Answer(UUID.randomUUID(), questionId, AnswerSnapshot.SCHEMA_VERSION, snapshot, Instant.now());
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/domain/model/history/AnswerSnapshot.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/model/history/AnswerSnapshot.java
@@ -1,0 +1,77 @@
+package com.kairos.module.context_engine.domain.model.history;
+
+import com.kairos.module.context_engine.domain.model.knowledge.KnowledgeTriple;
+import com.kairos.module.context_engine.domain.model.retrieval.ranking.RankedChunk;
+import com.kairos.module.context_engine.domain.model.retrieval.seed.ConceptSeedTarget;
+import com.kairos.module.context_engine.domain.model.retrieval.seed.GraphSeed;
+import com.kairos.module.context_engine.domain.model.retrieval.seed.PassageSeedTarget;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+/** Immutable, self-contained persistence representation of a retrieval execution. */
+public record AnswerSnapshot(
+        String retrievalVersion,
+        RetrievalParameters parameters,
+        List<GraphSeedSnapshot> seeds,
+        List<RankedPassageSnapshot> rankedPassages,
+        List<ActivatedTripleSnapshot> activatedTriples
+) {
+    public static final int SCHEMA_VERSION = 1;
+
+    public AnswerSnapshot {
+        if (retrievalVersion == null || retrievalVersion.isBlank() || parameters == null
+                || seeds == null || rankedPassages == null || activatedTriples == null) {
+            throw new IllegalArgumentException("Answer snapshot fields are required");
+        }
+        seeds = List.copyOf(seeds);
+        rankedPassages = List.copyOf(rankedPassages);
+        activatedTriples = List.copyOf(activatedTriples);
+    }
+
+    public static AnswerSnapshot from(
+            RetrievalParameters parameters,
+            List<GraphSeed> seeds,
+            List<RankedChunk> rankedChunks,
+            Map<UUID, Double> denseScores,
+            List<KnowledgeTriple> activatedTriples
+    ) {
+        return new AnswerSnapshot(
+                "hipporag-2",
+                parameters,
+                IntStream.range(0, seeds.size()).mapToObj(index -> GraphSeedSnapshot.from(seeds.get(index), index)).toList(),
+                rankedChunks.stream().map(chunk -> RankedPassageSnapshot.from(chunk, denseScores.get(chunk.chunk().getId()))).toList(),
+                IntStream.range(0, activatedTriples.size())
+                        .mapToObj(index -> ActivatedTripleSnapshot.from(activatedTriples.get(index), index)).toList()
+        );
+    }
+
+    public record RetrievalParameters(int semanticAnchorLimit, int tripleCandidateLimit, int recognitionSeedLimit,
+                                      int graphPassageLimit, double seedMinScore, double seedRelativeThreshold) { }
+
+    public record GraphSeedSnapshot(String type, UUID chunkId, String concept, double weight, int order) {
+        static GraphSeedSnapshot from(GraphSeed seed, int order) {
+            UUID chunkId = seed.target() instanceof PassageSeedTarget target ? target.chunkId() : null;
+            String concept = seed.target() instanceof ConceptSeedTarget target ? target.concept().name() : null;
+            return new GraphSeedSnapshot(seed.type().name(), chunkId, concept, seed.weight(), order);
+        }
+    }
+
+    public record RankedPassageSnapshot(UUID chunkId, UUID sourceId, String content, int rank, double finalScore,
+                                        Double denseScore, double graphScore, String retrievalSource) {
+        static RankedPassageSnapshot from(RankedChunk chunk, Double denseScore) {
+            return new RankedPassageSnapshot(chunk.chunk().getId(), chunk.chunk().getSource().getId(),
+                    chunk.chunk().getContent(), chunk.rank(), chunk.score(), denseScore, chunk.score(), chunk.source().name());
+        }
+    }
+
+    public record ActivatedTripleSnapshot(String tripleKey, UUID chunkId, String subject, String predicate, String object,
+                                          Double activationScore, double structuralWeight, int order) {
+        static ActivatedTripleSnapshot from(KnowledgeTriple triple, int order) {
+            return new ActivatedTripleSnapshot(null, triple.passage() == null ? null : triple.passage().chunkId(),
+                    triple.subject().name(), triple.predicate(), triple.object().name(), null, triple.weight(), order);
+        }
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/domain/model/history/Question.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/model/history/Question.java
@@ -1,0 +1,18 @@
+package com.kairos.module.context_engine.domain.model.history;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record Question(UUID id, UUID userId, String text, Instant createdAt) {
+
+    public Question {
+        if (id == null || userId == null || text == null || text.isBlank() || createdAt == null) {
+            throw new IllegalArgumentException("Question id, user id, text and creation time are required");
+        }
+        text = text.trim();
+    }
+
+    public static Question create(UUID userId, String text) {
+        return new Question(UUID.randomUUID(), userId, text, Instant.now());
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/domain/port/repository/HistoryRepository.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/port/repository/HistoryRepository.java
@@ -1,0 +1,16 @@
+package com.kairos.module.context_engine.domain.port.repository;
+
+import com.kairos.module.context_engine.domain.model.history.Answer;
+import com.kairos.module.context_engine.domain.model.history.Question;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface HistoryRepository {
+    void saveQuestion(Question question);
+    void saveAnswer(Answer answer);
+    Optional<Question> findQuestionByIdAndUserId(UUID questionId, UUID userId);
+    Optional<Answer> findAnswerByIdAndUserId(UUID answerId, UUID userId);
+    List<Answer> findAnswersByQuestionIdAndUserId(UUID questionId, UUID userId);
+}

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/config/RetrievalConfiguration.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/config/RetrievalConfiguration.java
@@ -1,0 +1,9 @@
+package com.kairos.module.context_engine.infrastructure.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(RetrievalProperties.class)
+public class RetrievalConfiguration {
+}

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/config/RetrievalProperties.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/config/RetrievalProperties.java
@@ -1,0 +1,30 @@
+package com.kairos.module.context_engine.infrastructure.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "kairos.retrieval")
+public record RetrievalProperties(
+        int semanticAnchorLimit,
+        int graphPassageLimit,
+        int tripleCandidateLimit,
+        int recognitionSeedLimit,
+        double seedMinScore,
+        double seedRelativeThreshold
+) {
+    public RetrievalProperties {
+        semanticAnchorLimit = positiveOrDefault(semanticAnchorLimit, 10);
+        graphPassageLimit = positiveOrDefault(graphPassageLimit, 20);
+        tripleCandidateLimit = positiveOrDefault(tripleCandidateLimit, 30);
+        recognitionSeedLimit = positiveOrDefault(recognitionSeedLimit, 10);
+        seedMinScore = positiveOrDefault(seedMinScore, 0.45d);
+        seedRelativeThreshold = positiveOrDefault(seedRelativeThreshold, 0.85d);
+    }
+
+    private static int positiveOrDefault(int value, int defaultValue) {
+        return value > 0 ? value : defaultValue;
+    }
+
+    private static double positiveOrDefault(double value, double defaultValue) {
+        return Double.isFinite(value) && value > 0 ? value : defaultValue;
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/entity/AnswerEntity.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/entity/AnswerEntity.java
@@ -1,0 +1,29 @@
+package com.kairos.module.context_engine.infrastructure.relational.entity;
+
+import com.kairos.module.context_engine.domain.model.history.Answer;
+import com.kairos.module.context_engine.domain.model.history.AnswerSnapshot;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.Immutable;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "answers")
+@Immutable
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor
+public class AnswerEntity {
+    @Id private UUID id;
+    @Column(name = "question_id", nullable = false) private UUID questionId;
+    @Column(name = "schema_version", nullable = false) private int schemaVersion;
+    @JdbcTypeCode(SqlTypes.JSON) @Column(nullable = false, columnDefinition = "jsonb") private AnswerSnapshot snapshot;
+    @Column(name = "created_at", nullable = false) private Instant createdAt;
+
+    public static AnswerEntity of(Answer answer) {
+        return new AnswerEntity(answer.id(), answer.questionId(), answer.schemaVersion(), answer.snapshot(), answer.createdAt());
+    }
+    public Answer toDomain() { return new Answer(id, questionId, schemaVersion, snapshot, createdAt); }
+}

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/entity/QuestionEntity.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/entity/QuestionEntity.java
@@ -1,0 +1,23 @@
+package com.kairos.module.context_engine.infrastructure.relational.entity;
+
+import com.kairos.module.context_engine.domain.model.history.Question;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "questions")
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor
+public class QuestionEntity {
+    @Id private UUID id;
+    @Column(name = "user_id", nullable = false) private UUID userId;
+    @Column(nullable = false, columnDefinition = "TEXT") private String text;
+    @Column(name = "created_at", nullable = false) private Instant createdAt;
+
+    public static QuestionEntity of(Question question) {
+        return new QuestionEntity(question.id(), question.userId(), question.text(), question.createdAt());
+    }
+    public Question toDomain() { return new Question(id, userId, text, createdAt); }
+}

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/history/JpaAnswerRepository.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/history/JpaAnswerRepository.java
@@ -1,0 +1,16 @@
+package com.kairos.module.context_engine.infrastructure.relational.repository.history;
+
+import com.kairos.module.context_engine.infrastructure.relational.entity.AnswerEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface JpaAnswerRepository extends JpaRepository<AnswerEntity, UUID> {
+    @Query("select a from AnswerEntity a, QuestionEntity q where a.questionId = q.id and a.id = :answerId and q.userId = :userId")
+    Optional<AnswerEntity> findByIdAndUserId(UUID answerId, UUID userId);
+    @Query("select a from AnswerEntity a, QuestionEntity q where a.questionId = q.id and a.questionId = :questionId and q.userId = :userId order by a.createdAt")
+    List<AnswerEntity> findAllByQuestionIdAndUserId(UUID questionId, UUID userId);
+}

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/history/JpaQuestionRepository.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/history/JpaQuestionRepository.java
@@ -1,0 +1,11 @@
+package com.kairos.module.context_engine.infrastructure.relational.repository.history;
+
+import com.kairos.module.context_engine.infrastructure.relational.entity.QuestionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface JpaQuestionRepository extends JpaRepository<QuestionEntity, UUID> {
+    Optional<QuestionEntity> findByIdAndUserId(UUID id, UUID userId);
+}

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/history/SpringHistoryRepositoryAdapter.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/history/SpringHistoryRepositoryAdapter.java
@@ -1,0 +1,24 @@
+package com.kairos.module.context_engine.infrastructure.relational.repository.history;
+
+import com.kairos.module.context_engine.domain.model.history.Answer;
+import com.kairos.module.context_engine.domain.model.history.Question;
+import com.kairos.module.context_engine.domain.port.repository.HistoryRepository;
+import com.kairos.module.context_engine.infrastructure.relational.entity.AnswerEntity;
+import com.kairos.module.context_engine.infrastructure.relational.entity.QuestionEntity;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public class SpringHistoryRepositoryAdapter implements HistoryRepository {
+    private final JpaQuestionRepository questions;
+    private final JpaAnswerRepository answers;
+    public SpringHistoryRepositoryAdapter(JpaQuestionRepository questions, JpaAnswerRepository answers) { this.questions = questions; this.answers = answers; }
+    public void saveQuestion(Question question) { questions.save(QuestionEntity.of(question)); }
+    public void saveAnswer(Answer answer) { answers.save(AnswerEntity.of(answer)); }
+    public Optional<Question> findQuestionByIdAndUserId(UUID questionId, UUID userId) { return questions.findByIdAndUserId(questionId, userId).map(QuestionEntity::toDomain); }
+    public Optional<Answer> findAnswerByIdAndUserId(UUID answerId, UUID userId) { return answers.findByIdAndUserId(answerId, userId).map(AnswerEntity::toDomain); }
+    public List<Answer> findAnswersByQuestionIdAndUserId(UUID questionId, UUID userId) { return answers.findAllByQuestionIdAndUserId(questionId, userId).stream().map(AnswerEntity::toDomain).toList(); }
+}

--- a/src/main/resources/db/migration/V2__add_retrieval_answer_history.sql
+++ b/src/main/resources/db/migration/V2__add_retrieval_answer_history.sql
@@ -1,0 +1,18 @@
+CREATE TABLE questions (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    text TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE INDEX idx_questions_user_id_created_at ON questions (user_id, created_at);
+
+CREATE TABLE answers (
+    id UUID PRIMARY KEY,
+    question_id UUID NOT NULL REFERENCES questions(id) ON DELETE CASCADE,
+    schema_version INTEGER NOT NULL,
+    snapshot JSONB NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE INDEX idx_answers_question_id_created_at ON answers (question_id, created_at);

--- a/src/test/java/com/kairos/module/context_engine/domain/model/history/AnswerSnapshotTest.java
+++ b/src/test/java/com/kairos/module/context_engine/domain/model/history/AnswerSnapshotTest.java
@@ -1,0 +1,48 @@
+package com.kairos.module.context_engine.domain.model.history;
+
+import com.kairos.module.context_engine.domain.model.content.Chunk;
+import com.kairos.module.context_engine.domain.model.content.Source;
+import com.kairos.module.context_engine.domain.model.knowledge.KnowledgeTriple;
+import com.kairos.module.context_engine.domain.model.knowledge.Passage;
+import com.kairos.module.context_engine.domain.model.retrieval.ranking.RankedChunk;
+import com.kairos.module.context_engine.domain.model.retrieval.seed.GraphSeed;
+import com.kairos.module.context_engine.domain.model.retrieval.source.RetrievalSource;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AnswerSnapshotTest {
+
+    @Test
+    void capturesSelfContainedRetrievalDataWithoutEmbeddingsOrSourceDocuments() {
+        UUID sourceId = UUID.randomUUID();
+        UUID chunkId = UUID.randomUUID();
+        Chunk chunk = Chunk.create(chunkId, new Source(sourceId, "Title", "Full source document", UUID.randomUUID()),
+                "Selected passage", 0, true, new float[]{0.1f, 0.2f});
+        RankedChunk rankedChunk = new RankedChunk(chunk, 1, 0.89, RetrievalSource.HYBRID);
+        KnowledgeTriple triple = KnowledgeTriple.create("Spring", "USES", "Postgres", Passage.fromChunkId(chunkId), 0.7);
+
+        AnswerSnapshot snapshot = AnswerSnapshot.from(
+                new AnswerSnapshot.RetrievalParameters(10, 30, 10, 20, 0.45, 0.85),
+                List.of(GraphSeed.passage(chunkId, 0.91), GraphSeed.concept("Spring", 0.8)),
+                List.of(rankedChunk), Map.of(chunkId, 0.91), List.of(triple));
+
+        assertThat(snapshot.rankedPassages()).singleElement().satisfies(passage -> {
+            assertThat(passage.chunkId()).isEqualTo(chunkId);
+            assertThat(passage.sourceId()).isEqualTo(sourceId);
+            assertThat(passage.content()).isEqualTo("Selected passage");
+            assertThat(passage.denseScore()).isEqualTo(0.91);
+            assertThat(passage.graphScore()).isEqualTo(0.89);
+            assertThat(passage.retrievalSource()).isEqualTo("HYBRID");
+        });
+        assertThat(snapshot.seeds()).extracting(AnswerSnapshot.GraphSeedSnapshot::type).containsExactly("PASSAGE", "CONCEPT");
+        assertThat(snapshot.activatedTriples()).singleElement()
+                .extracting(AnswerSnapshot.ActivatedTripleSnapshot::chunkId,
+                        AnswerSnapshot.ActivatedTripleSnapshot::structuralWeight)
+                .containsExactly(chunkId, 0.7);
+    }
+}

--- a/src/test/java/com/kairos/module/context_engine/integration/PostgresPersistenceIntegrationTest.java
+++ b/src/test/java/com/kairos/module/context_engine/integration/PostgresPersistenceIntegrationTest.java
@@ -4,10 +4,15 @@ import com.kairos.module.context_engine.domain.model.content.Chunk;
 import com.kairos.module.context_engine.domain.model.content.Source;
 import com.kairos.module.context_engine.domain.model.content.TripleExtracted;
 import com.kairos.module.context_engine.domain.model.retrieval.ranking.ScoredPassage;
+import com.kairos.module.context_engine.domain.model.history.Answer;
+import com.kairos.module.context_engine.domain.model.history.AnswerSnapshot;
+import com.kairos.module.context_engine.domain.model.history.Question;
+import com.kairos.module.context_engine.domain.port.repository.HistoryRepository;
 import com.kairos.module.context_engine.infrastructure.relational.repository.chunk.JpaChunkRepository;
 import com.kairos.module.context_engine.infrastructure.relational.repository.chunk.SpringChunkRepositoryAdapter;
 import com.kairos.module.context_engine.infrastructure.relational.repository.source.SpringSourceRepositoryAdapter;
 import com.kairos.module.context_engine.infrastructure.relational.repository.triple.SpringTripleRepositoryAdapter;
+import com.kairos.module.context_engine.infrastructure.relational.repository.history.SpringHistoryRepositoryAdapter;
 import com.kairos.module.context_engine.infrastructure.relational.semantic.SemanticSearchAdapter;
 import jakarta.persistence.EntityManager;
 import org.flywaydb.core.Flyway;
@@ -39,7 +44,8 @@ import static org.assertj.core.api.Assertions.assertThat;
         SemanticSearchAdapter.class,
         SpringSourceRepositoryAdapter.class,
         SpringChunkRepositoryAdapter.class,
-        SpringTripleRepositoryAdapter.class
+        SpringTripleRepositoryAdapter.class,
+        SpringHistoryRepositoryAdapter.class
 })
 @Testcontainers(disabledWithoutDocker = true)
 class PostgresPersistenceIntegrationTest {
@@ -66,6 +72,9 @@ class PostgresPersistenceIntegrationTest {
     private SemanticSearchAdapter semanticSearch;
 
     @Autowired
+    private HistoryRepository historyRepository;
+
+    @Autowired
     private JpaChunkRepository jpaChunkRepository;
 
     @Autowired
@@ -85,7 +94,7 @@ class PostgresPersistenceIntegrationTest {
 
     @Test
     void appliesInitialMigrationBeforeJpaValidation() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("1");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("2");
     }
 
     @Test
@@ -170,6 +179,28 @@ class PostgresPersistenceIntegrationTest {
                 });
     }
 
+    @Test
+    void persistsVersionedAnswerSnapshotWithoutLoadingCurrentKnowledgeRecords() {
+        UUID userId = UUID.randomUUID();
+        Question question = Question.create(userId, "How does retrieval work?");
+        AnswerSnapshot snapshot = new AnswerSnapshot("hipporag-2",
+                new AnswerSnapshot.RetrievalParameters(10, 30, 10, 20, 0.45, 0.85), List.of(), List.of(), List.of());
+        Answer first = Answer.create(question.id(), snapshot);
+        Answer second = Answer.create(question.id(), snapshot);
+
+        historyRepository.saveQuestion(question);
+        historyRepository.saveAnswer(first);
+        historyRepository.saveAnswer(second);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(historyRepository.findQuestionByIdAndUserId(question.id(), userId)).contains(question);
+        assertThat(historyRepository.findAnswersByQuestionIdAndUserId(question.id(), userId))
+                .extracting(Answer::snapshot)
+                .containsExactly(snapshot, snapshot);
+        assertThat(historyRepository.findAnswersByQuestionIdAndUserId(question.id(), UUID.randomUUID())).isEmpty();
+    }
+
     private Source source(UUID authorId, String suffix) {
         return new Source(UUID.randomUUID(), "source-" + suffix, "content-" + suffix, authorId);
     }
@@ -197,7 +228,8 @@ class PostgresPersistenceIntegrationTest {
     @EnableJpaRepositories(basePackages = {
             "com.kairos.module.context_engine.infrastructure.relational.repository.chunk",
             "com.kairos.module.context_engine.infrastructure.relational.repository.source",
-            "com.kairos.module.context_engine.infrastructure.relational.repository.triple"
+            "com.kairos.module.context_engine.infrastructure.relational.repository.triple",
+            "com.kairos.module.context_engine.infrastructure.relational.repository.history"
     })
     static class IntegrationApplication {
     }

--- a/src/test/java/com/kairos/module/context_engine/use_case/SearchSourceUseCaseTest.java
+++ b/src/test/java/com/kairos/module/context_engine/use_case/SearchSourceUseCaseTest.java
@@ -22,6 +22,7 @@ import com.kairos.module.context_engine.domain.port.graph.KnowledgeGraphSearch;
 import com.kairos.module.context_engine.domain.port.repository.HistoryRepository;
 import com.kairos.module.context_engine.domain.port.recognition.RecognitionMemory;
 import com.kairos.module.context_engine.domain.port.semantic.SemanticSearch;
+import com.kairos.module.context_engine.infrastructure.config.RetrievalProperties;
 import com.kairos.share.security.context.RequestContext;
 import com.kairos.share.security.context.RequestContextProvider;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
@@ -68,6 +70,9 @@ class SearchSourceUseCaseTest {
 
     @Mock
     private HistoryRepository historyRepository;
+
+    @Spy
+    private RetrievalProperties retrievalProperties = new RetrievalProperties(10, 20, 30, 10, 0.45, 0.85);
 
     @InjectMocks
     private SearchSourceUseCase useCase;

--- a/src/test/java/com/kairos/module/context_engine/use_case/SearchSourceUseCaseTest.java
+++ b/src/test/java/com/kairos/module/context_engine/use_case/SearchSourceUseCaseTest.java
@@ -19,6 +19,7 @@ import com.kairos.module.context_engine.domain.model.retrieval.seed.PassageSeedT
 import com.kairos.module.context_engine.domain.model.retrieval.source.RetrievalSource;
 import com.kairos.module.context_engine.domain.port.embedding.EmbeddingProvider;
 import com.kairos.module.context_engine.domain.port.graph.KnowledgeGraphSearch;
+import com.kairos.module.context_engine.domain.port.repository.HistoryRepository;
 import com.kairos.module.context_engine.domain.port.recognition.RecognitionMemory;
 import com.kairos.module.context_engine.domain.port.semantic.SemanticSearch;
 import com.kairos.share.security.context.RequestContext;
@@ -64,6 +65,9 @@ class SearchSourceUseCaseTest {
 
     @Mock
     private RequestContextProvider requestContextProvider;
+
+    @Mock
+    private HistoryRepository historyRepository;
 
     @InjectMocks
     private SearchSourceUseCase useCase;


### PR DESCRIPTION
This pull request introduces a versioned, auditable retrieval answer history for Kairos V1 by snapshotting retrieval executions as immutable JSONB objects, and refactors the retrieval flow to persist and associate questions and answers. The main changes add new domain models for `Question`, `Answer`, and `AnswerSnapshot`, a repository interface for history persistence, and refactor the retrieval use case to save and retrieve these entities. Retrieval parameters are now centralized in a configuration class.

**Retrieval answer history and domain model:**
* Added ADR-010 documenting the decision to persist retrieval executions as versioned JSONB snapshots, including rationale, consequences, and alternatives.
* Introduced new domain records: `Question`, `Answer`, and `AnswerSnapshot`, encapsulating all data needed for a reproducible, auditable retrieval result, and ensuring immutability and versioning. [[1]](diffhunk://#diff-5069f946cd98cb7b314109f4fae535e20b8ae00d0ae31e9c34048525683e105aR1-R18) [[2]](diffhunk://#diff-87ceb13f8f68aef64006a81b4658ac13e18767fab84ab3fb89dcf4e8662710d9R1-R16) [[3]](diffhunk://#diff-f1d9cb95092b2532e2eda4b9495a85f31bb3d1a30de4bc44c2d16fe809a84870R1-R77)

**Persistence and repository abstraction:**
* Added `HistoryRepository` interface to abstract persistence and retrieval of questions and answers, including methods for saving and querying by user and question/answer IDs.

**Retrieval flow refactor and configuration:**
* Refactored `SearchSourceUseCase` to:
  - Accept and persist `Question` and `Answer` entities for each retrieval,
  - Generate and save `AnswerSnapshot` after each execution,
  - Use a new `RetrievalProperties` config bean for all retrieval parameters instead of scattered `@Value` fields. [[1]](diffhunk://#diff-70321e99d18371a97e1ed1b237f6151f0d9222f4e7312ceb3856d665f2f5f503R4-R7) [[2]](diffhunk://#diff-70321e99d18371a97e1ed1b237f6151f0d9222f4e7312ceb3856d665f2f5f503L13-L42) [[3]](diffhunk://#diff-70321e99d18371a97e1ed1b237f6151f0d9222f4e7312ceb3856d665f2f5f503R42-R148)
* Added `RetrievalConfiguration` to enable external configuration of retrieval parameters.

**API and query changes:**
* Extended `SearchSourceQuery` to optionally include a `questionId`, supporting retrieval history linkage.