### PR TITLE
#87 feat: implement terraform with bootstrap fundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,18 @@ build/
 
 ### VS Code ###
 .vscode/
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+*.tfvars
+*.tfvars.json
+!*.tfvars.example
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/infra/terraform/bootstrap/README.md
+++ b/infra/terraform/bootstrap/README.md
@@ -1,0 +1,39 @@
+# Bootstrap AWS do Kairos
+
+Este módulo cria somente a fundação compartilhada do Terraform: o bucket S3 protegido para state e um Budget mensal. Ele começa com state local porque o bucket ainda não existe.
+
+## Pré-requisitos
+
+- Terraform entre 1.9 e 2.0;
+- AWS CLI autenticada com uma identidade administrativa não-root;
+- região e nome globalmente único para o bucket definidos;
+- MFA habilitado no root e Budget revisado antes do `apply`.
+
+## Execução
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# edite terraform.tfvars e substitua os valores de exemplo
+terraform init
+terraform fmt -check
+terraform validate
+terraform plan -out bootstrap.tfplan
+terraform apply bootstrap.tfplan
+```
+
+O primeiro `apply` deve ser revisado conscientemente. O bucket possui versionamento, criptografia SSE-S3, bloqueio de acesso público, ownership control, negação de transporte inseguro e proteção contra destruição pelo Terraform.
+
+## Próximo passo: migrar o state
+
+Depois que o bucket existir, inicialize o ambiente `dev` informando o bucket por configuração parcial:
+
+```bash
+cd ../environments/dev
+terraform init \
+  -backend-config="bucket=NOME_DO_BUCKET" \
+  -backend-config="region=REGIAO_ESCOLHIDA" \
+  -backend-config="key=kairos/dev/terraform.tfstate" \
+  -migrate-state
+```
+
+Não coloque credenciais, tokens, `terraform.tfvars` ou arquivos de state no Git.

--- a/infra/terraform/bootstrap/budget.tf
+++ b/infra/terraform/bootstrap/budget.tf
@@ -1,0 +1,31 @@
+resource "aws_budgets_budget" "monthly" {
+  name         = "kairos-monthly-${var.environment}"
+  budget_type  = "COST"
+  limit_amount = tostring(var.budget_limit)
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  dynamic "notification" {
+    for_each = length(var.budget_email_addresses) > 0 ? [1] : []
+
+    content {
+      comparison_operator        = "GREATER_THAN"
+      threshold                  = 80
+      threshold_type             = "PERCENTAGE"
+      notification_type          = "FORECASTED"
+      subscriber_email_addresses = var.budget_email_addresses
+    }
+  }
+
+  dynamic "notification" {
+    for_each = length(var.budget_email_addresses) > 0 ? [1] : []
+
+    content {
+      comparison_operator        = "GREATER_THAN"
+      threshold                  = 100
+      threshold_type             = "PERCENTAGE"
+      notification_type          = "ACTUAL"
+      subscriber_email_addresses = var.budget_email_addresses
+    }
+  }
+}

--- a/infra/terraform/bootstrap/outputs.tf
+++ b/infra/terraform/bootstrap/outputs.tf
@@ -1,0 +1,9 @@
+output "state_bucket_name" {
+  description = "Nome do bucket S3 do state."
+  value       = aws_s3_bucket.terraform_state.id
+}
+
+output "state_bucket_arn" {
+  description = "ARN do bucket S3 do state."
+  value       = aws_s3_bucket.terraform_state.arn
+}

--- a/infra/terraform/bootstrap/providers.tf
+++ b/infra/terraform/bootstrap/providers.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      project     = "kairos"
+      environment = var.environment
+      managed-by  = "terraform"
+      owner       = var.owner
+    }
+  }
+}

--- a/infra/terraform/bootstrap/state-bucket.tf
+++ b/infra/terraform/bootstrap/state-bucket.tf
@@ -1,0 +1,73 @@
+resource "aws_s3_bucket" "terraform_state" {
+  bucket        = var.state_bucket_name
+  force_destroy = false
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+data "aws_iam_policy_document" "terraform_state" {
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.terraform_state.arn,
+      "${aws_s3_bucket.terraform_state.arn}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+  policy = data.aws_iam_policy_document.terraform_state.json
+}

--- a/infra/terraform/bootstrap/terraform.tfvars.example
+++ b/infra/terraform/bootstrap/terraform.tfvars.example
@@ -1,0 +1,6 @@
+aws_region           = "us-east-1"
+state_bucket_name    = "kairos-terraform-state-change-me"
+budget_limit         = 10
+budget_email_addresses = ["you@example.com"]
+environment          = "dev"
+owner                = "Luca5Eckert"

--- a/infra/terraform/bootstrap/variables.tf
+++ b/infra/terraform/bootstrap/variables.tf
@@ -1,0 +1,33 @@
+variable "aws_region" {
+  description = "Região AWS escolhida para a fundação do Kairos."
+  type        = string
+}
+
+variable "state_bucket_name" {
+  description = "Nome globalmente único do bucket S3 que armazenará o state."
+  type        = string
+}
+
+variable "budget_limit" {
+  description = "Limite mensal do Budget em USD."
+  type        = number
+  default     = 10
+}
+
+variable "budget_email_addresses" {
+  description = "Destinatários dos alertas do Budget."
+  type        = list(string)
+  default     = []
+}
+
+variable "environment" {
+  description = "Ambiente ao qual a fundação se refere."
+  type        = string
+  default     = "dev"
+}
+
+variable "owner" {
+  description = "Responsável pelos recursos."
+  type        = string
+  default     = "Luca5Eckert"
+}

--- a/infra/terraform/bootstrap/versions.tf
+++ b/infra/terraform/bootstrap/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9.0, < 2.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/infra/terraform/environments/dev/README.md
+++ b/infra/terraform/environments/dev/README.md
@@ -1,0 +1,26 @@
+# Ambiente dev
+
+Este diretório ainda não cria VPC, EC2, EBS ou recursos da aplicação. Ele valida que o ambiente consegue usar o backend remoto e gerar um plano vazio/minimal.
+
+## Inicialização
+
+O backend S3 usa configuração parcial para não armazenar o nome do bucket no código:
+
+```bash
+terraform init \
+  -backend-config="bucket=NOME_DO_BUCKET" \
+  -backend-config="region=REGIAO_ESCOLHIDA" \
+  -backend-config="key=kairos/dev/terraform.tfstate"
+```
+
+Se houver state local existente, use `-migrate-state` após revisar a origem e o destino.
+
+## Validação
+
+```bash
+terraform fmt -check
+terraform validate
+terraform plan
+```
+
+O próximo recorte deverá adicionar a rede, o ECR, a IAM Role da EC2, a instância e o volume EBS.

--- a/infra/terraform/environments/dev/backend.tf
+++ b/infra/terraform/environments/dev/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    key          = "kairos/dev/terraform.tfstate"
+    use_lockfile = true
+    encrypt      = true
+  }
+}

--- a/infra/terraform/environments/dev/providers.tf
+++ b/infra/terraform/environments/dev/providers.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      project     = "kairos"
+      environment = "dev"
+      managed-by  = "terraform"
+      owner       = var.owner
+    }
+  }
+}

--- a/infra/terraform/environments/dev/terraform.tfvars.example
+++ b/infra/terraform/environments/dev/terraform.tfvars.example
@@ -1,0 +1,2 @@
+aws_region = "us-east-1"
+owner      = "Luca5Eckert"

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -1,0 +1,10 @@
+variable "aws_region" {
+  description = "Região AWS do ambiente dev."
+  type        = string
+}
+
+variable "owner" {
+  description = "Responsável pelo ambiente."
+  type        = string
+  default     = "Luca5Eckert"
+}

--- a/infra/terraform/environments/dev/versions.tf
+++ b/infra/terraform/environments/dev/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.9.0, < 2.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+  


### PR DESCRIPTION
This pull request introduces a new Terraform foundation for the Kairos project, establishing a secure and maintainable AWS environment. The main focus is on bootstrapping the shared infrastructure for Terraform state management and cost control, along with a minimal setup for the `dev` environment to validate remote backend usage. Key changes are grouped below:

---

**Terraform Bootstrap Foundation**

* Created a reusable Terraform module in `infra/terraform/bootstrap` to provision a secure S3 bucket for storing Terraform state, with versioning, encryption, public access blocking, ownership enforcement, and a policy to deny insecure transport. The bucket is protected from accidental deletion. (`state-bucket.tf`)
* Added a monthly AWS Budget resource with configurable alert thresholds and email notifications to monitor and control costs. (`budget.tf`)
* Defined input variables for region, bucket name, budget settings, environment, and owner, with example values provided. (`variables.tf`, `terraform.tfvars.example`) [[1]](diffhunk://#diff-26b023cc57b63c1bf907105b0b4a5febd2dbdcbd31c72df3e656a26766d17b7fR1-R33) [[2]](diffhunk://#diff-2b086156c5308ca89da7025c24ee9895a9ddb37cddb469b20ff99d8ad0966e33R1-R6)
* Outputs expose the bucket name and ARN for downstream use. (`outputs.tf`)
* Provider configuration applies default tags for resource traceability. (`providers.tf`)
* Documentation added to explain the bootstrapping process and next steps for state migration. (`README.md`)
* Pinned Terraform and AWS provider versions for reproducibility. (`versions.tf`)

**Dev Environment Setup**

* Initialized a minimal `dev` environment in `infra/terraform/environments/dev` that configures the remote S3 backend (using partial configuration), validates connectivity, and sets up provider defaults. (`backend.tf`, `providers.tf`, `variables.tf`, `terraform.tfvars.example`, `versions.tf`) [[1]](diffhunk://#diff-7bcfadb09652e9297fa2aa385e6d5d3c3a633949ad32bdc80e7f341fb64315bbR1-R7) [[2]](diffhunk://#diff-f43ab6acf30fdeff0009525f686b50f0c92d341a99a7f3c1d68d6d75c8c11427R1-R12) [[3]](diffhunk://#diff-5319473cf130ecce2858f7f08b6cfeee704fe7fd4f75b222f8909f11bb890807R1-R10) [[4]](diffhunk://#diff-409a1fd306c3c249d797e685210de7bba88a4ff0b3db06814d4a5d5a212eb2d4R1-R2) [[5]](diffhunk://#diff-3913fbdc8f949dc76d5ab30e03539efd2ca60b6d9619f9b9cea4aaf00a03ffb2R1-R12)
* Added documentation for initializing and validating the `dev` environment, with guidance on backend migration and next implementation steps. (`README.md`)

---

These changes lay the groundwork for secure, auditable, and cost-controlled Terraform operations in AWS, and prepare the project for future infrastructure expansion.