### PR TITLE
#52 feat: implement retry failed source context

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ The current retrieval path is inspired by HippoRAG 2:
 | Authentication | Registration, email confirmation, login, JWT sessions, roles, and authenticated request context |
 | User isolation | Source, vector, graph, progress, and retrieval queries are scoped to the authenticated user |
 | Ingestion | Transactional source upload, overlapping chunking, durable persistence, and asynchronous enrichment after commit |
-| Resume behavior | Internal use case selects unprocessed chunks; no public reprocessing endpoint or retry scheduler exists yet |
+| Resume behavior | Failed chunks are visible in source progress and can be retried explicitly without reprocessing completed chunks |
 | Embeddings | Local ONNX Runtime inference with `all-MiniLM-L6-v2` and `vector(384)` storage |
 | Knowledge extraction | Gemini structured output for factual triple extraction and recognition-memory seed selection |
 | Semantic search | PostgreSQL and pgvector HNSW indexes for passage and triple candidate retrieval |
 | Graph retrieval | Neo4j 5.26 with Graph Data Science and weighted Personalized PageRank |
 | Retrieval history | Immutable, versioned `AnswerSnapshot` documents stored as PostgreSQL `JSONB` |
-| Progress | `GET /sources/progress` reports total and processed chunks for the current user |
+| Progress | `GET /sources/progress` reports aggregate status and chunk counts by processing state for the current user |
 | Delivery | Docker Compose for local infrastructure and GitHub Actions for build, quality, security, and container validation |
 
 ## Why graph-augmented retrieval
@@ -202,7 +202,7 @@ sequenceDiagram
     G->>PG: Mark chunk processed
 ```
 
-If enrichment fails, chunks already marked as processed remain complete and unprocessed chunks remain eligible for the internal use case. The current API has no reprocessing endpoint and there is no automatic retry scheduler, so an operator cannot trigger this recovery through a supported public interface yet.
+If enrichment fails, the affected chunk is marked as `FAILED`, chunks already completed remain complete, and processing continues with the remaining claimed chunks. The authenticated owner can retry only failed chunks through `POST /sources/{sourceId}/retry`; automatic retries remain intentionally out of scope.
 
 ## Retrieval and history flow
 
@@ -262,6 +262,7 @@ All `/sources/**` endpoints require a valid JWT bearer token. Authentication end
 | `POST` | `/sources` | JWT | Stores a source and starts asynchronous enrichment |
 | `POST` | `/sources/search` | JWT | Searches the authenticated user's graph-augmented knowledge base |
 | `GET` | `/sources/progress` | JWT | Lists source chunk progress for the authenticated user |
+| `POST` | `/sources/{sourceId}/retry` | JWT | Asynchronously retries only failed chunks owned by the authenticated user |
 
 OpenAPI/Swagger is not configured in the current build. The complete request collection, validation cases, authentication flow, and local environment are available in [docs/postman/Kairos.postman_collection.json](docs/postman/Kairos.postman_collection.json) and [docs/postman/Kairos.local.postman_environment.json](docs/postman/Kairos.local.postman_environment.json).
 
@@ -446,7 +447,7 @@ For the protected `main` branch, require the successful checks exposed by the wo
 | The health endpoint is unreachable | Services are still starting or the host port differs from `APP_PORT` | Run `docker compose ps`, inspect logs, and use the configured host port |
 | `/sources` or `/sources/search` returns `401` | The route requires a valid JWT | Log in or confirm the user and send `Authorization: Bearer $TOKEN` |
 | Upload returns `201` but search is empty | Enrichment runs asynchronously | Poll `/sources/progress` and wait for processed chunks |
-| A source remains partially processed | A chunk failed during enrichment | Inspect application logs and source progress. There is currently no supported public reprocessing operation. |
+| A source reports `FAILED` | A chunk failed during enrichment | Inspect application logs, then call `POST /sources/{sourceId}/retry` to retry only failed chunks. |
 | Graph results are empty | Neo4j GDS is unavailable or graph enrichment has not completed | Check Neo4j logs and the application warning about unavailable GDS procedures |
 | Existing local data fails schema validation | A volume was created with an older schema | For disposable development data, run `docker compose down --volumes` and recreate the stack |
 | Gemini extraction fails | The API key or model configuration is missing or invalid | Check `GEMINI_API_KEY`, `KAIROS_LLM_MODEL`, and Spring AI settings |
@@ -456,7 +457,7 @@ For the protected `main` branch, require the successful checks exposed by the wo
 
 The current V1 is experimental, not a complete end-user knowledge application or a security-audited production service. The main remaining gaps are:
 
-- a supported reprocessing endpoint, automatic retry scheduler, and Neo4j rebuild procedure;
+- an automatic retry scheduler and Neo4j rebuild procedure;
 - a public API for reading persisted questions and answer snapshots;
 - OpenAPI/Swagger publication;
 - a dense-search fallback when Neo4j GDS is unavailable;

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -57,6 +57,6 @@ For graph search, Kairos creates a GDS projection filtered by the authenticated 
 
 ## Recovery and operator limitations
 
-The model permits Neo4j to be reconstructed from durable PostgreSQL chunks and triples, but Kairos does not expose a supported command, endpoint, or job to perform that reconstruction. Similarly, source progress is observable through `GET /sources/progress`, but failed enrichment cannot be retried through the public API.
+The model permits Neo4j to be reconstructed from durable PostgreSQL chunks and triples, but Kairos does not expose a supported command, endpoint, or job to perform that reconstruction. Source progress is observable through `GET /sources/progress`, and the authenticated owner can retry failed enrichment with `POST /sources/{sourceId}/retry`. Automatic retries are not scheduled.
 
 For now, investigate failed enrichment through application logs and database state. Do not present restart, re-upload, or direct use-case invocation as a supported recovery procedure.

--- a/src/main/java/com/kairos/module/context_engine/application/use_case/GenerateSourceContextUseCase.java
+++ b/src/main/java/com/kairos/module/context_engine/application/use_case/GenerateSourceContextUseCase.java
@@ -14,14 +14,15 @@ import com.kairos.module.context_engine.domain.port.graph.KnowledgeGraphStore;
 import com.kairos.module.context_engine.domain.port.repository.SourceRepository;
 import com.kairos.module.context_engine.domain.port.repository.TripleRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class GenerateSourceContextUseCase {
 
     private final TripleExtractor tripleExtractor;
@@ -37,7 +38,6 @@ public class GenerateSourceContextUseCase {
      * Generates context for a given source by chunking the content, extracting triples, and storing them in the knowledge graph.
      * @param command the command containing the source ID and content to process
      */
-    @Transactional
     public void execute(GenerateSourceContextCommand command) {
         Source source = sourceRepository.findById(command.sourceId())
                 .orElseThrow(() -> new RuntimeException("Source not found for id: " + command.sourceId()));
@@ -48,50 +48,65 @@ public class GenerateSourceContextUseCase {
         }
 
         List<Chunk> chunks = chunkRepository.findAllNotProcessedBySourceId(source.getId());
-
-        embedChunks(chunks);
-        generateKnowledgeGraph(chunks, userId);
-    }
-
-    /**
-     * Generates a knowledge graph context for the given source and its associated chunks.
-     * @param chunks the list of chunks associated with the source, from which to extract triples and of the knowledge graph context
-     */
-    private void generateKnowledgeGraph(List<Chunk> chunks, UUID userId) {
-        List<Passage> passages = chunks.stream()
-                .map(chunk -> Passage.fromChunkId(chunk.getId()))
-                .toList();
-        knowledgeGraphStore.savePassages(passages, userId);
-
-        createContextForKnowledgeGraph(chunks, passages, userId);
-    }
-
-
-    /**
-     * Extracts triples from the content of each chunk and saves them to the knowledge graph store, associating them with the corresponding chunk ID.
-     * @param chunks the list of chunks from which to extract triples and of the knowledge graph context
-     */
-    private void createContextForKnowledgeGraph(List<Chunk> chunks, List<Passage> passages, UUID userId) {
-        for (int i = 0; i < chunks.size(); i++) {
-            Chunk chunk = chunks.get(i);
-            Passage passage = passages.get(i);
-
-            List<Triple> triples = tripleExtractor.extract(chunk.getContent());
-
-            List<TripleExtracted> extractedTriples = triples.stream()
-                    .map(triple -> this.createEmbeddingTriple(triple, chunk))
-                    .toList();
-
-            List<KnowledgeTriple> knowledgeTriples = triples.stream()
-                    .map(triple -> KnowledgeTriple.create(triple, passage))
-                    .toList();
-
-            tripleRepository.saveAll(extractedTriples);
-            knowledgeGraphStore.saveAllForChunk(chunk.getId(), userId, knowledgeTriples);
-
-            chunk.markAsProcessed();
+        chunks.forEach(chunk -> {
+            chunk.markAsProcessing();
             chunkRepository.save(chunk);
+        });
+
+        processClaimedChunks(source, chunks);
+    }
+
+    public void executeClaimed(UUID sourceId, List<UUID> chunkIds) {
+        Source source = sourceRepository.findById(sourceId)
+                .orElseThrow(() -> new RuntimeException("Source not found for id: " + sourceId));
+
+        List<Chunk> chunks = chunkRepository.findAllByIds(chunkIds).stream()
+                .filter(chunk -> chunk.getSource().getId().equals(sourceId))
+                .filter(chunk -> chunk.getProcessingStatus() ==
+                        com.kairos.module.context_engine.domain.model.content.ChunkProcessingStatus.PROCESSING)
+                .toList();
+
+        processClaimedChunks(source, chunks);
+    }
+
+    private void processClaimedChunks(Source source, List<Chunk> chunks) {
+        UUID userId = source.getAuthorId();
+        if (userId == null) {
+            throw new IllegalStateException("Source author is required for context generation: " + source.getId());
         }
+
+        for (Chunk chunk : chunks) {
+            try {
+                processChunk(chunk, userId);
+                chunk.markAsProcessed();
+                chunkRepository.save(chunk);
+            } catch (RuntimeException exception) {
+                chunk.markAsFailed();
+                chunkRepository.save(chunk);
+                log.error("Failed to generate source context for sourceId={} chunkId={}",
+                        source.getId(), chunk.getId(), exception);
+            }
+        }
+    }
+
+    private void processChunk(Chunk chunk, UUID userId) {
+        float[] embedding = embeddingProvider.embed(chunk.getContent());
+        chunk.addEmbedding(embedding);
+        chunkRepository.save(chunk);
+
+        Passage passage = Passage.fromChunkId(chunk.getId());
+        knowledgeGraphStore.savePassages(List.of(passage), userId);
+
+        List<Triple> triples = tripleExtractor.extract(chunk.getContent());
+        List<TripleExtracted> extractedTriples = triples.stream()
+                .map(triple -> createEmbeddingTriple(triple, chunk))
+                .toList();
+        List<KnowledgeTriple> knowledgeTriples = triples.stream()
+                .map(triple -> KnowledgeTriple.create(triple, passage))
+                .toList();
+
+        tripleRepository.saveAll(extractedTriples);
+        knowledgeGraphStore.saveAllForChunk(chunk.getId(), userId, knowledgeTriples);
     }
 
     /**
@@ -113,18 +128,5 @@ public class GenerateSourceContextUseCase {
 
         return tripleExtracted;
     }
-
-    /**
-     * Embeds the content of each chunk using the embedding provider and saves the updated chunks back to the repository.
-     * @param chunks the list of chunks to embed and save
-     */
-    private void embedChunks(List<Chunk> chunks) {
-        for (Chunk chunk : chunks) {
-            float[] embedding = embeddingProvider.embed(chunk.getContent());
-            chunk.addEmbedding(embedding);
-            chunkRepository.save(chunk);
-        }
-    }
-
 
 }

--- a/src/main/java/com/kairos/module/context_engine/application/use_case/RetrySourceContextUseCase.java
+++ b/src/main/java/com/kairos/module/context_engine/application/use_case/RetrySourceContextUseCase.java
@@ -1,0 +1,51 @@
+package com.kairos.module.context_engine.application.use_case;
+
+import com.kairos.module.context_engine.domain.event.RetrySourceContextEvent;
+import com.kairos.module.context_engine.domain.exception.SourceRetryConflictException;
+import com.kairos.module.context_engine.domain.model.content.ChunkProcessingStatus;
+import com.kairos.module.context_engine.domain.port.event.SourceEventPublisher;
+import com.kairos.module.context_engine.domain.port.repository.ChunkRepository;
+import com.kairos.module.context_engine.domain.port.repository.SourceRepository;
+import com.kairos.share.security.context.RequestContextProvider;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class RetrySourceContextUseCase {
+
+    private final SourceRepository sourceRepository;
+    private final ChunkRepository chunkRepository;
+    private final SourceEventPublisher eventPublisher;
+    private final RequestContextProvider requestContextProvider;
+
+    @Transactional
+    public void execute(UUID sourceId) {
+        UUID userId = requestContextProvider.getRequestContext().userId();
+        sourceRepository.findByIdAndAuthorIdForUpdate(sourceId, userId)
+                .orElseThrow(() -> new EntityNotFoundException("Source not found"));
+
+        if (!chunkRepository.findAllBySourceIdAndStatus(sourceId, ChunkProcessingStatus.PROCESSING).isEmpty()) {
+            throw new SourceRetryConflictException("Source context processing is already in progress");
+        }
+
+        var failedChunks = chunkRepository.findAllBySourceIdAndStatus(sourceId, ChunkProcessingStatus.FAILED);
+        if (failedChunks.isEmpty()) {
+            throw new SourceRetryConflictException("Source has no failed chunks to retry");
+        }
+
+        failedChunks.forEach(chunk -> {
+            chunk.markAsProcessing();
+            chunkRepository.save(chunk);
+        });
+
+        eventPublisher.send(new RetrySourceContextEvent(
+                sourceId,
+                failedChunks.stream().map(chunk -> chunk.getId()).toList()
+        ));
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/domain/event/RetrySourceContextEvent.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/event/RetrySourceContextEvent.java
@@ -1,0 +1,13 @@
+package com.kairos.module.context_engine.domain.event;
+
+import java.util.List;
+import java.util.UUID;
+
+public record RetrySourceContextEvent(
+        UUID sourceId,
+        List<UUID> chunkIds
+) {
+    public RetrySourceContextEvent {
+        chunkIds = List.copyOf(chunkIds);
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/domain/exception/SourceRetryConflictException.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/exception/SourceRetryConflictException.java
@@ -1,0 +1,8 @@
+package com.kairos.module.context_engine.domain.exception;
+
+public class SourceRetryConflictException extends RuntimeException {
+
+    public SourceRetryConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/domain/model/content/Chunk.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/model/content/Chunk.java
@@ -13,25 +13,27 @@ public class Chunk {
     private final String content;
 
     private final int index;
-    private boolean processed;
+    private ChunkProcessingStatus processingStatus;
 
     private float[] embedding;
 
     public Chunk(UUID id, Source source, String content, int index, boolean processed, float[] embedding) {
+        this(id, source, content, index,
+                processed ? ChunkProcessingStatus.COMPLETED : ChunkProcessingStatus.PENDING,
+                embedding);
+    }
+
+    public Chunk(UUID id, Source source, String content, int index, ChunkProcessingStatus processingStatus, float[] embedding) {
         this.id = id;
         this.source = source;
         this.content = content;
         this.index = index;
-        this.processed = processed;
+        this.processingStatus = processingStatus;
         this.embedding = embedding;
     }
 
     public Chunk(UUID id, Source source, String content, int index, boolean processed) {
-        this.id = id;
-        this.source = source;
-        this.content = content;
-        this.index = index;
-        this.processed = processed;
+        this(id, source, content, index, processed, null);
     }
 
 
@@ -56,7 +58,15 @@ public class Chunk {
     }
 
     public void markAsProcessed() {
-        this.processed = true;
+        this.processingStatus = ChunkProcessingStatus.COMPLETED;
+    }
+
+    public void markAsProcessing() {
+        this.processingStatus = ChunkProcessingStatus.PROCESSING;
+    }
+
+    public void markAsFailed() {
+        this.processingStatus = ChunkProcessingStatus.FAILED;
     }
 
     public UUID getId() {
@@ -76,11 +86,15 @@ public class Chunk {
     }
 
     public boolean isProcessed() {
-        return processed;
+        return processingStatus == ChunkProcessingStatus.COMPLETED;
     }
 
     public void setProcessed(boolean processed) {
-        this.processed = processed;
+        this.processingStatus = processed ? ChunkProcessingStatus.COMPLETED : ChunkProcessingStatus.PENDING;
+    }
+
+    public ChunkProcessingStatus getProcessingStatus() {
+        return processingStatus;
     }
 
     public float[] getEmbedding() {

--- a/src/main/java/com/kairos/module/context_engine/domain/model/content/ChunkProcessingStatus.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/model/content/ChunkProcessingStatus.java
@@ -1,0 +1,8 @@
+package com.kairos.module.context_engine.domain.model.content;
+
+public enum ChunkProcessingStatus {
+    PENDING,
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/com/kairos/module/context_engine/domain/model/progress/SourceProcessingStatus.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/model/progress/SourceProcessingStatus.java
@@ -1,0 +1,8 @@
+package com.kairos.module.context_engine.domain.model.progress;
+
+public enum SourceProcessingStatus {
+    PENDING,
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/com/kairos/module/context_engine/domain/model/progress/SourceProgressUpload.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/model/progress/SourceProgressUpload.java
@@ -5,6 +5,29 @@ import com.kairos.module.context_engine.domain.model.content.Source;
 public record SourceProgressUpload(
         Source source,
         int totalChunks,
-        int processedChunks
+        int pendingChunks,
+        int processingChunks,
+        int completedChunks,
+        int failedChunks
 ) {
+    public SourceProgressUpload(Source source, int totalChunks, int processedChunks) {
+        this(source, totalChunks, totalChunks - processedChunks, 0, processedChunks, 0);
+    }
+
+    public SourceProcessingStatus status() {
+        if (processingChunks > 0) {
+            return SourceProcessingStatus.PROCESSING;
+        }
+        if (failedChunks > 0) {
+            return SourceProcessingStatus.FAILED;
+        }
+        if (totalChunks > 0 && completedChunks == totalChunks) {
+            return SourceProcessingStatus.COMPLETED;
+        }
+        return SourceProcessingStatus.PENDING;
+    }
+
+    public int processedChunks() {
+        return completedChunks;
+    }
 }

--- a/src/main/java/com/kairos/module/context_engine/domain/port/event/SourceEventPublisher.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/port/event/SourceEventPublisher.java
@@ -1,6 +1,7 @@
 package com.kairos.module.context_engine.domain.port.event;
 
 import com.kairos.module.context_engine.domain.event.CreatedSourceEvent;
+import com.kairos.module.context_engine.domain.event.RetrySourceContextEvent;
 
 public interface SourceEventPublisher {
 
@@ -9,4 +10,6 @@ public interface SourceEventPublisher {
      * @param event The CreatedSourceEvent containing the source ID and content to be processed.
      */
     void send(CreatedSourceEvent event);
+
+    void send(RetrySourceContextEvent event);
 }

--- a/src/main/java/com/kairos/module/context_engine/domain/port/repository/ChunkRepository.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/port/repository/ChunkRepository.java
@@ -1,6 +1,7 @@
 package com.kairos.module.context_engine.domain.port.repository;
 
 import com.kairos.module.context_engine.domain.model.content.Chunk;
+import com.kairos.module.context_engine.domain.model.content.ChunkProcessingStatus;
 
 import java.util.List;
 import java.util.UUID;
@@ -11,4 +12,8 @@ public interface ChunkRepository {
     List<Chunk> findAllBySourceId(UUID id);
 
     List<Chunk> findAllNotProcessedBySourceId(UUID sourceId);
+
+    List<Chunk> findAllBySourceIdAndStatus(UUID sourceId, ChunkProcessingStatus status);
+
+    List<Chunk> findAllByIds(List<UUID> ids);
 }

--- a/src/main/java/com/kairos/module/context_engine/domain/port/repository/SourceRepository.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/port/repository/SourceRepository.java
@@ -22,6 +22,8 @@ public interface SourceRepository {
      */
     Optional<Source> findById(UUID id);
 
+    Optional<Source> findByIdAndAuthorIdForUpdate(UUID id, UUID authorId);
+
     Optional<Source> findByAuthorIdAndTitleAndContent(UUID authorId, String title, String content);
 
     /**

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/event/consumer/RetrySourceContextListener.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/event/consumer/RetrySourceContextListener.java
@@ -1,0 +1,25 @@
+package com.kairos.module.context_engine.infrastructure.event.consumer;
+
+import com.kairos.module.context_engine.application.use_case.GenerateSourceContextUseCase;
+import com.kairos.module.context_engine.domain.event.RetrySourceContextEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RetrySourceContextListener {
+
+    private final GenerateSourceContextUseCase generateSourceContextUseCase;
+
+    @Async
+    @TransactionalEventListener(RetrySourceContextEvent.class)
+    public void handle(RetrySourceContextEvent event) {
+        log.info("Retrying failed source context for sourceId={} chunks={}",
+                event.sourceId(), event.chunkIds());
+        generateSourceContextUseCase.executeClaimed(event.sourceId(), event.chunkIds());
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/event/publisher/SpringSourceEventPublisher.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/event/publisher/SpringSourceEventPublisher.java
@@ -1,6 +1,7 @@
 package com.kairos.module.context_engine.infrastructure.event.publisher;
 
 import com.kairos.module.context_engine.domain.event.CreatedSourceEvent;
+import com.kairos.module.context_engine.domain.event.RetrySourceContextEvent;
 import com.kairos.module.context_engine.domain.port.event.SourceEventPublisher;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,11 @@ public class SpringSourceEventPublisher implements SourceEventPublisher {
 
     @Override
     public void send(CreatedSourceEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+
+    @Override
+    public void send(RetrySourceContextEvent event) {
         applicationEventPublisher.publishEvent(event);
     }
 }

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/entity/ChunkEntity.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/entity/ChunkEntity.java
@@ -1,6 +1,7 @@
 package com.kairos.module.context_engine.infrastructure.relational.entity;
 
 import com.kairos.module.context_engine.domain.model.content.Chunk;
+import com.kairos.module.context_engine.domain.model.content.ChunkProcessingStatus;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -34,7 +35,9 @@ public class ChunkEntity {
     @Column(name = "chunk_index", nullable = false)
     private int index;
 
-    private boolean processed;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "processing_status", nullable = false)
+    private ChunkProcessingStatus processingStatus;
 
     @JdbcTypeCode(SqlTypes.VECTOR)
     @Array(length = 384)
@@ -46,7 +49,7 @@ public class ChunkEntity {
                 new SourceEntity(chunk.getSource().getId()),
                 chunk.getContent(),
                 chunk.getIndex(),
-                chunk.isProcessed(),
+                chunk.getProcessingStatus(),
                 chunk.getEmbedding()
         );
     }
@@ -57,7 +60,7 @@ public class ChunkEntity {
                 source.toDomain(),
                 content,
                 index,
-                processed,
+                processingStatus,
                 embedding
         );
     }

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/projection/SourceProgressProjection.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/projection/SourceProgressProjection.java
@@ -2,10 +2,13 @@ package com.kairos.module.context_engine.infrastructure.relational.projection;
 
 public interface SourceProgressProjection {
 
+    java.util.UUID getId();
     String getTitle();
     String getContent();
+    java.util.UUID getAuthorId();
     int getTotalChunks();
-    int getProcessedChunks();
-
-
+    int getPendingChunks();
+    int getProcessingChunks();
+    int getCompletedChunks();
+    int getFailedChunks();
 }

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/chunk/JpaChunkRepository.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/chunk/JpaChunkRepository.java
@@ -41,7 +41,8 @@ public interface JpaChunkRepository extends JpaRepository<ChunkEntity, UUID> {
             @Param("limit") int limit
     );
 
-    List<ChunkEntity> findAllBySource_IdAndProcessedFalse(UUID sourceId);
+    List<ChunkEntity> findAllBySource_IdAndProcessingStatus(UUID sourceId,
+                                                            com.kairos.module.context_engine.domain.model.content.ChunkProcessingStatus status);
 
     List<ChunkEntity> findAllByIdInAndSource_AuthorId(List<UUID> ids, UUID authorId);
 }

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/chunk/SpringChunkRepositoryAdapter.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/chunk/SpringChunkRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package com.kairos.module.context_engine.infrastructure.relational.repository.chunk;
 
 import com.kairos.module.context_engine.domain.model.content.Chunk;
+import com.kairos.module.context_engine.domain.model.content.ChunkProcessingStatus;
 import com.kairos.module.context_engine.domain.port.repository.ChunkRepository;
 import com.kairos.module.context_engine.infrastructure.relational.entity.ChunkEntity;
 import org.springframework.stereotype.Repository;
@@ -35,9 +36,19 @@ public class SpringChunkRepositoryAdapter implements ChunkRepository {
 
     @Override
     public List<Chunk> findAllNotProcessedBySourceId(UUID sourceId) {
-        var entities = chunkRepository.findAllBySource_IdAndProcessedFalse(sourceId);
+        return findAllBySourceIdAndStatus(sourceId, ChunkProcessingStatus.PENDING);
+    }
 
-        return entities.stream()
+    @Override
+    public List<Chunk> findAllBySourceIdAndStatus(UUID sourceId, ChunkProcessingStatus status) {
+        return chunkRepository.findAllBySource_IdAndProcessingStatus(sourceId, status).stream()
+                .map(ChunkEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<Chunk> findAllByIds(List<UUID> ids) {
+        return chunkRepository.findAllById(ids).stream()
                 .map(ChunkEntity::toDomain)
                 .toList();
     }

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/source/JpaSourceRepository.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/source/JpaSourceRepository.java
@@ -3,16 +3,21 @@ package com.kairos.module.context_engine.infrastructure.relational.repository.so
 import com.kairos.module.context_engine.infrastructure.relational.entity.SourceEntity;
 import com.kairos.module.context_engine.infrastructure.relational.projection.SourceProgressProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import jakarta.persistence.LockModeType;
 
 public interface JpaSourceRepository extends JpaRepository<SourceEntity, UUID> {
 
     Optional<SourceEntity> findFirstByAuthorIdAndTitleAndContent(UUID authorId, String title, String content);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<SourceEntity> findByIdAndAuthorId(UUID id, UUID authorId);
 
     /**
      * Find all sources progress by author id.
@@ -22,17 +27,31 @@ public interface JpaSourceRepository extends JpaRepository<SourceEntity, UUID> {
      */
     @Query("""
             SELECT
+                s.id AS id,
                 s.title AS title,
                 s.content AS content,
+                s.authorId AS authorId,
                 COUNT(c.id) AS totalChunks,
                 COALESCE(
-                    SUM(CASE WHEN c.processed = true THEN 1 ELSE 0 END),
+                    SUM(CASE WHEN c.processingStatus = com.kairos.module.context_engine.domain.model.content.ChunkProcessingStatus.PENDING THEN 1 ELSE 0 END),
                     0
-                ) AS processedChunks
+                ) AS pendingChunks,
+                COALESCE(
+                    SUM(CASE WHEN c.processingStatus = com.kairos.module.context_engine.domain.model.content.ChunkProcessingStatus.PROCESSING THEN 1 ELSE 0 END),
+                    0
+                ) AS processingChunks,
+                COALESCE(
+                    SUM(CASE WHEN c.processingStatus = com.kairos.module.context_engine.domain.model.content.ChunkProcessingStatus.COMPLETED THEN 1 ELSE 0 END),
+                    0
+                ) AS completedChunks,
+                COALESCE(
+                    SUM(CASE WHEN c.processingStatus = com.kairos.module.context_engine.domain.model.content.ChunkProcessingStatus.FAILED THEN 1 ELSE 0 END),
+                    0
+                ) AS failedChunks
             FROM SourceEntity s
             LEFT JOIN s.chunkEntities c
             WHERE s.authorId = :authorId
-            GROUP BY s.id, s.title, s.content
+            GROUP BY s.id, s.title, s.content, s.authorId
             """)
     List<SourceProgressProjection> findAllSourcesProgressByAuthorId(
             @Param("authorId") UUID authorId

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/source/SpringSourceRepositoryAdapter.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/source/SpringSourceRepositoryAdapter.java
@@ -33,6 +33,12 @@ public class SpringSourceRepositoryAdapter implements SourceRepository {
     }
 
     @Override
+    public Optional<Source> findByIdAndAuthorIdForUpdate(UUID id, UUID authorId) {
+        return jpaSourceRepository.findByIdAndAuthorId(id, authorId)
+                .map(SourceEntity::toDomain);
+    }
+
+    @Override
     public Optional<Source> findByAuthorIdAndTitleAndContent(UUID authorId, String title, String content) {
         return jpaSourceRepository.findFirstByAuthorIdAndTitleAndContent(authorId, title, content)
                 .map(SourceEntity::toDomain);
@@ -55,9 +61,12 @@ public class SpringSourceRepositoryAdapter implements SourceRepository {
 
         return sourceProgressEntities.stream()
                 .map(projection -> new SourceProgressUpload(
-                        new Source(projection.getTitle(), projection.getContent()),
+                        new Source(projection.getId(), projection.getTitle(), projection.getContent(), projection.getAuthorId()),
                         projection.getTotalChunks(),
-                        projection.getProcessedChunks()
+                        projection.getPendingChunks(),
+                        projection.getProcessingChunks(),
+                        projection.getCompletedChunks(),
+                        projection.getFailedChunks()
                 ))
                 .toList();
     }

--- a/src/main/java/com/kairos/module/context_engine/presentation/controller/SourceController.java
+++ b/src/main/java/com/kairos/module/context_engine/presentation/controller/SourceController.java
@@ -4,6 +4,7 @@ import com.kairos.module.context_engine.application.command.UploadSourceCommand;
 import com.kairos.module.context_engine.application.query.SearchSourceQuery;
 import com.kairos.module.context_engine.application.use_case.GetAllSourceProgressUploadUseCase;
 import com.kairos.module.context_engine.application.use_case.SearchSourceUseCase;
+import com.kairos.module.context_engine.application.use_case.RetrySourceContextUseCase;
 import com.kairos.module.context_engine.application.use_case.UploadSourceUseCase;
 import com.kairos.module.context_engine.presentation.dto.request.GenerateSourceContextRequest;
 import com.kairos.module.context_engine.presentation.dto.request.UploadSourceRequest;
@@ -22,13 +23,17 @@ public class SourceController {
     private final UploadSourceUseCase uploadSourceUseCase;
     private final SearchSourceUseCase searchSourceUseCase;
     private final GetAllSourceProgressUploadUseCase getAllSourceProgressUploadUseCase;
+    private final RetrySourceContextUseCase retrySourceContextUseCase;
 
     private final SourceMapper mapper;
 
-    public SourceController(UploadSourceUseCase uploadSourceUseCase, SearchSourceUseCase searchSourceUseCase, GetAllSourceProgressUploadUseCase getAllSourceProgressUploadUseCase, SourceMapper mapper) {
+    public SourceController(UploadSourceUseCase uploadSourceUseCase, SearchSourceUseCase searchSourceUseCase,
+                            GetAllSourceProgressUploadUseCase getAllSourceProgressUploadUseCase,
+                            RetrySourceContextUseCase retrySourceContextUseCase, SourceMapper mapper) {
         this.uploadSourceUseCase = uploadSourceUseCase;
         this.searchSourceUseCase = searchSourceUseCase;
         this.getAllSourceProgressUploadUseCase = getAllSourceProgressUploadUseCase;
+        this.retrySourceContextUseCase = retrySourceContextUseCase;
         this.mapper = mapper;
     }
 
@@ -62,6 +67,12 @@ public class SourceController {
         var result = getAllSourceProgressUploadUseCase.execute();
 
         return ResponseEntity.ok(mapper.toProgressUploadResponse(result));
+    }
+
+    @PostMapping("/{sourceId}/retry")
+    public ResponseEntity<Void> retrySourceContext(@PathVariable java.util.UUID sourceId) {
+        retrySourceContextUseCase.execute(sourceId);
+        return ResponseEntity.accepted().build();
     }
 
 }

--- a/src/main/java/com/kairos/module/context_engine/presentation/dto/response/ProgressUploadResponse.java
+++ b/src/main/java/com/kairos/module/context_engine/presentation/dto/response/ProgressUploadResponse.java
@@ -18,16 +18,24 @@ public record ProgressUploadResponse(
     record SourceProgressUploadResponse(
             String sourceId,
             String sourceTitle,
+            String status,
             int totalChunks,
-            int processedChunks
+            int pendingChunks,
+            int processingChunks,
+            int completedChunks,
+            int failedChunks
     ) {
 
         public static SourceProgressUploadResponse of(SourceProgressUpload upload) {
             return new SourceProgressUploadResponse(
                     upload.source().getId().toString(),
                     upload.source().getTitle(),
+                    upload.status().name(),
                     upload.totalChunks(),
-                    upload.processedChunks()
+                    upload.pendingChunks(),
+                    upload.processingChunks(),
+                    upload.completedChunks(),
+                    upload.failedChunks()
             );
         }
 

--- a/src/main/java/com/kairos/share/exception/GlobalHandlerException.java
+++ b/src/main/java/com/kairos/share/exception/GlobalHandlerException.java
@@ -2,6 +2,7 @@ package com.kairos.share.exception;
 
 import com.kairos.module.auth.infrastructure.email.EmailConfirmationDeliveryException;
 import com.kairos.module.context_engine.domain.exception.EmbeddingException;
+import com.kairos.module.context_engine.domain.exception.SourceRetryConflictException;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,18 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 @Slf4j
 @ControllerAdvice
 public class GlobalHandlerException {
+
+    @ExceptionHandler(SourceRetryConflictException.class)
+    public ResponseEntity<ErrorResponse> handle(SourceRetryConflictException e, HttpServletRequest request) {
+        log.warn("[409 CONFLICT] {} {} | {}", request.getMethod(), request.getRequestURI(), e.getMessage());
+        var response = ErrorResponse.toInstance(
+                HttpStatus.CONFLICT.value(),
+                "Source retry conflict",
+                e.getMessage(),
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
+    }
 
     @ExceptionHandler(EmailConfirmationDeliveryException.class)
     public ResponseEntity<ErrorResponse> handle(EmailConfirmationDeliveryException e, HttpServletRequest request) {

--- a/src/main/resources/db/migration/V3__add_chunk_processing_status.sql
+++ b/src/main/resources/db/migration/V3__add_chunk_processing_status.sql
@@ -1,0 +1,20 @@
+ALTER TABLE chunks
+    ADD COLUMN processing_status TEXT;
+
+UPDATE chunks
+SET processing_status = CASE
+    WHEN processed THEN 'COMPLETED'
+    ELSE 'PENDING'
+END;
+
+ALTER TABLE chunks
+    ALTER COLUMN processing_status SET NOT NULL,
+    ALTER COLUMN processing_status SET DEFAULT 'PENDING',
+    ADD CONSTRAINT ck_chunks_processing_status
+        CHECK (processing_status IN ('PENDING', 'PROCESSING', 'COMPLETED', 'FAILED'));
+
+CREATE INDEX idx_chunks_source_processing_status
+    ON chunks(source_id, processing_status);
+
+ALTER TABLE chunks
+    DROP COLUMN processed;

--- a/src/test/java/com/kairos/module/context_engine/infrastructure/event/consumer/RetrySourceContextListenerTest.java
+++ b/src/test/java/com/kairos/module/context_engine/infrastructure/event/consumer/RetrySourceContextListenerTest.java
@@ -1,0 +1,26 @@
+package com.kairos.module.context_engine.infrastructure.event.consumer;
+
+import com.kairos.module.context_engine.application.use_case.GenerateSourceContextUseCase;
+import com.kairos.module.context_engine.domain.event.RetrySourceContextEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class RetrySourceContextListenerTest {
+
+    @Test
+    void handle_processesExactlyTheClaimedChunks() {
+        GenerateSourceContextUseCase useCase = mock(GenerateSourceContextUseCase.class);
+        RetrySourceContextListener listener = new RetrySourceContextListener(useCase);
+        UUID sourceId = UUID.randomUUID();
+        List<UUID> chunkIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+
+        listener.handle(new RetrySourceContextEvent(sourceId, chunkIds));
+
+        verify(useCase).executeClaimed(sourceId, chunkIds);
+    }
+}

--- a/src/test/java/com/kairos/module/context_engine/infrastructure/event/publisher/SpringSourceEventPublisherTest.java
+++ b/src/test/java/com/kairos/module/context_engine/infrastructure/event/publisher/SpringSourceEventPublisherTest.java
@@ -1,11 +1,13 @@
 package com.kairos.module.context_engine.infrastructure.event.publisher;
 
 import com.kairos.module.context_engine.domain.event.CreatedSourceEvent;
+import com.kairos.module.context_engine.domain.event.RetrySourceContextEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.UUID;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
@@ -39,6 +41,18 @@ class SpringSourceEventPublisherTest {
         assertThatThrownBy(() -> publisher.send(event))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("Spring event bus unavailable");
+
+        verify(applicationEventPublisher).publishEvent(event);
+    }
+
+    @Test
+    void shouldPublishRetrySourceContextEvent() {
+        RetrySourceContextEvent event = new RetrySourceContextEvent(
+                UUID.randomUUID(),
+                List.of(UUID.randomUUID())
+        );
+
+        publisher.send(event);
 
         verify(applicationEventPublisher).publishEvent(event);
     }

--- a/src/test/java/com/kairos/module/context_engine/infrastructure/relational/repository/chunk/SpringChunkRepositoryAdapterTest.java
+++ b/src/test/java/com/kairos/module/context_engine/infrastructure/relational/repository/chunk/SpringChunkRepositoryAdapterTest.java
@@ -2,6 +2,7 @@ package com.kairos.module.context_engine.infrastructure.relational.repository.ch
 
 import com.kairos.module.context_engine.domain.model.content.Chunk;
 import com.kairos.module.context_engine.domain.model.content.Source;
+import com.kairos.module.context_engine.domain.model.content.ChunkProcessingStatus;
 import com.kairos.module.context_engine.infrastructure.relational.entity.ChunkEntity;
 import com.kairos.module.context_engine.infrastructure.relational.entity.SourceEntity;
 import com.kairos.module.context_engine.infrastructure.relational.repository.chunk.JpaChunkRepository;
@@ -55,7 +56,7 @@ class SpringChunkRepositoryAdapterTest {
                 source,
                 "chunk content",
                 3,
-                true,
+                ChunkProcessingStatus.COMPLETED,
                 new float[]{0.1f, 0.2f}
         );
 
@@ -81,7 +82,7 @@ class SpringChunkRepositoryAdapterTest {
                 SourceEntity.of(source),
                 chunk.getContent(),
                 chunk.getIndex(),
-                chunk.isProcessed(),
+                chunk.getProcessingStatus(),
                 chunk.getEmbedding()
         );
 

--- a/src/test/java/com/kairos/module/context_engine/infrastructure/relational/repository/source/SpringSourceRepositoryAdapterTest.java
+++ b/src/test/java/com/kairos/module/context_engine/infrastructure/relational/repository/source/SpringSourceRepositoryAdapterTest.java
@@ -24,14 +24,26 @@ class SpringSourceRepositoryAdapterTest {
     @Test
     void findAllSourcesProgressByAuthorId_mapsEveryProjectionFieldInOrder() {
         UUID authorId = UUID.randomUUID();
+        UUID firstId = UUID.randomUUID();
+        UUID secondId = UUID.randomUUID();
+        when(firstProjection.getId()).thenReturn(firstId);
+        when(firstProjection.getAuthorId()).thenReturn(authorId);
         when(firstProjection.getTitle()).thenReturn("First source");
         when(firstProjection.getContent()).thenReturn("first content");
         when(firstProjection.getTotalChunks()).thenReturn(5);
-        when(firstProjection.getProcessedChunks()).thenReturn(3);
+        when(firstProjection.getPendingChunks()).thenReturn(1);
+        when(firstProjection.getProcessingChunks()).thenReturn(0);
+        when(firstProjection.getCompletedChunks()).thenReturn(3);
+        when(firstProjection.getFailedChunks()).thenReturn(1);
+        when(secondProjection.getId()).thenReturn(secondId);
+        when(secondProjection.getAuthorId()).thenReturn(authorId);
         when(secondProjection.getTitle()).thenReturn("Second source");
         when(secondProjection.getContent()).thenReturn("second content");
         when(secondProjection.getTotalChunks()).thenReturn(2);
-        when(secondProjection.getProcessedChunks()).thenReturn(2);
+        when(secondProjection.getPendingChunks()).thenReturn(0);
+        when(secondProjection.getProcessingChunks()).thenReturn(0);
+        when(secondProjection.getCompletedChunks()).thenReturn(2);
+        when(secondProjection.getFailedChunks()).thenReturn(0);
         when(jpaSourceRepository.findAllSourcesProgressByAuthorId(authorId))
                 .thenReturn(List.of(firstProjection, secondProjection));
 
@@ -44,7 +56,8 @@ class SpringSourceRepositoryAdapterTest {
                         org.assertj.core.groups.Tuple.tuple("First source", "first content", 5, 3),
                         org.assertj.core.groups.Tuple.tuple("Second source", "second content", 2, 2)
                 );
-        assertThat(result).extracting(upload -> upload.source().getId()).doesNotHaveDuplicates();
+        assertThat(result).extracting(upload -> upload.source().getId())
+                .containsExactly(firstId, secondId);
         verify(jpaSourceRepository).findAllSourcesProgressByAuthorId(authorId);
     }
 

--- a/src/test/java/com/kairos/module/context_engine/infrastructure/semantic/SemanticSearchAdapterTest.java
+++ b/src/test/java/com/kairos/module/context_engine/infrastructure/semantic/SemanticSearchAdapterTest.java
@@ -375,7 +375,9 @@ class SemanticSearchAdapterTest {
     }
 
     private ChunkEntity chunkEntity(UUID id, SourceEntity source, String content, int index) {
-        return new ChunkEntity(id, source, content, index, false, QUERY_VECTOR);
+        return new ChunkEntity(id, source, content, index,
+                com.kairos.module.context_engine.domain.model.content.ChunkProcessingStatus.PENDING,
+                QUERY_VECTOR);
     }
 
     private PassageCandidateProjection passageCandidateProjection(UUID chunkId, Double denseScore) {

--- a/src/test/java/com/kairos/module/context_engine/integration/PostgresPersistenceIntegrationTest.java
+++ b/src/test/java/com/kairos/module/context_engine/integration/PostgresPersistenceIntegrationTest.java
@@ -97,8 +97,8 @@ class PostgresPersistenceIntegrationTest {
     }
 
     @Test
-    void appliesInitialMigrationBeforeJpaValidation() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("2");
+    void appliesLatestMigrationBeforeJpaValidation() {
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("3");
     }
 
     @Test

--- a/src/test/java/com/kairos/module/context_engine/presentation/controller/SourceControllerSecurityTest.java
+++ b/src/test/java/com/kairos/module/context_engine/presentation/controller/SourceControllerSecurityTest.java
@@ -3,6 +3,7 @@ package com.kairos.module.context_engine.presentation.controller;
 import com.kairos.module.context_engine.application.use_case.SearchSourceUseCase;
 import com.kairos.module.context_engine.application.use_case.GetAllSourceProgressUploadUseCase;
 import com.kairos.module.context_engine.application.use_case.UploadSourceUseCase;
+import com.kairos.module.context_engine.application.use_case.RetrySourceContextUseCase;
 import com.kairos.module.context_engine.presentation.controller.SourceController;
 import com.kairos.module.context_engine.presentation.mapper.SourceMapper;
 import com.kairos.share.security.config.AuthSecurityConfiguration;
@@ -34,6 +35,9 @@ class SourceControllerSecurityTest {
 
     @MockitoBean
     private GetAllSourceProgressUploadUseCase getAllSourceProgressUploadUseCase;
+
+    @MockitoBean
+    private RetrySourceContextUseCase retrySourceContextUseCase;
 
     @MockitoBean
     private SourceMapper mapper;

--- a/src/test/java/com/kairos/module/context_engine/presentation/controller/SourceControllerTest.java
+++ b/src/test/java/com/kairos/module/context_engine/presentation/controller/SourceControllerTest.java
@@ -3,7 +3,9 @@ package com.kairos.module.context_engine.presentation.controller;
 import com.kairos.module.context_engine.application.use_case.SearchSourceUseCase;
 import com.kairos.module.context_engine.application.use_case.GetAllSourceProgressUploadUseCase;
 import com.kairos.module.context_engine.application.use_case.UploadSourceUseCase;
+import com.kairos.module.context_engine.application.use_case.RetrySourceContextUseCase;
 import com.kairos.module.context_engine.domain.model.SearchResult;
+import com.kairos.module.context_engine.domain.exception.SourceRetryConflictException;
 import com.kairos.module.context_engine.domain.model.content.Source;
 import com.kairos.module.context_engine.domain.model.progress.SourceProgressUpload;
 import com.kairos.module.context_engine.presentation.controller.SourceController;
@@ -23,6 +25,7 @@ import java.util.UUID;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -43,6 +46,9 @@ class SourceControllerTest {
     private GetAllSourceProgressUploadUseCase getAllSourceProgressUploadUseCase;
 
     @Mock
+    private RetrySourceContextUseCase retrySourceContextUseCase;
+
+    @Mock
     private SourceMapper mapper;
 
     private MockMvc mockMvc;
@@ -53,6 +59,7 @@ class SourceControllerTest {
                 uploadSourceUseCase,
                 searchSourceUseCase,
                 getAllSourceProgressUploadUseCase,
+                retrySourceContextUseCase,
                 mapper
         ))
                 .setControllerAdvice(new GlobalHandlerException())
@@ -209,9 +216,35 @@ class SourceControllerTest {
                 .andExpect(jsonPath("$.sourceProgressUploads[0].sourceId").value(source.getId().toString()))
                 .andExpect(jsonPath("$.sourceProgressUploads[0].sourceTitle").value("RAG notes"))
                 .andExpect(jsonPath("$.sourceProgressUploads[0].totalChunks").value(5))
-                .andExpect(jsonPath("$.sourceProgressUploads[0].processedChunks").value(3));
+                .andExpect(jsonPath("$.sourceProgressUploads[0].status").value("PENDING"))
+                .andExpect(jsonPath("$.sourceProgressUploads[0].pendingChunks").value(2))
+                .andExpect(jsonPath("$.sourceProgressUploads[0].processingChunks").value(0))
+                .andExpect(jsonPath("$.sourceProgressUploads[0].completedChunks").value(3))
+                .andExpect(jsonPath("$.sourceProgressUploads[0].failedChunks").value(0));
 
         verify(getAllSourceProgressUploadUseCase).execute();
         verify(mapper).toProgressUploadResponse(progress);
+    }
+
+    @Test
+    void retrySourceContext_returnsAccepted() throws Exception {
+        UUID sourceId = UUID.randomUUID();
+
+        mockMvc.perform(post("/sources/{sourceId}/retry", sourceId))
+                .andExpect(status().isAccepted());
+
+        verify(retrySourceContextUseCase).execute(sourceId);
+    }
+
+    @Test
+    void retrySourceContext_withoutEligibleFailuresReturnsConflict() throws Exception {
+        UUID sourceId = UUID.randomUUID();
+        doThrow(new SourceRetryConflictException("Source has no failed chunks to retry"))
+                .when(retrySourceContextUseCase).execute(sourceId);
+
+        mockMvc.perform(post("/sources/{sourceId}/retry", sourceId))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value(409))
+                .andExpect(jsonPath("$.message").value("Source retry conflict"));
     }
 }

--- a/src/test/java/com/kairos/module/context_engine/presentation/mapper/SourceMapperTest.java
+++ b/src/test/java/com/kairos/module/context_engine/presentation/mapper/SourceMapperTest.java
@@ -73,11 +73,15 @@ class SourceMapperTest {
         assertThat(uploadsJson.get(0).path("sourceId").asText()).isEqualTo(firstSourceId.toString());
         assertThat(uploadsJson.get(0).path("sourceTitle").asText()).isEqualTo("First source");
         assertThat(uploadsJson.get(0).path("totalChunks").asInt()).isEqualTo(4);
-        assertThat(uploadsJson.get(0).path("processedChunks").asInt()).isEqualTo(1);
+        assertThat(uploadsJson.get(0).path("status").asText()).isEqualTo("PENDING");
+        assertThat(uploadsJson.get(0).path("pendingChunks").asInt()).isEqualTo(3);
+        assertThat(uploadsJson.get(0).path("completedChunks").asInt()).isEqualTo(1);
         assertThat(uploadsJson.get(1).path("sourceId").asText()).isEqualTo(secondSourceId.toString());
         assertThat(uploadsJson.get(1).path("sourceTitle").asText()).isEqualTo("Second source");
         assertThat(uploadsJson.get(1).path("totalChunks").asInt()).isEqualTo(7);
-        assertThat(uploadsJson.get(1).path("processedChunks").asInt()).isEqualTo(7);
+        assertThat(uploadsJson.get(1).path("status").asText()).isEqualTo("COMPLETED");
+        assertThat(uploadsJson.get(1).path("pendingChunks").asInt()).isZero();
+        assertThat(uploadsJson.get(1).path("completedChunks").asInt()).isEqualTo(7);
     }
 
     @Test

--- a/src/test/java/com/kairos/module/context_engine/use_case/GenerateSourceContextUseCaseTest.java
+++ b/src/test/java/com/kairos/module/context_engine/use_case/GenerateSourceContextUseCaseTest.java
@@ -2,25 +2,19 @@ package com.kairos.module.context_engine.use_case;
 
 import com.kairos.module.context_engine.application.command.GenerateSourceContextCommand;
 import com.kairos.module.context_engine.application.use_case.GenerateSourceContextUseCase;
-import com.kairos.module.context_engine.domain.model.knowledge.Passage;
-import com.kairos.module.context_engine.domain.port.embedding.EmbeddingProvider;
-import com.kairos.module.context_engine.domain.port.graph.KnowledgeGraphStore;
-import com.kairos.module.context_engine.domain.port.extraction.TripleExtractor;
-import com.kairos.module.context_engine.domain.model.content.Chunk;
-import com.kairos.module.context_engine.domain.model.knowledge.KnowledgeTriple;
-import com.kairos.module.context_engine.domain.model.content.Source;
 import com.kairos.module.context_engine.domain.model.Triple;
+import com.kairos.module.context_engine.domain.model.content.Chunk;
+import com.kairos.module.context_engine.domain.model.content.ChunkProcessingStatus;
+import com.kairos.module.context_engine.domain.model.content.Source;
+import com.kairos.module.context_engine.domain.port.embedding.EmbeddingProvider;
+import com.kairos.module.context_engine.domain.port.extraction.TripleExtractor;
+import com.kairos.module.context_engine.domain.port.graph.KnowledgeGraphStore;
 import com.kairos.module.context_engine.domain.port.repository.ChunkRepository;
 import com.kairos.module.context_engine.domain.port.repository.SourceRepository;
 import com.kairos.module.context_engine.domain.port.repository.TripleRepository;
-import com.kairos.module.context_engine.domain.model.content.TripleExtracted;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -30,604 +24,103 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-/**
- * Unit tests for {@link GenerateSourceContextUseCase}.
- * Tests the orchestration of chunk embedding, triple extraction, and knowledge graph generation.
- *
- * Testing Strategy:
- * - Source resolution and error handling
- * - Chunk loading (unprocessed chunks only)
- * - Embedding generation for chunks
- * - Triple extraction and embedding
- * - Knowledge graph persistence
- * - Transaction semantics and ordering
- */
 @ExtendWith(MockitoExtension.class)
-@DisplayName("GenerateSourceContextUseCase")
 class GenerateSourceContextUseCaseTest {
 
-    @Mock
-    private TripleExtractor tripleExtractor;
+    @Mock TripleExtractor tripleExtractor;
+    @Mock EmbeddingProvider embeddingProvider;
+    @Mock KnowledgeGraphStore knowledgeGraphStore;
+    @Mock ChunkRepository chunkRepository;
+    @Mock SourceRepository sourceRepository;
+    @Mock TripleRepository tripleRepository;
+    @InjectMocks GenerateSourceContextUseCase useCase;
 
-    @Mock
-    private EmbeddingProvider embeddingProvider;
-
-    @Mock
-    private KnowledgeGraphStore knowledgeGraphStore;
-
-    @Mock
-    private ChunkRepository chunkRepository;
-
-    @Mock
-    private SourceRepository sourceRepository;
-
-    @Mock
-    private TripleRepository tripleRepository;
-
-    @Captor
-    private ArgumentCaptor<List<TripleExtracted>> tripleExtractedCaptor;
-
-    @Captor
-    private ArgumentCaptor<List<KnowledgeTriple>> knowledgeTripleCaptor;
-
-    @Captor
-    private ArgumentCaptor<List<Passage>> passageCaptor;
-
-    @InjectMocks
-    private GenerateSourceContextUseCase useCase;
-
-    private Source source;
     private UUID sourceId;
     private UUID authorId;
+    private Source source;
 
     @BeforeEach
     void setUp() {
         sourceId = UUID.randomUUID();
         authorId = UUID.randomUUID();
-        source = new Source(sourceId, "Clean Code", "some content", authorId);
+        source = new Source(sourceId, "Source", "content", authorId);
     }
 
     private Chunk chunk(String content, int index) {
         return Chunk.create(UUID.randomUUID(), source, content, index, false, null);
     }
 
-    private Triple triple(String subject, String predicate, String object) {
-        return new Triple(subject, predicate, object);
+    @Test
+    void execute_processesOnlyPendingChunksAndMarksThemCompleted() {
+        Chunk chunk = chunk("chunk", 0);
+        when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
+        when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of(chunk));
+        when(embeddingProvider.embed("chunk")).thenReturn(new float[]{0.1f});
+        when(tripleExtractor.extract("chunk")).thenReturn(List.of());
+
+        useCase.execute(GenerateSourceContextCommand.of(sourceId));
+
+        assertThat(chunk.getProcessingStatus()).isEqualTo(ChunkProcessingStatus.COMPLETED);
+        verify(knowledgeGraphStore).savePassages(anyList(), eq(authorId));
+        verify(knowledgeGraphStore).saveAllForChunk(eq(chunk.getId()), eq(authorId), anyList());
     }
 
-    // =========================================================================
-    // Execution Flow & Happy Path
-    // =========================================================================
+    @Test
+    void execute_marksFailedChunkAndContinuesWithNextChunk() {
+        Chunk failed = chunk("failed", 0);
+        Chunk completed = chunk("completed", 1);
+        when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
+        when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of(failed, completed));
+        when(embeddingProvider.embed("failed")).thenThrow(new RuntimeException("provider unavailable"));
+        when(embeddingProvider.embed("completed")).thenReturn(new float[]{0.2f});
+        when(tripleExtractor.extract("completed")).thenReturn(List.of());
 
-    @Nested
-    @DisplayName("execute(GenerateSourceContextCommand)")
-    class ExecuteMethod {
+        useCase.execute(GenerateSourceContextCommand.of(sourceId));
 
-        @Test
-        @DisplayName("resolves source from repository by ID")
-        void resolveSource() {
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of());
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            verify(sourceRepository).findById(sourceId);
-        }
-
-        @Test
-        @DisplayName("loads unprocessed chunks for the source")
-        void loadUnprocessedChunks() {
-            Chunk chunk = chunk("content", 0);
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of(chunk));
-            when(embeddingProvider.embed("content")).thenReturn(new float[]{0.1f});
-            when(tripleExtractor.extract("content")).thenReturn(List.of());
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            verify(chunkRepository).findAllNotProcessedBySourceId(sourceId);
-        }
-
-        @Test
-        @DisplayName("throws RuntimeException when source not found")
-        void throwsExceptionWhenSourceNotFound() {
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.empty());
-
-            assertThatThrownBy(() -> useCase.execute(GenerateSourceContextCommand.of(sourceId)))
-                    .isInstanceOf(RuntimeException.class)
-                    .hasMessageContaining(sourceId.toString())
-                    .hasMessageContaining("Source not found");
-
-            // Verify no downstream operations when source fails
-            verifyNoInteractions(chunkRepository, embeddingProvider, tripleExtractor);
-        }
-
-        @Test
-        @DisplayName("skips processing when no unprocessed chunks exist")
-        void skipsProcessingWhenNoChunks() {
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of());
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            verifyNoInteractions(embeddingProvider, tripleExtractor, tripleRepository);
-            verify(chunkRepository, never()).save(any(Chunk.class));
-            // knowledgeGraphStore.savePassages() is still called with empty list
-            verify(knowledgeGraphStore).savePassages(List.of(), authorId);
-            verify(knowledgeGraphStore, never()).saveAllForChunk(any(UUID.class), any(UUID.class), anyList());
-        }
-
-        @Test
-        @DisplayName("throws IllegalStateException when source has no author")
-        void throwsExceptionWhenSourceHasNoAuthor() {
-            Source authorlessSource = new Source(sourceId, "Legacy", "content");
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(authorlessSource));
-
-            assertThatThrownBy(() -> useCase.execute(GenerateSourceContextCommand.of(sourceId)))
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("Source author is required");
-
-            verifyNoInteractions(chunkRepository, embeddingProvider, knowledgeGraphStore, tripleExtractor, tripleRepository);
-        }
+        assertThat(failed.getProcessingStatus()).isEqualTo(ChunkProcessingStatus.FAILED);
+        assertThat(completed.getProcessingStatus()).isEqualTo(ChunkProcessingStatus.COMPLETED);
+        verify(tripleExtractor, never()).extract("failed");
+        verify(tripleExtractor).extract("completed");
     }
 
-    // =========================================================================
-    // Chunk Embedding Phase
-    // =========================================================================
+    @Test
+    void executeClaimed_ignoresChunksOutsideSourceAndChunksNotProcessing() {
+        Chunk claimed = new Chunk(UUID.randomUUID(), source, "claimed", 0,
+                ChunkProcessingStatus.PROCESSING, null);
+        Chunk pending = chunk("pending", 1);
+        Source otherSource = new Source(UUID.randomUUID(), "Other", "content", authorId);
+        Chunk other = new Chunk(UUID.randomUUID(), otherSource, "other", 0,
+                ChunkProcessingStatus.PROCESSING, null);
+        when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
+        when(chunkRepository.findAllByIds(anyList())).thenReturn(List.of(claimed, pending, other));
+        when(embeddingProvider.embed("claimed")).thenReturn(new float[]{0.1f});
+        when(tripleExtractor.extract("claimed")).thenReturn(List.of(new Triple("A", "R", "B")));
+        when(embeddingProvider.embed(claimed.getId() + ":A-R-B")).thenReturn(new float[]{0.2f});
 
-    @Nested
-    @DisplayName("Chunk Embedding Phase")
-    class ChunkEmbeddingPhase {
+        useCase.executeClaimed(sourceId, List.of(claimed.getId(), pending.getId(), other.getId()));
 
-        @Test
-        @DisplayName("embeds each chunk's content")
-        void embedsChunkContent() {
-            Chunk first = chunk("first content", 0);
-            Chunk second = chunk("second content", 1);
-            float[] firstEmbedding = new float[]{0.1f, 0.2f};
-            float[] secondEmbedding = new float[]{0.3f, 0.4f};
-
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId))
-                    .thenReturn(List.of(first, second));
-            when(embeddingProvider.embed("first content")).thenReturn(firstEmbedding);
-            when(embeddingProvider.embed("second content")).thenReturn(secondEmbedding);
-            when(tripleExtractor.extract(anyString())).thenReturn(List.of());
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            assertThat(first.getEmbedding()).isEqualTo(firstEmbedding);
-            assertThat(second.getEmbedding()).isEqualTo(secondEmbedding);
-        }
-
-        @Test
-        @DisplayName("saves each chunk after embedding")
-        void savesChunksAfterEmbedding() {
-            Chunk chunk = chunk("content", 0);
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of(chunk));
-            when(embeddingProvider.embed("content")).thenReturn(new float[]{0.1f});
-            when(tripleExtractor.extract("content")).thenReturn(List.of());
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            // Save called twice: once in embedChunks, once in createContextForKnowledgeGraph
-            verify(chunkRepository, times(2)).save(chunk);
-        }
-
-        @Test
-        @DisplayName("calls embedding provider once per chunk")
-        void callsEmbeddingProviderOncePerChunk() {
-            Chunk first = chunk("first", 0);
-            Chunk second = chunk("second", 1);
-
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId))
-                    .thenReturn(List.of(first, second));
-            when(embeddingProvider.embed(anyString())).thenReturn(new float[]{0.1f});
-            when(tripleExtractor.extract(anyString())).thenReturn(List.of());
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            // Called twice: once for "first" chunk, once for "second" chunk (in embedChunks phase)
-            verify(embeddingProvider, times(2)).embed(anyString());
-        }
-
-        @Test
-        @DisplayName("stops before graph generation when a later chunk embedding fails")
-        void stopsBeforeGraphGenerationWhenChunkEmbeddingFails() {
-            Chunk first = chunk("first", 0);
-            Chunk second = chunk("second", 1);
-
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId))
-                    .thenReturn(List.of(first, second));
-            when(embeddingProvider.embed("first")).thenReturn(new float[]{0.1f});
-            when(embeddingProvider.embed("second"))
-                    .thenThrow(new RuntimeException("Second embedding failed"));
-
-            assertThatThrownBy(() -> useCase.execute(GenerateSourceContextCommand.of(sourceId)))
-                    .isInstanceOf(RuntimeException.class)
-                    .hasMessage("Second embedding failed");
-
-            assertThat(first.getEmbedding()).containsExactly(0.1f);
-            assertThat(first.isProcessed()).isFalse();
-            assertThat(second.getEmbedding()).isNull();
-            assertThat(second.isProcessed()).isFalse();
-            verify(chunkRepository).save(first);
-            verify(chunkRepository, never()).save(second);
-            verifyNoInteractions(knowledgeGraphStore, tripleExtractor, tripleRepository);
-        }
+        assertThat(claimed.getProcessingStatus()).isEqualTo(ChunkProcessingStatus.COMPLETED);
+        assertThat(pending.getProcessingStatus()).isEqualTo(ChunkProcessingStatus.PENDING);
+        verify(embeddingProvider, never()).embed("pending");
+        verify(embeddingProvider, never()).embed("other");
     }
 
-    // =========================================================================
-    // Knowledge Graph Generation Phase
-    // =========================================================================
-
-    @Nested
-    @DisplayName("Knowledge Graph Generation Phase")
-    class KnowledgeGraphGenerationPhase {
-
-        @Test
-        @DisplayName("saves passages for all chunks")
-        void savesPassages() {
-            Chunk chunk = chunk("content", 0);
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of(chunk));
-            when(embeddingProvider.embed("content")).thenReturn(new float[]{0.1f});
-            when(tripleExtractor.extract("content")).thenReturn(List.of());
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            verify(knowledgeGraphStore).savePassages(passageCaptor.capture(), eq(authorId));
-            List<Passage> savedPassages = passageCaptor.getValue();
-            assertThat(savedPassages).hasSize(1);
-            assertThat(savedPassages.getFirst().chunkId()).isEqualTo(chunk.getId());
-        }
-
-        @Test
-        @DisplayName("extracts triples from chunk content")
-        void extractsTriplesFromContent() {
-            Chunk chunk = chunk("machine learning content", 0);
-            Triple triple = triple("neural network", "USES", "backpropagation");
-
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of(chunk));
-            when(embeddingProvider.embed(anyString())).thenReturn(new float[]{0.1f});
-            when(tripleExtractor.extract("machine learning content")).thenReturn(List.of(triple));
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            verify(tripleExtractor).extract("machine learning content");
-        }
-
-        @Test
-        @DisplayName("generates embeddings for each extracted triple")
-        void generatesTripleEmbeddings() {
-            Chunk chunk = chunk("content", 0);
-            Triple triple = triple("spring", "USES", "jpa");
-
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of(chunk));
-            when(embeddingProvider.embed("content")).thenReturn(new float[]{0.1f});
-            String tripleKey = chunk.getId() + ":spring-USES-jpa";
-            when(embeddingProvider.embed(tripleKey)).thenReturn(new float[]{0.7f, 0.8f});
-            when(tripleExtractor.extract("content")).thenReturn(List.of(triple));
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            verify(embeddingProvider).embed(tripleKey);
-        }
-
-        @Test
-        @DisplayName("saves extracted triples with embeddings to repository")
-        void savesExtractedTriplesToRepository() {
-            Chunk chunk = chunk("content", 0);
-            Triple triple = triple("spring", "USES", "jpa");
-            float[] tripleEmbedding = new float[]{0.7f, 0.8f};
-
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of(chunk));
-            when(embeddingProvider.embed("content")).thenReturn(new float[]{0.1f});
-            String tripleKey = chunk.getId() + ":spring-USES-jpa";
-            when(embeddingProvider.embed(tripleKey)).thenReturn(tripleEmbedding);
-            when(tripleExtractor.extract("content")).thenReturn(List.of(triple));
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            verify(tripleRepository).saveAll(tripleExtractedCaptor.capture());
-            List<TripleExtracted> saved = tripleExtractedCaptor.getValue();
-
-            assertThat(saved).hasSize(1);
-            TripleExtracted extracted = saved.getFirst();
-            assertThat(extracted.getKey()).isEqualTo(tripleKey);
-            assertThat(extracted.getSuject()).isEqualTo("spring");
-            assertThat(extracted.getPredicate()).isEqualTo("USES");
-            assertThat(extracted.getObject()).isEqualTo("jpa");
-            assertThat(extracted.getEmbedding()).isEqualTo(tripleEmbedding);
-        }
-
-        @Test
-        @DisplayName("saves knowledge triples to graph store by chunk")
-        void savesKnowledgeTriplesToGraph() {
-            Chunk chunk = chunk("content", 0);
-            Triple triple = triple("concept", "RELATES_TO", "other");
-
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of(chunk));
-            when(embeddingProvider.embed(anyString())).thenReturn(new float[]{0.1f});
-            when(tripleExtractor.extract("content")).thenReturn(List.of(triple));
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            verify(knowledgeGraphStore).saveAllForChunk(eq(chunk.getId()), eq(authorId), knowledgeTripleCaptor.capture());
-            List<KnowledgeTriple> saved = knowledgeTripleCaptor.getValue();
-
-            assertThat(saved).hasSize(1);
-            assertThat(saved.getFirst().passage().chunkId()).isEqualTo(chunk.getId());
-        }
-
-        @Test
-        @DisplayName("handles empty triple extraction gracefully")
-        void handlesEmptyTripleExtraction() {
-            Chunk chunk = chunk("content", 0);
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of(chunk));
-            when(embeddingProvider.embed("content")).thenReturn(new float[]{0.1f});
-            when(tripleExtractor.extract("content")).thenReturn(List.of());
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            verify(tripleRepository).saveAll(tripleExtractedCaptor.capture());
-            assertThat(tripleExtractedCaptor.getValue()).isEmpty();
-
-            verify(knowledgeGraphStore).saveAllForChunk(eq(chunk.getId()), eq(authorId), knowledgeTripleCaptor.capture());
-            assertThat(knowledgeTripleCaptor.getValue()).isEmpty();
-        }
-
-        @Test
-        @DisplayName("marks chunks as processed after extraction")
-        void marksChunksAsProcessed() {
-            Chunk chunk = chunk("content", 0);
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of(chunk));
-            when(embeddingProvider.embed("content")).thenReturn(new float[]{0.1f});
-            when(tripleExtractor.extract("content")).thenReturn(List.of());
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            assertThat(chunk.isProcessed()).isTrue();
-        }
-
-        @Test
-        @DisplayName("marks chunk as processed only after triples and graph relationships are saved")
-        void marksChunkAsProcessedOnlyAfterTripleAndGraphPersistence() {
-            Chunk chunk = chunk("content", 0);
-            Triple triple = triple("spring", "USES", "jpa");
-
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of(chunk));
-            when(embeddingProvider.embed("content")).thenReturn(new float[]{0.1f});
-            when(embeddingProvider.embed(chunk.getId() + ":spring-USES-jpa")).thenReturn(new float[]{0.2f});
-            when(tripleExtractor.extract("content")).thenReturn(List.of(triple));
-            doAnswer(invocation -> {
-                assertThat(chunk.isProcessed()).isFalse();
-                return null;
-            }).when(tripleRepository).saveAll(anyList());
-            doAnswer(invocation -> {
-                assertThat(chunk.isProcessed()).isFalse();
-                return null;
-            }).when(knowledgeGraphStore).saveAllForChunk(eq(chunk.getId()), eq(authorId), anyList());
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            assertThat(chunk.isProcessed()).isTrue();
-            var inOrder = inOrder(tripleRepository, knowledgeGraphStore, chunkRepository);
-            inOrder.verify(tripleRepository).saveAll(anyList());
-            inOrder.verify(knowledgeGraphStore).saveAllForChunk(eq(chunk.getId()), eq(authorId), anyList());
-            inOrder.verify(chunkRepository).save(chunk);
-        }
-    }
-
-    // =========================================================================
-    // Integration & Ordering Tests
-    // =========================================================================
-
-    @Nested
-    @DisplayName("Integration & Execution Order")
-    class IntegrationTests {
-
-        @Test
-        @DisplayName("executes operations in correct order: embed -> graph generation -> mark processed")
-        void executesInCorrectOrder() {
-            Chunk chunk = chunk("content", 0);
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of(chunk));
-            when(embeddingProvider.embed("content")).thenReturn(new float[]{0.1f});
-            when(tripleExtractor.extract("content")).thenReturn(List.of());
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            var inOrder = inOrder(
-                    chunkRepository,
-                    embeddingProvider,
-                    knowledgeGraphStore,
-                    tripleExtractor,
-                    tripleRepository
-            );
-
-            // 1. Embedding provider called for chunk content
-            inOrder.verify(embeddingProvider).embed("content");
-            // 2. First save after embedding
-            inOrder.verify(chunkRepository).save(chunk);
-            // 3. Graph operations (passages saved)
-            inOrder.verify(knowledgeGraphStore).savePassages(anyList(), eq(authorId));
-            // 4. Graph operations (triples saved)
-            inOrder.verify(tripleRepository).saveAll(anyList());
-            inOrder.verify(knowledgeGraphStore).saveAllForChunk(any(UUID.class), eq(authorId), anyList());
-            // 5. Second save after marking processed
-            inOrder.verify(chunkRepository).save(chunk);
-        }
-
-        @Test
-        @DisplayName("processes multiple chunks independently")
-        void processesMultipleChunksIndependently() {
-            Chunk first = chunk("first content", 0);
-            Chunk second = chunk("second content", 1);
-
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId))
-                    .thenReturn(List.of(first, second));
-            when(embeddingProvider.embed("first content")).thenReturn(new float[]{0.1f});
-            when(embeddingProvider.embed("second content")).thenReturn(new float[]{0.2f});
-            when(tripleExtractor.extract("first content")).thenReturn(List.of());
-            when(tripleExtractor.extract("second content")).thenReturn(List.of());
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            // Verify both chunks processed
-            verify(knowledgeGraphStore, times(2)).saveAllForChunk(any(UUID.class), eq(authorId), anyList());
-            verify(chunkRepository, times(4)).save(any(Chunk.class)); // 2x per chunk
-        }
-
-        @Test
-        @DisplayName("saves passages once for all chunks")
-        void savesPassagesOnceForAllChunks() {
-            Chunk first = chunk("first", 0);
-            Chunk second = chunk("second", 1);
-
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId))
-                    .thenReturn(List.of(first, second));
-            when(embeddingProvider.embed(anyString())).thenReturn(new float[]{0.1f});
-            when(tripleExtractor.extract(anyString())).thenReturn(List.of());
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            verify(knowledgeGraphStore, times(1)).savePassages(passageCaptor.capture(), eq(authorId));
-            assertThat(passageCaptor.getValue()).hasSize(2);
-        }
-    }
-
-    // =========================================================================
-    // Error Handling & Edge Cases
-    // =========================================================================
-
-    @Nested
-    @DisplayName("Error Handling & Edge Cases")
-    class ErrorHandlingTests {
-
-        @Test
-        @DisplayName("propagates embedding provider exceptions")
-        void propagatesEmbeddingException() {
-            Chunk chunk = chunk("content", 0);
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of(chunk));
-            when(embeddingProvider.embed("content"))
-                    .thenThrow(new RuntimeException("Embedding service unavailable"));
-
-            assertThatThrownBy(() -> useCase.execute(GenerateSourceContextCommand.of(sourceId)))
-                    .isInstanceOf(RuntimeException.class)
-                    .hasMessage("Embedding service unavailable");
-        }
-
-        @Test
-        @DisplayName("propagates triple embedding exceptions without saving triples or marking chunks")
-        void propagatesTripleEmbeddingExceptionWithoutPersistingTriplesOrMarkingChunks() {
-            Chunk first = chunk("first", 0);
-            Chunk second = chunk("second", 1);
-            Triple triple = triple("A", "RELATES_TO", "B");
-
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId))
-                    .thenReturn(List.of(first, second));
-            when(embeddingProvider.embed("first")).thenReturn(new float[]{0.1f});
-            when(embeddingProvider.embed("second")).thenReturn(new float[]{0.2f});
-            when(tripleExtractor.extract("first")).thenReturn(List.of(triple));
-            when(embeddingProvider.embed(first.getId() + ":A-RELATES_TO-B"))
-                    .thenThrow(new RuntimeException("Triple embedding failed"));
-
-            assertThatThrownBy(() -> useCase.execute(GenerateSourceContextCommand.of(sourceId)))
-                    .isInstanceOf(RuntimeException.class)
-                    .hasMessage("Triple embedding failed");
-
-            assertThat(first.isProcessed()).isFalse();
-            assertThat(second.isProcessed()).isFalse();
-            verify(knowledgeGraphStore).savePassages(passageCaptor.capture(), eq(authorId));
-            assertThat(passageCaptor.getValue())
-                    .extracting(Passage::chunkId)
-                    .containsExactly(first.getId(), second.getId());
-            verify(tripleRepository, never()).saveAll(anyList());
-            verify(knowledgeGraphStore, never()).saveAllForChunk(any(UUID.class), any(UUID.class), anyList());
-            verify(tripleExtractor, never()).extract("second");
-            verify(chunkRepository, times(1)).save(first);
-            verify(chunkRepository, times(1)).save(second);
-        }
-
-        @Test
-        @DisplayName("propagates triple extraction exceptions")
-        void propagatesExtractionException() {
-            Chunk chunk = chunk("content", 0);
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of(chunk));
-            when(embeddingProvider.embed("content")).thenReturn(new float[]{0.1f});
-            when(tripleExtractor.extract("content"))
-                    .thenThrow(new RuntimeException("Triple extraction failed"));
-
-            assertThatThrownBy(() -> useCase.execute(GenerateSourceContextCommand.of(sourceId)))
-                    .isInstanceOf(RuntimeException.class)
-                    .hasMessage("Triple extraction failed");
-        }
-
-        @Test
-        @DisplayName("propagates repository exceptions")
-        void propagatesRepositoryException() {
-            when(sourceRepository.findById(sourceId))
-                    .thenThrow(new RuntimeException("Database connection failed"));
-
-            assertThatThrownBy(() -> useCase.execute(GenerateSourceContextCommand.of(sourceId)))
-                    .isInstanceOf(RuntimeException.class)
-                    .hasMessage("Database connection failed");
-        }
-
-        @Test
-        @DisplayName("handles multiple triples per chunk")
-        void handlesMultipleTriplesPerChunk() {
-            Chunk chunk = chunk("content", 0);
-            List<Triple> triples = List.of(
-                    triple("A", "R1", "B"),
-                    triple("B", "R2", "C"),
-                    triple("C", "R3", "D")
-            );
-
-            when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
-            when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of(chunk));
-            when(embeddingProvider.embed("content")).thenReturn(new float[]{0.1f});
-            when(embeddingProvider.embed(chunk.getId() + ":A-R1-B")).thenReturn(new float[]{0.5f});
-            when(embeddingProvider.embed(chunk.getId() + ":B-R2-C")).thenReturn(new float[]{0.6f});
-            when(embeddingProvider.embed(chunk.getId() + ":C-R3-D")).thenReturn(new float[]{0.7f});
-            when(tripleExtractor.extract("content")).thenReturn(triples);
-
-            useCase.execute(GenerateSourceContextCommand.of(sourceId));
-
-            verify(tripleRepository).saveAll(tripleExtractedCaptor.capture());
-            assertThat(tripleExtractedCaptor.getValue()).hasSize(3);
-
-            verify(knowledgeGraphStore).saveAllForChunk(eq(chunk.getId()), eq(authorId), knowledgeTripleCaptor.capture());
-            assertThat(knowledgeTripleCaptor.getValue()).hasSize(3);
-        }
+    @Test
+    void execute_withNoPendingChunksDoesNoProcessingWork() {
+        when(sourceRepository.findById(sourceId)).thenReturn(Optional.of(source));
+        when(chunkRepository.findAllNotProcessedBySourceId(sourceId)).thenReturn(List.of());
+
+        useCase.execute(GenerateSourceContextCommand.of(sourceId));
+
+        verifyNoInteractions(embeddingProvider, tripleExtractor, knowledgeGraphStore, tripleRepository);
+        verify(chunkRepository, never()).save(any());
     }
 }

--- a/src/test/java/com/kairos/module/context_engine/use_case/RetrySourceContextUseCaseTest.java
+++ b/src/test/java/com/kairos/module/context_engine/use_case/RetrySourceContextUseCaseTest.java
@@ -1,0 +1,108 @@
+package com.kairos.module.context_engine.use_case;
+
+import com.kairos.module.context_engine.application.use_case.RetrySourceContextUseCase;
+import com.kairos.module.context_engine.domain.event.RetrySourceContextEvent;
+import com.kairos.module.context_engine.domain.exception.SourceRetryConflictException;
+import com.kairos.module.context_engine.domain.model.content.Chunk;
+import com.kairos.module.context_engine.domain.model.content.ChunkProcessingStatus;
+import com.kairos.module.context_engine.domain.model.content.Source;
+import com.kairos.module.context_engine.domain.port.event.SourceEventPublisher;
+import com.kairos.module.context_engine.domain.port.repository.ChunkRepository;
+import com.kairos.module.context_engine.domain.port.repository.SourceRepository;
+import com.kairos.share.security.context.RequestContext;
+import com.kairos.share.security.context.RequestContextProvider;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RetrySourceContextUseCaseTest {
+
+    @Mock SourceRepository sourceRepository;
+    @Mock ChunkRepository chunkRepository;
+    @Mock SourceEventPublisher eventPublisher;
+    @Mock RequestContextProvider requestContextProvider;
+    @InjectMocks RetrySourceContextUseCase useCase;
+
+    private UUID sourceId;
+    private UUID userId;
+    private Source source;
+
+    @BeforeEach
+    void setUp() {
+        sourceId = UUID.randomUUID();
+        userId = UUID.randomUUID();
+        source = new Source(sourceId, "Source", "content", userId);
+        when(requestContextProvider.getRequestContext())
+                .thenReturn(new RequestContext(userId, "user@example.com", List.of()));
+    }
+
+    @Test
+    void execute_claimsOnlyFailedChunksAndPublishesRetry() {
+        Chunk failed = new Chunk(UUID.randomUUID(), source, "failed", 0,
+                ChunkProcessingStatus.FAILED, null);
+        when(sourceRepository.findByIdAndAuthorIdForUpdate(sourceId, userId)).thenReturn(Optional.of(source));
+        when(chunkRepository.findAllBySourceIdAndStatus(sourceId, ChunkProcessingStatus.PROCESSING))
+                .thenReturn(List.of());
+        when(chunkRepository.findAllBySourceIdAndStatus(sourceId, ChunkProcessingStatus.FAILED))
+                .thenReturn(List.of(failed));
+
+        useCase.execute(sourceId);
+
+        assertThat(failed.getProcessingStatus()).isEqualTo(ChunkProcessingStatus.PROCESSING);
+        ArgumentCaptor<RetrySourceContextEvent> event = ArgumentCaptor.forClass(RetrySourceContextEvent.class);
+        verify(eventPublisher).send(event.capture());
+        assertThat(event.getValue().chunkIds()).containsExactly(failed.getId());
+    }
+
+    @Test
+    void execute_hidesSourcesOwnedByAnotherUser() {
+        when(sourceRepository.findByIdAndAuthorIdForUpdate(sourceId, userId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.execute(sourceId))
+                .isInstanceOf(EntityNotFoundException.class);
+
+        verify(eventPublisher, never()).send(org.mockito.ArgumentMatchers.any(RetrySourceContextEvent.class));
+    }
+
+    @Test
+    void execute_rejectsConcurrentProcessing() {
+        Chunk processing = new Chunk(UUID.randomUUID(), source, "processing", 0,
+                ChunkProcessingStatus.PROCESSING, null);
+        when(sourceRepository.findByIdAndAuthorIdForUpdate(sourceId, userId)).thenReturn(Optional.of(source));
+        when(chunkRepository.findAllBySourceIdAndStatus(sourceId, ChunkProcessingStatus.PROCESSING))
+                .thenReturn(List.of(processing));
+
+        assertThatThrownBy(() -> useCase.execute(sourceId))
+                .isInstanceOf(SourceRetryConflictException.class)
+                .hasMessageContaining("already in progress");
+    }
+
+    @Test
+    void execute_rejectsSourceWithoutFailedChunks() {
+        when(sourceRepository.findByIdAndAuthorIdForUpdate(sourceId, userId)).thenReturn(Optional.of(source));
+        when(chunkRepository.findAllBySourceIdAndStatus(sourceId, ChunkProcessingStatus.PROCESSING))
+                .thenReturn(List.of());
+        when(chunkRepository.findAllBySourceIdAndStatus(sourceId, ChunkProcessingStatus.FAILED))
+                .thenReturn(List.of());
+
+        assertThatThrownBy(() -> useCase.execute(sourceId))
+                .isInstanceOf(SourceRetryConflictException.class)
+                .hasMessageContaining("no failed chunks");
+    }
+}


### PR DESCRIPTION
This pull request introduces a robust and user-facing retry mechanism for failed source chunk processing, along with improved chunk status tracking and progress reporting. The main focus is on allowing authenticated users to explicitly retry failed chunks, enhancing observability, and ensuring chunk processing is idempotent and resilient. The changes affect both code and documentation, clarifying the new retry behavior and updating the API surface.

**Retry and Recovery Improvements**
- Added a new `RetrySourceContextUseCase` class and supporting event (`RetrySourceContextEvent`) to enable explicit, authenticated retries of failed chunks via `POST /sources/{sourceId}/retry`. This prevents reprocessing completed chunks and guards against concurrent retries. [[1]](diffhunk://#diff-a44c772f0c2026a77aa0446682df5088c93b835b017c68b85ab186d102d28bf2R1-R51) [[2]](diffhunk://#diff-e4d4d6b74e4949e49b1fac2c840c51f63fc5b3178ee40f73f45f8d2551221fb7R1-R13) [[3]](diffhunk://#diff-56a66e5c803415cb7209262c27fea7c9b6506ad99c596c89be405f61589b952eR1-R8)
- Updated the `Chunk` model to use a new `ChunkProcessingStatus` enum, supporting `PENDING`, `PROCESSING`, `COMPLETED`, and `FAILED` states, with new methods for marking and querying status. [[1]](diffhunk://#diff-abcf32c548f1b7b059a05ad8e41fde179618858a3e98f06cce02b6bdaeaf704bL16-R36) [[2]](diffhunk://#diff-893d9f5776a8b8eaaf61c251959702af7711e1ba525bd15ca904a4774ef2026fR1-R8) [[3]](diffhunk://#diff-abcf32c548f1b7b059a05ad8e41fde179618858a3e98f06cce02b6bdaeaf704bL59-R69) [[4]](diffhunk://#diff-abcf32c548f1b7b059a05ad8e41fde179618858a3e98f06cce02b6bdaeaf704bL79-R97)
- Refactored `GenerateSourceContextUseCase` to process only claimed chunks, mark chunk status transitions explicitly, and handle failures gracefully by marking chunks as `FAILED` and logging errors. [[1]](diffhunk://#diff-d96fbdb395b1e19a2c0c442fa697167755084796b94d74a9e4bb364087486075R17-R25) [[2]](diffhunk://#diff-d96fbdb395b1e19a2c0c442fa697167755084796b94d74a9e4bb364087486075L40) [[3]](diffhunk://#diff-d96fbdb395b1e19a2c0c442fa697167755084796b94d74a9e4bb364087486075R51-L94) [[4]](diffhunk://#diff-d96fbdb395b1e19a2c0c442fa697167755084796b94d74a9e4bb364087486075L117-L129)

**Progress Reporting and Status Aggregation**
- Enhanced `SourceProgressUpload` to report chunk counts by processing state (pending, processing, completed, failed) and to compute an aggregate source status using a new `SourceProcessingStatus` enum. [[1]](diffhunk://#diff-076343499f57e905bea63d19696c157f04045d0601d869524a8fcdbe8e06be41L8-R32) [[2]](diffhunk://#diff-042171b8e2d2940bbd34ddc5d00a6a03bab003d4545b51fca911781e2335faf8R1-R8)

**Documentation and API Updates**
- Updated the documentation (`README.md`, `docs/operations.md`) to describe the new retry endpoint, clarify recovery steps, and reflect the improved chunk and source status reporting. The public API now exposes `POST /sources/{sourceId}/retry`, and guidance is provided for handling failed chunks. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R74) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L205-R205) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R265) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L449-R450) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L459-R460) [[6]](diffhunk://#diff-ad74991b96593fdee570962fc5b1e319080abd55e16614f556f74b7de8fd02d1L60-R60)

These changes together make chunk processing more transparent and reliable for users and operators, while preventing accidental reprocessing and supporting better operational recovery.