### PR TITLE
docs: add document operational limitations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@
   <img src="https://img.shields.io/badge/Docker-Compose-blue" alt="Docker Compose">
 </p>
 
-**Standard RAG retrieves similar passages. Kairos retrieves connected knowledge.**
+**Standard RAG retrieves similar passages. Kairos is designed to retrieve connected knowledge.**
 
 Kairos is a JVM-native personal knowledge graph engine for graph-augmented retrieval. It turns source material into durable chunks, extracts factual triples, creates local embeddings, and combines vector search with graph propagation to recover context that is related by meaning and structure.
 
 The project is intentionally built as a retrieval backend rather than a chat interface. Its boundaries are explicit: PostgreSQL stores durable text, vectors, and retrieval history; Neo4j stores the graph projection; Gemini is used for extraction and recognition-memory decisions; the embedding model runs locally on the JVM.
+
+> **Maturity:** experimental retrieval backend. Kairos has automated quality and security checks, but it has not undergone an independent security audit and does not claim production readiness. No software license or contribution policy has been published yet.
 
 ## Contents
 
@@ -32,6 +34,7 @@ The project is intentionally built as a retrieval backend rather than a chat int
 - [Retrieval and history flow](#retrieval-and-history-flow)
 - [API](#api)
 - [Quick start](#quick-start)
+- [Security, privacy, and operations](docs/operations.md)
 - [Testing and CI/CD](#testing-and-cicd)
 - [Troubleshooting](#troubleshooting)
 - [Limitations and roadmap](#limitations-and-roadmap)
@@ -62,7 +65,7 @@ The current retrieval path is inspired by HippoRAG 2:
 | Authentication | Registration, email confirmation, login, JWT sessions, roles, and authenticated request context |
 | User isolation | Source, vector, graph, progress, and retrieval queries are scoped to the authenticated user |
 | Ingestion | Transactional source upload, overlapping chunking, durable persistence, and asynchronous enrichment after commit |
-| Resume behavior | Enrichment processes only unprocessed chunks when the use case is invoked again |
+| Resume behavior | Internal use case selects unprocessed chunks; no public reprocessing endpoint or retry scheduler exists yet |
 | Embeddings | Local ONNX Runtime inference with `all-MiniLM-L6-v2` and `vector(384)` storage |
 | Knowledge extraction | Gemini structured output for factual triple extraction and recognition-memory seed selection |
 | Semantic search | PostgreSQL and pgvector HNSW indexes for passage and triple candidate retrieval |
@@ -166,7 +169,7 @@ The persistent model separates durable knowledge from its graph projection:
 | Passage and concept nodes | Derived graph representation connecting chunks through concepts | Neo4j |
 | Question and `AnswerSnapshot` | Immutable, versioned record of a retrieval execution and its returned context | PostgreSQL JSONB |
 
-Neo4j can therefore be rebuilt from durable PostgreSQL data, while a historical answer remains readable without depending on the current graph or chunks.
+The model makes a Neo4j rebuild possible from durable PostgreSQL data, while a historical answer remains readable without depending on the current graph or chunks. A supported rebuild command, endpoint, or job is **not** implemented yet.
 
 ## Ingestion flow
 
@@ -199,7 +202,7 @@ sequenceDiagram
     G->>PG: Mark chunk processed
 ```
 
-If enrichment fails, completed chunks remain marked as processed and pending chunks can be handled by a later invocation. There is no automatic retry scheduler yet.
+If enrichment fails, chunks already marked as processed remain complete and unprocessed chunks remain eligible for the internal use case. The current API has no reprocessing endpoint and there is no automatic retry scheduler, so an operator cannot trigger this recovery through a supported public interface yet.
 
 ## Retrieval and history flow
 
@@ -236,6 +239,16 @@ These defaults are bound from `kairos.retrieval` and can be overridden through t
 | `seed-relative-threshold` | 0.85 | Relative score threshold applied to seed selection |
 
 All Spring configuration options are documented in [docs/configuration.md](docs/configuration.md). The history model is implemented internally, but there is not yet a public endpoint for listing or reading historical questions and answers.
+
+## Data locality and external processing
+
+Embeddings are generated locally in the JVM. This does **not** mean all document data stays local:
+
+- during ingestion, the complete content of each chunk is sent to Gemini for triple extraction;
+- during search, Gemini receives the user query and the selected candidate triples (subject, predicate, object, and score) for recognition-memory seed selection;
+- Kairos currently configures Gemini as its LLM provider. The extraction and recognition interfaces are domain ports, but no local LLM provider is supplied or documented.
+
+Do not submit sensitive content unless its processing by the configured Gemini provider is acceptable for your environment. See [security, privacy, and operational limitations](docs/operations.md) before deployment.
 
 ## API
 
@@ -324,7 +337,11 @@ The endpoint returns graph evidence separately from ranked chunks. UUIDs and sco
 
 ### Run with Docker Compose
 
-1. Create the environment file:
+1. Create the environment file (choose the command for your shell):
+
+   ```bash
+   cp .env.example .env
+   ```
 
    ```powershell
    Copy-Item .env.example .env
@@ -429,7 +446,7 @@ For the protected `main` branch, require the successful checks exposed by the wo
 | The health endpoint is unreachable | Services are still starting or the host port differs from `APP_PORT` | Run `docker compose ps`, inspect logs, and use the configured host port |
 | `/sources` or `/sources/search` returns `401` | The route requires a valid JWT | Log in or confirm the user and send `Authorization: Bearer $TOKEN` |
 | Upload returns `201` but search is empty | Enrichment runs asynchronously | Poll `/sources/progress` and wait for processed chunks |
-| A source remains partially processed | A chunk failed during enrichment | Invoke the enrichment flow again; only unprocessed chunks are selected |
+| A source remains partially processed | A chunk failed during enrichment | Inspect application logs and source progress. There is currently no supported public reprocessing operation. |
 | Graph results are empty | Neo4j GDS is unavailable or graph enrichment has not completed | Check Neo4j logs and the application warning about unavailable GDS procedures |
 | Existing local data fails schema validation | A volume was created with an older schema | For disposable development data, run `docker compose down --volumes` and recreate the stack |
 | Gemini extraction fails | The API key or model configuration is missing or invalid | Check `GEMINI_API_KEY`, `KAIROS_LLM_MODEL`, and Spring AI settings |
@@ -437,19 +454,23 @@ For the protected `main` branch, require the successful checks exposed by the wo
 
 ## Limitations and roadmap
 
-The current V1 is an operational retrieval backend, not a complete end-user knowledge application. The main remaining gaps are:
+The current V1 is experimental, not a complete end-user knowledge application or a security-audited production service. The main remaining gaps are:
 
-- automatic or scheduled retries for failed enrichment;
+- a supported reprocessing endpoint, automatic retry scheduler, and Neo4j rebuild procedure;
 - a public API for reading persisted questions and answer snapshots;
 - OpenAPI/Swagger publication;
 - a dense-search fallback when Neo4j GDS is unavailable;
+- request-size limits, rate limiting, and upload-abuse controls;
+- a stable Spring AI release (the current `2.0.0-M6` dependency is a milestone release);
+- a published software license, contribution guide, and vulnerability-disclosure policy;
 - broader user-management features beyond authentication and source ownership.
 
-Search the repository's [open GitHub Issues](https://github.com/Luca5Eckert/Kairos/issues) for the current roadmap. Completed retrieval work, including HippoRAG 2 search, chunk resume behavior, and JSONB retrieval history, is documented as current capability rather than future work.
+Search the repository's [open GitHub Issues](https://github.com/Luca5Eckert/Kairos/issues) for the current roadmap. Completed retrieval work, including HippoRAG 2 search and JSONB retrieval history, is documented as current capability rather than future work.
 
 ## Technical references
 
 - [Configuration reference](docs/configuration.md)
+- [Security, privacy, and operations](docs/operations.md)
 - [ADR index](docs/adr/)
 - [Postman collection](docs/postman/Kairos.postman_collection.json)
 - [HippoRAG 2: From RAG to Memory](https://arxiv.org/abs/2502.14802)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p>
   <img src="https://img.shields.io/badge/Java-21-orange" alt="Java 21">
-  <img src="https://img.shields.io/badge/Spring%20Boot-4.0.5-green" alt="Spring Boot 4.0.5">
+  <img src="https://img.shields.io/badge/Spring%20Boot-4.0.7-green" alt="Spring Boot 4.0.7">
   <img src="https://img.shields.io/badge/Spring%20AI-2.0.0--M6-green" alt="Spring AI 2.0.0-M6">
   <img src="https://img.shields.io/badge/PostgreSQL-16-blue" alt="PostgreSQL 16">
   <img src="https://img.shields.io/badge/Neo4j-5.26-blue" alt="Neo4j 5.26">
@@ -27,6 +27,7 @@ The project is intentionally built as a retrieval backend rather than a chat int
 - [Current capabilities](#current-capabilities)
 - [Why graph-augmented retrieval](#why-graph-augmented-retrieval)
 - [Architecture](#architecture)
+- [Data model](#data-model)
 - [Ingestion flow](#ingestion-flow)
 - [Retrieval and history flow](#retrieval-and-history-flow)
 - [API](#api)
@@ -148,9 +149,24 @@ flowchart TB
 The stores have deliberately different responsibilities:
 
 - **PostgreSQL** is the source of truth for users, sources, chunks, vectors, triples, progress, questions, and answers.
-- **pgvector** performs dense passage and triple candidate retrieval using HNSW indexes.
-- **Neo4j** contains a user-scoped projection of passages, concepts, and relationships used for graph expansion.
+- **pgvector** is the PostgreSQL extension used for HNSW-backed dense passage and triple recall; it does not own the source data.
+- **Neo4j with Graph Data Science** contains a user-scoped, derived projection of passages, concepts, and relationships, then runs weighted Personalized PageRank for graph propagation.
+- **Gemini** is limited to structured triple extraction and constrained recognition-memory seed selection; it is not the primary ranking engine.
 - **Answer snapshots** are self-contained historical records. Reading one does not require loading the current chunks, triples, or Neo4j graph.
+
+## Data model
+
+The persistent model separates durable knowledge from its graph projection:
+
+| Record | Purpose | Storage |
+| --- | --- | --- |
+| Source | User-owned submitted document | PostgreSQL |
+| Chunk | Overlapping, processable source segment with embedding and processing state | PostgreSQL + pgvector |
+| Knowledge triple | Subject-predicate-object fact extracted from a chunk | PostgreSQL; projected to Neo4j |
+| Passage and concept nodes | Derived graph representation connecting chunks through concepts | Neo4j |
+| Question and `AnswerSnapshot` | Immutable, versioned record of a retrieval execution and its returned context | PostgreSQL JSONB |
+
+Neo4j can therefore be rebuilt from durable PostgreSQL data, while a historical answer remains readable without depending on the current graph or chunks.
 
 ## Ingestion flow
 
@@ -206,7 +222,20 @@ flowchart LR
     question --> snapshot
 ```
 
-Retrieval tuning defaults and all Spring configuration options are documented in [docs/configuration.md](docs/configuration.md). The history model is implemented internally, but there is not yet a public endpoint for listing or reading historical questions and answers.
+### Retrieval defaults
+
+These defaults are bound from `kairos.retrieval` and can be overridden through the corresponding `KAIROS_*` environment variables.
+
+| Setting | Default | Role |
+| --- | ---: | --- |
+| `semantic-anchor-limit` | 10 | Dense passage candidates used as direct graph anchors |
+| `graph-passage-limit` | 20 | Maximum passages returned after graph ranking |
+| `triple-candidate-limit` | 30 | Dense triple candidates presented to recognition memory |
+| `recognition-seed-limit` | 10 | Maximum concept seeds selected from triple candidates |
+| `seed-min-score` | 0.45 | Minimum score required for a graph seed |
+| `seed-relative-threshold` | 0.85 | Relative score threshold applied to seed selection |
+
+All Spring configuration options are documented in [docs/configuration.md](docs/configuration.md). The history model is implemented internally, but there is not yet a public endpoint for listing or reading historical questions and answers.
 
 ## API
 
@@ -260,6 +289,30 @@ curl -X POST http://127.0.0.1:8081/sources/search \
   -d '{"termQuery":"How do knowledge graphs improve retrieval?"}'
 ```
 
+The endpoint returns graph evidence separately from ranked chunks. UUIDs and scores below are illustrative; field names match the public response contract.
+
+```json
+{
+  "knowledgeGraph": [
+    {
+      "subject": "Knowledge graphs",
+      "predicate": "connect",
+      "object": "entities across passages",
+      "chunkId": "c4f2397a-c1a0-4eaa-92b7-117ef8cba3b9"
+    }
+  ],
+  "chunkContexts": [
+    {
+      "chunkId": "c4f2397a-c1a0-4eaa-92b7-117ef8cba3b9",
+      "content": "Knowledge graphs connect entities and relationships across passages.",
+      "rank": 1,
+      "score": 0.7812,
+      "source": "GRAPH"
+    }
+  ]
+}
+```
+
 ## Quick start
 
 ### Prerequisites
@@ -311,6 +364,16 @@ On Windows:
 Integration tests use Testcontainers and require an accessible Docker daemon. When Docker is unavailable, those tests are skipped by design; the GitHub Actions runner executes them with Docker enabled.
 
 ## Testing and CI/CD
+
+The quality gates validate implementation behavior and regressions. They do not, by themselves, prove retrieval gains in Recall@K, MRR, NDCG, or answer quality; those claims require a labeled evaluation set.
+
+Latest verified local run (`2026-07-29`, `./mvnw clean verify`):
+
+| Signal | Result |
+| --- | --- |
+| Tests | 262 executed; 0 failures, 0 errors, 9 skipped |
+| JaCoCo line coverage | 87.15% |
+| JaCoCo branch coverage | 73.00% |
 
 The repository uses three GitHub Actions workflows. CI, Qodana, and Security start independently for pull requests and pushes to `main` or `develop`.
 

--- a/docs/adr/ADR-007 — Ingestion Pipeline - Async Dual-Path Processing.md
+++ b/docs/adr/ADR-007 — Ingestion Pipeline - Async Dual-Path Processing.md
@@ -1,8 +1,22 @@
 # ADR-007 — Ingestion Pipeline - Async Dual-Path Processing
 
-- **Status:** Accepted
+- **Status:** Superseded in part — historical design record, not an implementation specification
 - **Date:** 2026-04-05
 - **Context:** Kairos — Personal Knowledge Engine
+
+---
+
+## Current implementation status (2026-07-29)
+
+The implementation differs materially from the proposal below:
+
+- `POST /sources` returns `201 Created` with no status payload; `GET /sources/{id}` is not implemented.
+- An in-process asynchronous `CreatedSourceEvent` starts enrichment after a successful upload transaction.
+- Chunks use a single `processed` flag. The proposed source-state machine is not implemented.
+- The code does not use the proposed parallel per-chunk paths, virtual-thread executor, retry/backoff policy, or synonymy workflow.
+- `POST /sources/{id}/reprocess` is **not** implemented. There is no scheduler, CLI command, or supported administrative operation for retrying failed enrichment.
+
+The sections below preserve the original design rationale and proposed future behavior. Refer to [Security, Privacy, and Operational Limitations](../operations.md) and the README for the behavior that exists today.
 
 ---
 
@@ -129,7 +143,9 @@ Chunks are processed **sequentially** (not in parallel) to respect Gemini Flash'
 |`PARTIAL_FAILURE`|Embeddings saved, but some chunks missing graph data (or vice versa)|
 |`FAILED`|Critical failure — source is not usable for retrieval|
 
-### Reprocessing
+### Proposed reprocessing (not implemented)
+
+This section is a future design proposal. The endpoint and source state described below do not exist in the current API.
 
 Sources with `PARTIAL_FAILURE` status expose a reprocessing endpoint:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Kairos Configuration
 
-This file is the full configuration reference for local development and tuning.
+This file is the full configuration reference for local development and tuning. For data handling, security controls, and operational limitations, see [Security, Privacy, and Operational Limitations](operations.md).
 
 ## Environment Variables
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,62 @@
+# Security, Privacy, and Operational Limitations
+
+This document describes the behavior implemented by Kairos today. It is not a security audit, an operational runbook, or a production-readiness claim.
+
+## Maturity and support boundary
+
+Kairos is an experimental retrieval backend. It has automated Maven, coverage, container, static-analysis, dependency-review, and vulnerability-scanning workflows, but it has not undergone an independent security audit.
+
+The repository currently has no published software license, `CONTRIBUTING.md`, or vulnerability-disclosure policy. Do not assume redistribution rights, contribution rules, or a security-response SLA until those policies are published.
+
+Spring AI is currently pinned to `2.0.0-M6`, a milestone release. Upgrades can introduce compatibility changes and should be tested before deployment.
+
+## Data locality and Gemini
+
+ONNX embeddings are generated locally by the JVM. Gemini remains part of the data path:
+
+| Operation | Data sent to Gemini |
+| --- | --- |
+| Triple extraction during ingestion | The complete content of each source chunk, embedded in the extraction prompt |
+| Recognition memory during search | The user query plus the dense candidate triples: key, subject, predicate, object, and similarity score |
+
+The recognition-memory request does not send full chunk text by design. Triple extraction does. Treat both document chunks and candidate triples as potentially sensitive data and review the configured provider's terms, retention, and regional controls before use.
+
+The code isolates extraction and recognition behind domain ports, so an alternative provider can be implemented. Kairos does not currently ship, configure, or document a local LLM provider.
+
+Application logs intentionally identify processing by source ID; they are not a documented content-redaction boundary. Treat logs and external-provider telemetry as part of the deployment threat model.
+
+## Security controls and gaps
+
+Implemented controls include JWT-protected source routes, authenticated request context, user-scoped retrieval queries, `.env` exclusion from Git, and CI security checks.
+
+The following controls are **not** implemented at the application boundary:
+
+- request-content size limits beyond non-blank validation;
+- API rate limiting or per-user quotas;
+- upload-abuse protection;
+- a documented secrets-file integration; configuration is supplied through environment variables, with `.env` used only for local Compose convenience;
+- a public vulnerability-disclosure process.
+
+SMTP and Gemini credentials are required by the supplied Compose workflow. Use distinct, non-default credentials and a long random `AUTH_SESSION_SECRET` outside local development.
+
+## PostgreSQL and Neo4j consistency
+
+PostgreSQL is the durable source of truth. Neo4j is a derived graph projection. Their writes do not participate in a distributed transaction.
+
+For each unprocessed chunk, Kairos writes the embedding and extracted triples to PostgreSQL, merges graph data into Neo4j, then marks the chunk as processed in PostgreSQL. A failure can therefore leave an intermediate state, such as durable relational data without a completed graph projection. There is no reconciliation job or supported external rebuild procedure yet.
+
+Neo4j graph mutation uses `MERGE` for a passage keyed by `chunkId` and for a triple relationship keyed by predicate, chunk ID, and user ID. Repeating those graph writes does not create another relationship with the same key. This is graph-write idempotency, not a guarantee of end-to-end recovery across both databases.
+
+The internal enrichment use case selects chunks whose `processed` flag is false. It runs automatically after a new source is committed through an in-process asynchronous event. There is currently no `POST /sources/{id}/reprocess` endpoint, scheduler, CLI command, or administrative job to invoke it after a failed run.
+
+## Multi-user graph isolation
+
+Each `Passage` node has a `user_id`. `CONTAINS` and `TRIPLE` relationships also carry `user_id`; `PhraseNode` nodes are shared by normalized name.
+
+For graph search, Kairos creates a GDS projection filtered by the authenticated user's passages and relationships. Personalized PageRank and the final PostgreSQL hydration both use that user scope. This prevents traversal through another user's relationships even when two users share a concept name. The design should still be treated as application-enforced tenant isolation, not as separate Neo4j databases per tenant.
+
+## Recovery and operator limitations
+
+The model permits Neo4j to be reconstructed from durable PostgreSQL chunks and triples, but Kairos does not expose a supported command, endpoint, or job to perform that reconstruction. Similarly, source progress is observable through `GET /sources/progress`, but failed enrichment cannot be retried through the public API.
+
+For now, investigate failed enrichment through application logs and database state. Do not present restart, re-upload, or direct use-case invocation as a supported recovery procedure.


### PR DESCRIPTION
This pull request makes significant improvements to the documentation for the Kairos project, clarifying its experimental status, operational limitations, and data handling practices. It adds a dedicated operations and security reference, expands the README with more accurate descriptions of current behavior, and updates the ADR for ingestion to reflect implementation gaps. The changes also improve configuration and troubleshooting guidance.

**Key documentation and operational updates:**

*Project maturity, security, and operational limitations:*
- Added a new `docs/operations.md` file detailing the experimental status, lack of production-readiness claims, data sent to Gemini, current security controls, and unimplemented features like request-size limits, rate limiting, and reprocessing endpoints.
- README now explicitly states the project is experimental, not production-ready, and lacks a published license or contribution policy. Links to the new operations documentation are included throughout. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R37) F8e34abfL446R446, [[2]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180L3-R3)

*Accurate reflection of current implementation:*
- README and ADR-007 updated to clarify that features such as a reprocessing endpoint, retry scheduler, and Neo4j rebuild are not yet implemented; the ADR now marks these as future design proposals. [[1]](diffhunk://#diff-2cf99834e84982de5415eae1037640dced71f37429c531bcf7a9cb4e15a2f320L3-R22) [[2]](diffhunk://#diff-2cf99834e84982de5415eae1037640dced71f37429c531bcf7a9cb4e15a2f320L132-R148) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R68) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L186-R205) F8e34abfL446R446)

*Expanded technical and usage documentation:*
- Added sections to the README describing the data model, retrieval defaults, and data locality, including specifics on what is sent to Gemini during ingestion and search. (F8e34abfL152R152, F8e34abfL225R225)
- Improved API documentation with example responses and clarified the quick start instructions for different shells. (F8e34abfL302R302, F8e34abfL337R337)
- Updated configuration documentation to reference the new operations and security guide.

*Testing, CI, and troubleshooting:*
- README now includes the latest local test run results, coverage metrics, and more explicit troubleshooting steps for operational issues. (F8e34abfL382R382, F8e34abfL446R446)

These changes make the documentation more accurate, transparent, and useful for both users and operators, while setting clear expectations about the current state and limitations of the project.