### PR TITLE
#89 feat: implement basic aws infrastructure in dev environment

### DIFF
--- a/infra/terraform/environments/dev/.terraform.lock.hcl
+++ b/infra/terraform/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.57.1"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:WXndu9uKvbnmspexcbki89ZuGLt2SUyAfZ5GgQUm+QU=",
+    "zh:2d29e22480a81c21fb3f2fd52f9bd3ca4a82c37f3bb1b1036e881e42cddc75a1",
+    "zh:33aeb08e9973199b30f8a8e48a58dc67cfb6e32879f7a1c05c521899fe718f53",
+    "zh:37b7f977a7e7d45ad11d42958bc264873fb34573eee925915038ea05607abc9e",
+    "zh:41ebdcf4bcd073a01d58505a5f5118b85668de357d2d9f266926923e817a1842",
+    "zh:43093dfc3559c2c0467c92f48b29ae0221d52e912fce03dd77abd90806fdcc7d",
+    "zh:63b4252933e828d3590c0c64b827ec0f8955aa52df719fe67f45a846111fccc4",
+    "zh:7473b036e9f8167c7a09e4865de95d07922eae6a612b94e819d44c87ba5298de",
+    "zh:783c73e66bf50a74983803e1ec6d6237bae2891f9d4fd4824cfd5350121552ae",
+    "zh:83681e1d8d002048b76d7144cb96c8c8501dc973d1fee41b7579a46ad9eb04c2",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b08b4168d4e2a81badbbe65d95f692ed3292c2b71cd00b9889a3bb7cf54c1188",
+    "zh:b4320ca25f4f67beebcbd6563ece2e490bd9dcb0a7e59b5d7a437ddaf53768ed",
+    "zh:d7f99254d6e05bac3dffae9b437c47cd807b4e66d941e56364be0a28ead418bd",
+    "zh:e433e91689758a341c91840cc7b5d3a3c5089004766d20659d57199b88ad8a5f",
+    "zh:e4c5a9b0f96a5fe2b5ed5592d4c2ac33240cf5308bcb14e52d6f2e0eb183a014",
+    "zh:fc4b554ae98e40e3ab6878ec9501ba2b05213d30668ee357d48b207993ffbe03",
+  ]
+}

--- a/infra/terraform/environments/dev/README.md
+++ b/infra/terraform/environments/dev/README.md
@@ -1,26 +1,88 @@
-# Ambiente dev
+# Ambiente AWS dev
 
-Este diretório ainda não cria VPC, EC2, EBS ou recursos da aplicação. Ele valida que o ambiente consegue usar o backend remoto e gerar um plano vazio/minimal.
+Este root module cria a infraestrutura minima do Kairos: VPC com uma subnet publica, ECR, identidade de runtime, uma EC2 Amazon Linux 2023, Elastic IP e um EBS de dados montado em `/srv/kairos`. Ele nao executa os containers da aplicacao.
 
-## Inicialização
+## Decisoes
 
-O backend S3 usa configuração parcial para não armazenar o nome do bucket no código:
+- A subnet unica fica, por padrao, na zona `a` da regiao. Defina `availability_zone` explicitamente quando essa zona nao estiver disponivel na conta.
+- A EC2 usa Amazon Linux 2023, obtida por filtro controlado de AMIs oficiais da Amazon.
+- `t3.medium` (4 GiB) e a hipotese economica inicial, mas tem pouca margem para JVM, ONNX, PostgreSQL e Neo4j GDS. `t3.large` (8 GiB) e a opcao recomendada para o primeiro runtime completo. CPU, memoria e disco devem ser medidos depois do deploy.
+- Um Elastic IP fornece endereco estavel antes da futura configuracao de DNS e HTTPS.
+- O EBS `gp3` de 50 GiB e independente da EC2. O attachment nao o apaga quando a instancia e substituida. Entretanto, `terraform destroy` inclui o volume: crie um snapshot e remova o volume do state quando os dados precisarem sobreviver a destruicao completa do ambiente.
+- A saida permite HTTPS para ECR, SSM, Gemini e atualizacoes, SMTP com TLS nas portas 465/587 e DNS somente para o resolver da VPC. Nao existem NAT Gateway ou VPC endpoints; restricao por destino exige endpoints/proxy e pertence a um recorte posterior.
+- As portas publicas de entrada sao somente 80 e 443. Nao ha SSH, e 8080, 5432, 7474 e 7687 nao sao expostas.
+- Participar do grupo `docker` equivale, na pratica, a ter privilegio de root. Somente o usuario operacional `kairos` e adicionado.
+
+## Inicializacao e plano
+
+O backend usa S3 com lockfile nativo. O bucket permanece como configuracao parcial e nunca deve ser gravado em arquivos versionados:
 
 ```bash
+cp terraform.tfvars.example terraform.tfvars
 terraform init \
   -backend-config="bucket=NOME_DO_BUCKET" \
-  -backend-config="region=REGIAO_ESCOLHIDA" \
-  -backend-config="key=kairos/dev/terraform.tfstate"
+  -backend-config="region=us-east-1"
+terraform fmt -check -recursive ../../
+terraform validate
+terraform plan -out dev.tfplan
+terraform show dev.tfplan
 ```
 
-Se houver state local existente, use `-migrate-state` após revisar a origem e o destino.
+Revise especialmente substituicoes, destruicoes, o limite de 20 imagens da lifecycle policy do ECR e o custo antes do `apply`. Tags de release devem ser o SHA completo do commit; `latest` nao e uma identidade de release nem de rollback. Como os repositorios sao imutaveis, uma tag publicada nao pode ser sobrescrita.
 
-## Validação
+## Custo antes do apply
+
+Estimativa registrada em 2026-08-01 para o padrao em `us-east-1`, 730 horas/mes, sem impostos, trafego, snapshots ou creditos gratuitos:
+
+| Recurso | Hipotese | Estimativa mensal |
+| --- | --- | ---: |
+| EC2 | `t3.medium` a USD 0,0416/h | USD 30,37 |
+| EBS gp3 | 66 GiB (16 root + 50 data) a USD 0,08/GiB-mes, no baseline | USD 5,28 |
+| Elastic IP | 1 IPv4 a USD 0,005/h | USD 3,65 |
+| ECR | variavel, USD 0,10/GB-mes | USD 0,10 por GB |
+| **Base, antes do ECR** | | **USD 39,30/mes** |
+
+Com `t3.large`, a base sobe para aproximadamente USD 69,66/mes. As referencias sao as paginas AWS para [EC2 T3](https://docs.aws.amazon.com/prescriptive-guidance/latest/optimize-costs-microsoft-workloads/right-size-selection.html), [EBS gp3](https://aws.amazon.com/ebs/general-purpose/), [IPv4 publico](https://aws.amazon.com/vpc/pricing/) e [ECR](https://aws.amazon.com/ecr/pricing/). Consulte novamente a calculadora imediatamente antes do `apply`, pois precos variam.
+
+Uma EC2 ligada continuamente domina o custo. Parar a EC2 interrompe compute, mas EBS, ECR e IPv4 alocado continuam cobrados. O Budget da fundacao e apenas alerta e nao bloqueia gastos.
+
+## Validacao apos apply
+
+Obtenha os IDs com `terraform output` e confira o node no Systems Manager. Nao e criada key pair:
 
 ```bash
-terraform fmt -check
-terraform validate
-terraform plan
+aws ssm describe-instance-information \
+  --filters Key=InstanceIds,Values=$(terraform output -raw instance_id)
+aws ssm start-session --target $(terraform output -raw instance_id)
 ```
 
-O próximo recorte deverá adicionar a rede, o ECR, a IAM Role da EC2, a instância e o volume EBS.
+Na sessao, valide bootstrap, Docker, mount e reinicio:
+
+```bash
+sudo tail -n 200 /var/log/kairos-bootstrap.log
+docker version
+docker compose version
+findmnt /srv/kairos
+ls -ld /srv/kairos /srv/kairos/{postgres,neo4j,runtime,backups,logs}
+sudo reboot
+```
+
+Apos o reboot, abra nova sessao e repita `findmnt /srv/kairos`. Para testar a role sem credenciais estaticas, publique previamente uma imagem descartavel com tag SHA e execute no host:
+
+```bash
+aws ecr get-login-password --region REGIAO | \
+  docker login --username AWS --password-stdin ID_DA_CONTA.dkr.ecr.REGIAO.amazonaws.com
+docker pull URL_DO_REPOSITORIO@sha256:DIGEST
+```
+
+O pull deve funcionar. Um push deve falhar, pois a role nao possui `ecr:PutImage` nem permissoes de upload. O host tambem nao recebe acesso ao bucket de state, Secrets Manager, Parameter Store ou APIs de infraestrutura.
+
+## Reexecucao e recuperacao
+
+O bootstrap fica em `/var/lib/cloud/instance/scripts/part-001` e registra logs em `/var/log/kairos-bootstrap.log`. Ele pode ser reexecutado com `sudo bash` nesse arquivo. O script detecta filesystem existente, usa UUID no `/etc/fstab`, evita entradas duplicadas e preserva os dados.
+
+Para substituir a EC2 com dados reais: tire snapshot do EBS, confira o plano, mantenha o volume fora de qualquer destruicao planejada e somente entao associe-o ao novo host. O modulo usa o ID do volume para descobri-lo, inclusive quando Nitro apresenta o disco como NVMe. Nunca teste substituicao destrutiva sem snapshot ou dados descartaveis.
+
+## Destruicao segura
+
+Antes de destruir, revise `terraform plan -destroy`. Se os dados forem descartaveis, aplique o destroy normalmente. Se precisarem sobreviver, crie e valide um snapshot e retire o EBS do gerenciamento deste state antes do destroy. EBS persistente nao e backup. Verifique tambem imagens de rollback que serao removidas junto com os repositorios ECR.

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -1,0 +1,45 @@
+locals {
+  name              = "kairos-dev"
+  availability_zone = coalesce(var.availability_zone, "${var.aws_region}a")
+  ecr_repositories  = toset(["kairos/app", "kairos/neo4j"])
+}
+
+module "network" {
+  source = "../../modules/network"
+
+  name               = local.name
+  vpc_cidr           = var.vpc_cidr
+  public_subnet_cidr = var.public_subnet_cidr
+  availability_zone  = local.availability_zone
+}
+
+module "ecr" {
+  source = "../../modules/ecr"
+
+  repository_names   = local.ecr_repositories
+  max_release_images = var.ecr_max_release_images
+}
+
+module "iam_instance" {
+  source = "../../modules/iam-instance"
+
+  name                = "${local.name}-host"
+  ecr_repository_arns = module.ecr.repository_arns
+}
+
+module "compute" {
+  source = "../../modules/compute"
+
+  name                   = "${local.name}-host"
+  availability_zone      = local.availability_zone
+  subnet_id              = module.network.public_subnet_id
+  security_group_id      = module.network.security_group_id
+  instance_profile_name  = module.iam_instance.instance_profile_name
+  instance_type          = var.instance_type
+  root_volume_size       = var.root_volume_size
+  data_volume_size       = var.data_volume_size
+  data_volume_type       = var.data_volume_type
+  data_volume_iops       = var.data_volume_iops
+  data_volume_throughput = var.data_volume_throughput
+  docker_compose_version = var.docker_compose_version
+}

--- a/infra/terraform/environments/dev/outputs.tf
+++ b/infra/terraform/environments/dev/outputs.tf
@@ -1,0 +1,44 @@
+output "vpc_id" {
+  description = "ID da VPC dedicada."
+  value       = module.network.vpc_id
+}
+
+output "public_subnet_id" {
+  description = "ID da subnet publica."
+  value       = module.network.public_subnet_id
+}
+
+output "security_group_id" {
+  description = "ID do security group da EC2."
+  value       = module.network.security_group_id
+}
+
+output "instance_id" {
+  description = "ID da EC2."
+  value       = module.compute.instance_id
+}
+
+output "public_ip" {
+  description = "Elastic IP do host."
+  value       = module.compute.public_ip
+}
+
+output "data_volume_id" {
+  description = "ID do EBS persistente."
+  value       = module.compute.data_volume_id
+}
+
+output "app_ecr_repository_url" {
+  description = "URL do ECR da aplicacao."
+  value       = module.ecr.repository_urls["kairos/app"]
+}
+
+output "neo4j_ecr_repository_url" {
+  description = "URL do ECR do Neo4j."
+  value       = module.ecr.repository_urls["kairos/neo4j"]
+}
+
+output "instance_role_arn" {
+  description = "ARN da role exclusiva do runtime."
+  value       = module.iam_instance.role_arn
+}

--- a/infra/terraform/environments/dev/terraform.tfvars.example
+++ b/infra/terraform/environments/dev/terraform.tfvars.example
@@ -1,2 +1,7 @@
 aws_region = "us-east-1"
 owner      = "Luca5Eckert"
+
+# A zona deve pertencer a aws_region. Null seleciona a zona "a".
+availability_zone = "us-east-1a"
+instance_type     = "t3.medium"
+data_volume_size  = 50

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -8,3 +8,70 @@ variable "owner" {
   type        = string
   default     = "Luca5Eckert"
 }
+
+variable "availability_zone" {
+  description = "AZ da subnet e do volume. Null usa a zona 'a' da regiao."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "vpc_cidr" {
+  description = "CIDR da VPC dedicada."
+  type        = string
+  default     = "10.20.0.0/16"
+}
+
+variable "public_subnet_cidr" {
+  description = "CIDR da subnet publica unica."
+  type        = string
+  default     = "10.20.1.0/24"
+}
+
+variable "instance_type" {
+  description = "Tipo da EC2. t3.medium e a hipotese economica inicial de 4 GiB."
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "root_volume_size" {
+  description = "Tamanho do root volume gp3 em GiB."
+  type        = number
+  default     = 16
+}
+
+variable "data_volume_size" {
+  description = "Tamanho do volume persistente em GiB."
+  type        = number
+  default     = 50
+}
+
+variable "data_volume_type" {
+  description = "Tipo do volume persistente."
+  type        = string
+  default     = "gp3"
+}
+
+variable "data_volume_iops" {
+  description = "IOPS do volume gp3."
+  type        = number
+  default     = 3000
+}
+
+variable "data_volume_throughput" {
+  description = "Throughput do volume gp3 em MiB/s."
+  type        = number
+  default     = 125
+}
+
+variable "ecr_max_release_images" {
+  description = "Numero de imagens com tag mantidas por repositorio."
+  type        = number
+  default     = 20
+}
+
+variable "docker_compose_version" {
+  description = "Versao fixa do Docker Compose plugin instalada no host."
+  type        = string
+  default     = "2.39.1"
+}

--- a/infra/terraform/environments/dev/versions.tf
+++ b/infra/terraform/environments/dev/versions.tf
@@ -9,4 +9,4 @@ terraform {
   }
 }
 
-  
+

--- a/infra/terraform/modules/compute/bootstrap.sh.tftpl
+++ b/infra/terraform/modules/compute/bootstrap.sh.tftpl
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+exec > >(tee -a /var/log/kairos-bootstrap.log | logger -t kairos-bootstrap -s 2>/dev/console) 2>&1
+
+dnf install -y docker xfsprogs curl awscli2
+systemctl enable --now docker
+
+if ! rpm -q amazon-ssm-agent >/dev/null 2>&1; then
+  dnf install -y amazon-ssm-agent
+fi
+
+if ! id kairos >/dev/null 2>&1; then
+  useradd --create-home --shell /bin/bash kairos
+fi
+usermod -aG docker kairos
+
+install -d -m 0755 /usr/local/lib/docker/cli-plugins
+compose_arch="$(uname -m)"
+case "$compose_arch" in
+  x86_64) compose_arch=x86_64 ;;
+  aarch64) compose_arch=aarch64 ;;
+  *) echo "Unsupported architecture: $compose_arch"; exit 1 ;;
+esac
+compose_path=/usr/local/lib/docker/cli-plugins/docker-compose
+if ! "$compose_path" version 2>/dev/null | grep -q "v${docker_compose_version}"; then
+  curl --fail --location --retry 5 \
+    "https://github.com/docker/compose/releases/download/v${docker_compose_version}/docker-compose-linux-$compose_arch" \
+    --output "$compose_path"
+  chmod 0755 "$compose_path"
+fi
+
+volume_serial="${replace(data_volume_id, "-", "")}"
+data_device=""
+for attempt in $(seq 1 60); do
+  data_device="$(lsblk -ndo PATH,SERIAL | awk -v serial="$volume_serial" '$2 == serial {print $1; exit}')"
+  [ -n "$data_device" ] && break
+  sleep 5
+done
+[ -n "$data_device" ] || { echo "EBS data volume was not attached in time"; exit 1; }
+
+if ! blkid "$data_device" >/dev/null 2>&1; then
+  mkfs.xfs "$data_device"
+fi
+
+volume_uuid="$(blkid -s UUID -o value "$data_device")"
+install -d -m 0750 -o kairos -g kairos /srv/kairos
+fstab_entry="UUID=$volume_uuid /srv/kairos xfs defaults,nofail 0 2"
+grep -qE "^UUID=$volume_uuid[[:space:]]" /etc/fstab || printf '%s\n' "$fstab_entry" >> /etc/fstab
+mountpoint -q /srv/kairos || mount /srv/kairos
+
+for directory in postgres neo4j runtime backups logs; do
+  install -d -m 0750 -o kairos -g kairos "/srv/kairos/$directory"
+done
+chown kairos:kairos /srv/kairos
+chmod 0750 /srv/kairos
+
+systemctl enable amazon-ssm-agent
+systemctl restart amazon-ssm-agent
+
+docker version
+docker compose version

--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -1,0 +1,77 @@
+data "aws_ami" "amazon_linux_2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023*-kernel-6.1-x86_64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_ebs_volume" "data" {
+  availability_zone = var.availability_zone
+  encrypted         = true
+  size              = var.data_volume_size
+  type              = var.data_volume_type
+  iops              = var.data_volume_type == "gp3" ? var.data_volume_iops : null
+  throughput        = var.data_volume_type == "gp3" ? var.data_volume_throughput : null
+
+  tags = { Name = "${var.name}-data" }
+}
+
+resource "aws_instance" "this" {
+  ami                         = data.aws_ami.amazon_linux_2023.id
+  instance_type               = var.instance_type
+  availability_zone           = var.availability_zone
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = [var.security_group_id]
+  iam_instance_profile        = var.instance_profile_name
+  associate_public_ip_address = true
+  user_data_replace_on_change = true
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
+  root_block_device {
+    encrypted             = true
+    volume_size           = var.root_volume_size
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
+
+  user_data = templatefile("${path.module}/bootstrap.sh.tftpl", {
+    data_volume_id         = aws_ebs_volume.data.id
+    docker_compose_version = var.docker_compose_version
+  })
+
+  tags = { Name = var.name }
+}
+
+resource "aws_volume_attachment" "data" {
+  device_name = "/dev/sdf"
+  volume_id   = aws_ebs_volume.data.id
+  instance_id = aws_instance.this.id
+}
+
+resource "aws_eip" "this" {
+  domain   = "vpc"
+  instance = aws_instance.this.id
+  tags     = { Name = var.name }
+}

--- a/infra/terraform/modules/compute/outputs.tf
+++ b/infra/terraform/modules/compute/outputs.tf
@@ -1,0 +1,3 @@
+output "instance_id" { value = aws_instance.this.id }
+output "public_ip" { value = aws_eip.this.public_ip }
+output "data_volume_id" { value = aws_ebs_volume.data.id }

--- a/infra/terraform/modules/compute/variables.tf
+++ b/infra/terraform/modules/compute/variables.tf
@@ -1,0 +1,20 @@
+variable "name" { type = string }
+variable "availability_zone" { type = string }
+variable "subnet_id" { type = string }
+variable "security_group_id" { type = string }
+variable "instance_profile_name" { type = string }
+variable "instance_type" { type = string }
+variable "root_volume_size" { type = number }
+variable "data_volume_size" { type = number }
+variable "data_volume_type" { type = string }
+variable "docker_compose_version" { type = string }
+
+variable "data_volume_iops" {
+  type    = number
+  default = 3000
+}
+
+variable "data_volume_throughput" {
+  type    = number
+  default = 125
+}

--- a/infra/terraform/modules/ecr/main.tf
+++ b/infra/terraform/modules/ecr/main.tf
@@ -1,0 +1,46 @@
+resource "aws_ecr_repository" "this" {
+  for_each = var.repository_names
+
+  name                 = each.value
+  image_tag_mutability = "IMMUTABLE"
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  for_each   = aws_ecr_repository.this
+  repository = each.value.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Preserve the newest tagged releases for rollback"
+        selection = {
+          tagStatus      = "tagged"
+          tagPatternList = ["*"]
+          countType      = "imageCountMoreThan"
+          countNumber    = var.max_release_images
+        }
+        action = { type = "expire" }
+      },
+      {
+        rulePriority = 2
+        description  = "Remove stale untagged images"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 14
+        }
+        action = { type = "expire" }
+      }
+    ]
+  })
+}

--- a/infra/terraform/modules/ecr/outputs.tf
+++ b/infra/terraform/modules/ecr/outputs.tf
@@ -1,0 +1,7 @@
+output "repository_urls" {
+  value = { for name, repository in aws_ecr_repository.this : name => repository.repository_url }
+}
+
+output "repository_arns" {
+  value = [for repository in aws_ecr_repository.this : repository.arn]
+}

--- a/infra/terraform/modules/ecr/variables.tf
+++ b/infra/terraform/modules/ecr/variables.tf
@@ -1,0 +1,10 @@
+variable "repository_names" {
+  description = "Nomes dos repositorios privados."
+  type        = set(string)
+}
+
+variable "max_release_images" {
+  description = "Quantidade de imagens com tag preservadas para rollback."
+  type        = number
+  default     = 20
+}

--- a/infra/terraform/modules/iam-instance/main.tf
+++ b/infra/terraform/modules/iam-instance/main.tf
@@ -1,0 +1,48 @@
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  name               = var.name
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+data "aws_iam_policy_document" "ecr_pull" {
+  statement {
+    sid       = "EcrAuthentication"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "PullKairosImages"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+    resources = var.ecr_repository_arns
+  }
+}
+
+resource "aws_iam_role_policy" "ecr_pull" {
+  name   = "${var.name}-ecr-pull"
+  role   = aws_iam_role.this.id
+  policy = data.aws_iam_policy_document.ecr_pull.json
+}
+
+resource "aws_iam_instance_profile" "this" {
+  name = var.name
+  role = aws_iam_role.this.name
+}

--- a/infra/terraform/modules/iam-instance/outputs.tf
+++ b/infra/terraform/modules/iam-instance/outputs.tf
@@ -1,0 +1,2 @@
+output "instance_profile_name" { value = aws_iam_instance_profile.this.name }
+output "role_arn" { value = aws_iam_role.this.arn }

--- a/infra/terraform/modules/iam-instance/variables.tf
+++ b/infra/terraform/modules/iam-instance/variables.tf
@@ -1,0 +1,9 @@
+variable "name" {
+  description = "Nome da identidade da instancia."
+  type        = string
+}
+
+variable "ecr_repository_arns" {
+  description = "Repositorios dos quais o host pode baixar imagens."
+  type        = list(string)
+}

--- a/infra/terraform/modules/network/main.tf
+++ b/infra/terraform/modules/network/main.tf
@@ -1,0 +1,101 @@
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = { Name = "${var.name}-vpc" }
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+  tags   = { Name = "${var.name}-igw" }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_cidr
+  availability_zone       = var.availability_zone
+  map_public_ip_on_launch = true
+
+  tags = { Name = "${var.name}-public" }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = { Name = "${var.name}-public" }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_security_group" "instance" {
+  name        = "${var.name}-instance"
+  description = "Public HTTP/HTTPS only; no SSH or service database ports"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description = "Future HTTP to HTTPS redirect"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Future HTTPS proxy"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "HTTPS for ECR, SSM, Gemini and host updates"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "SMTP submission with STARTTLS"
+    from_port   = 587
+    to_port     = 587
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Implicit TLS SMTP"
+    from_port   = 465
+    to_port     = 465
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "DNS over UDP to the VPC resolver"
+    from_port   = 53
+    to_port     = 53
+    protocol    = "udp"
+    cidr_blocks = ["${cidrhost(var.vpc_cidr, 2)}/32"]
+  }
+
+  egress {
+    description = "DNS over TCP to the VPC resolver"
+    from_port   = 53
+    to_port     = 53
+    protocol    = "tcp"
+    cidr_blocks = ["${cidrhost(var.vpc_cidr, 2)}/32"]
+  }
+
+  tags = { Name = "${var.name}-instance" }
+}

--- a/infra/terraform/modules/network/outputs.tf
+++ b/infra/terraform/modules/network/outputs.tf
@@ -1,0 +1,3 @@
+output "vpc_id" { value = aws_vpc.this.id }
+output "public_subnet_id" { value = aws_subnet.public.id }
+output "security_group_id" { value = aws_security_group.instance.id }

--- a/infra/terraform/modules/network/variables.tf
+++ b/infra/terraform/modules/network/variables.tf
@@ -1,0 +1,19 @@
+variable "name" {
+  description = "Prefixo de nome dos recursos de rede."
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR da VPC."
+  type        = string
+}
+
+variable "public_subnet_cidr" {
+  description = "CIDR da subnet publica."
+  type        = string
+}
+
+variable "availability_zone" {
+  description = "Availability Zone da subnet publica unica."
+  type        = string
+}


### PR DESCRIPTION
This pull request introduces the initial infrastructure-as-code for the Kairos development environment using Terraform. It provisions a minimal but complete AWS environment, including networking, compute, persistent storage, ECR repositories, and IAM roles, with a focus on security, cost estimation, and operational clarity. The code is modular, parameterized, and ready for extension.

The most important changes are:

**Core Infrastructure Provisioning:**

* Added a new Terraform environment in `infra/terraform/environments/dev` that creates a VPC, a public subnet, an EC2 instance (Amazon Linux 2023), an Elastic IP, a persistent EBS volume, ECR repositories for the application and Neo4j, and all required IAM resources. All resources are parameterized for easy customization. [[1]](diffhunk://#diff-af74b4876a5462542711a77fcf5b1bfbe08fed962abc3717e1968bd9f8d4b1f5R1-R45) [[2]](diffhunk://#diff-762bbf55b88b5fd521c76173959698618fbd45be180d2c37532105a8b1741295R1-R77) [[3]](diffhunk://#diff-e35460085f9a02747228fd9915751a0d98c2b8bcebd86b57f7b3b187d2b9745aR1-R46) [[4]](diffhunk://#diff-b588eff6c526884920f728db97f91e33f2b2b025c95bdc3e1822be06ac450311R1-R48)

**Security and Access Control:**

* Configured the EC2 instance with a dedicated IAM role that allows only ECR image pulls and SSM access—no SSH or push permissions, and no access to the state bucket or other AWS APIs. Security groups expose only ports 80 and 443; internal ports and SSH are not open. [[1]](diffhunk://#diff-b588eff6c526884920f728db97f91e33f2b2b025c95bdc3e1822be06ac450311R1-R48) [[2]](diffhunk://#diff-af74b4876a5462542711a77fcf5b1bfbe08fed962abc3717e1968bd9f8d4b1f5R1-R45)

**Bootstrapping and Automation:**

* Implemented a robust `bootstrap.sh` script for the EC2 instance that installs Docker, Docker Compose (with architecture detection and version pinning), SSM agent, and mounts the EBS data volume to `/srv/kairos`, creating all necessary subdirectories with correct permissions. The script is idempotent and logs to `/var/log/kairos-bootstrap.log`.

**Outputs and Documentation:**

* Defined comprehensive Terraform outputs for all key resources (VPC, subnet, security group, instance, EBS, ECR URLs, IAM role) to facilitate inspection and integration. [[1]](diffhunk://#diff-1970101eb4e54f1884a979f40ee34755ccf61e0c9506558ed061a928e47477c9R1-R44) [[2]](diffhunk://#diff-bf98036f0b48b67b81ff543fd0e5bceab989e2b524490c06eb87d72153f3687fR1-R3) [[3]](diffhunk://#diff-33768f242e03a37a0e931158d994bcb295a0bd8c9f944fc2fbe4c12712ec2a2aR1-R7) [[4]](diffhunk://#diff-fdbcae5abfcd51dcfd8855fca8f04f9e56467f2b9353e84fd951d653fa0c02ccR1-R2)
* Overhauled the environment `README.md` with detailed explanations of architecture decisions, initialization steps, cost estimates, validation, and safe destruction procedures.

**Parameterization and Defaults:**

* Added and documented variables for all tunable parameters (e.g., instance type, volume sizes, AZ, Docker Compose version), with sensible defaults and examples. [[1]](diffhunk://#diff-5319473cf130ecce2858f7f08b6cfeee704fe7fd4f75b222f8909f11bb890807R11-R77) [[2]](diffhunk://#diff-409a1fd306c3c249d797e685210de7bba88a4ff0b3db06814d4a5d5a212eb2d4R3-R7) [[3]](diffhunk://#diff-138ff60acfc4460aad0bbba22f61c4fa8e8e1498f6778f662768dbfab822c3f0R1-R20) [[4]](diffhunk://#diff-10f31669bbee48f9310aeb017e52b5aced37ed09f27259c303a235558de43810R1-R10) [[5]](diffhunk://#diff-faba9cb06c8246ad0b7a05e6694c9e16e25fd6dbc9799b1c4551e58e50caa43aR1-R9)

These changes lay the foundation for a secure, reproducible, and maintainable AWS-based development environment for Kairos.