### PR TITLE
#94 feat: add api of history of questions/answer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,14 @@
 
 Before working on an issue, read [`docs/ai/issue-workflow.md`](docs/ai/issue-workflow.md). Follow its sequence and keep the change scoped to the issue.
 
+## Branch and commit discipline
+
+Issue work must never be performed directly on `main` or `master`. Before editing, inspect the checkout and create or switch to a dedicated branch named `feature/<issue-number>-<short-slug>` (for example, `feature/94-history-api`). Create the branch before running the issue preflight so the evidence records the correct branch.
+
+Commits are required for issue work. Make small, atomic commits after each coherent increment. Group implementation and its focused tests when they form one behavior; keep documentation, CI, and tooling changes in separate commits when they are independently reviewable. Stage explicit paths, never unrelated user files, and follow the repository's existing conventional commit format with the issue reference when appropriate. Do not leave issue changes uncommitted at delivery. Push only when the user authorizes publishing.
+
 After implementation, read [`docs/ai/documentation-policy.md`](docs/ai/documentation-policy.md) before deciding whether versioned documentation, an ADR, or an Obsidian note is needed.
 
 Use `scripts/ai/preflight.sh` to capture the issue, checkout state, commit conventions, and baseline. Use `scripts/ai/validate.sh` as the source of truth for the complete Maven validation. Keep `.ai-runs/` local, preserve unrelated working-tree changes, and add or update focused tests with implementation changes.
 
-Commits should be small, atomic, and follow the repository's existing conventional format. The final report must include the issue, files changed, tests and validation commands with results, documentation decision, known risks, and commit references.
+The final report must include the issue, branch, files changed, commit hashes, tests and validation commands with results, documentation decision, and known risks. Explicitly report any unrelated user-owned files left uncommitted.

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ If enrichment fails, the affected chunk is marked as `FAILED`, chunks already co
 
 ## Retrieval and history flow
 
-`POST /sources/search` is user-scoped from the request context. Every execution persists the question and an immutable answer snapshot, while the public response remains focused on ranked chunks and activated triples.
+`POST /sources/search` is user-scoped from the request context. Every execution persists the question and an immutable answer snapshot, while the public response remains focused on ranked chunks and activated triples. Pass an existing `questionId` to append a new immutable answer without overwriting earlier executions. The `/history/questions` and `/history/answers` endpoints expose those records with user-scoped pagination; detailed answers are served entirely from the stored JSONB snapshot.
 
 ```mermaid
 flowchart LR
@@ -233,8 +233,10 @@ These defaults are bound from `kairos.retrieval` and can be overridden through t
 | `recognition-seed-limit` | 10 | Maximum concept seeds selected from triple candidates |
 | `seed-min-score` | 0.45 | Minimum score required for a graph seed |
 | `seed-relative-threshold` | 0.85 | Relative score threshold applied to seed selection |
+| `history.default-page-size` | 20 | Default page size for history endpoints |
+| `history.max-page-size` | 100 | Maximum accepted page size for history endpoints |
 
-All Spring configuration options are documented in [docs/configuration.md](docs/configuration.md). The history model is implemented internally, but there is not yet a public endpoint for listing or reading historical questions and answers.
+All Spring configuration options are documented in [docs/configuration.md](docs/configuration.md). History responses use `content`, `page`, `size`, `totalElements`, `totalPages`, `first`, and `last`; list endpoints default to page `0`, size `20`, and reject sizes above the configurable maximum.
 
 ## Data locality and external processing
 
@@ -248,7 +250,7 @@ Do not submit sensitive content unless its processing by the configured Gemini p
 
 ## API
 
-All `/sources/**` endpoints require a valid JWT bearer token. Authentication endpoints are public.
+All `/sources/**` and `/history/**` endpoints require a valid JWT bearer token. Authentication endpoints are public.
 
 | Method | Path | Authentication | Description |
 | --- | --- | --- | --- |
@@ -256,7 +258,11 @@ All `/sources/**` endpoints require a valid JWT bearer token. Authentication end
 | `POST` | `/auth/confirm-email` | Public | Confirms a user and returns a JWT |
 | `POST` | `/auth/login` | Public | Authenticates by username or email and returns a JWT |
 | `POST` | `/sources` | JWT | Stores a source and starts asynchronous enrichment |
-| `POST` | `/sources/search` | JWT | Searches the authenticated user's graph-augmented knowledge base |
+| `POST` | `/sources/search` | JWT | Searches the authenticated user's graph-augmented knowledge base; accepts optional `questionId` to append a new answer |
+| `GET` | `/history/questions` | JWT | Lists the authenticated user's questions with pagination |
+| `GET` | `/history/questions/{questionId}` | JWT | Returns question metadata and execution counts |
+| `GET` | `/history/questions/{questionId}/answers` | JWT | Lists persisted answer summaries with pagination |
+| `GET` | `/history/answers/{answerId}` | JWT | Returns a complete immutable answer snapshot |
 | `GET` | `/sources/progress` | JWT | Lists source chunk progress for the authenticated user |
 | `POST` | `/sources/{sourceId}/retry` | JWT | Asynchronously retries only failed chunks owned by the authenticated user |
 
@@ -290,7 +296,7 @@ curl http://127.0.0.1:8081/sources/progress \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-Search the authenticated knowledge base after enrichment has processed the chunks:
+Search the authenticated knowledge base after enrichment has processed the chunks. To re-execute an existing question, include its `questionId` in the same body: `{"termQuery":"How do knowledge graphs improve retrieval?","questionId":"<question-id>"}`.
 
 ```bash
 curl -X POST http://127.0.0.1:8081/sources/search \
@@ -299,7 +305,11 @@ curl -X POST http://127.0.0.1:8081/sources/search \
   -d '{"termQuery":"How do knowledge graphs improve retrieval?"}'
 ```
 
-The endpoint returns graph evidence separately from ranked chunks. UUIDs and scores below are illustrative; field names match the public response contract.
+The endpoint returns graph evidence separately from ranked chunks. UUIDs and scores below are illustrative; field names match the public response contract. History can then be read with:
+
+```bash
+curl "http://127.0.0.1:8081/history/questions?page=0&size=20" -H "Authorization: Bearer $TOKEN"
+```
 
 ```json
 {
@@ -453,7 +463,6 @@ For the protected `main` branch, require the successful checks exposed by the wo
 The current V1 is experimental, not a complete end-user knowledge application or a security-audited production service. The main remaining gaps are:
 
 - an automatic retry scheduler and Neo4j rebuild procedure;
-- a public API for reading persisted questions and answer snapshots;
 - OpenAPI/Swagger publication;
 - a dense-search fallback when Neo4j GDS is unavailable;
 - request-size limits, rate limiting, and upload-abuse controls;

--- a/docs/ai/issue-workflow.md
+++ b/docs/ai/issue-workflow.md
@@ -104,7 +104,7 @@ Run the canonical validation from the repository root:
 bash scripts/ai/validate.sh
 ```
 
-This prepares the pinned model and runs `./mvnw --batch-mode --no-transfer-progress clean verify`, including tests, packaging, and JaCoCo enforcement. The `validation.yml` workflow reuses this script. Container smoke tests and vulnerability scanning remain in the CI container job because they require Docker and GitHub Actions services.
+This prepares the pinned model and runs `./mvnw --batch-mode --no-transfer-progress clean verify`, including tests, packaging, and JaCoCo enforcement. The script also fails when Testcontainers reports Docker-backed tests as skipped, so a successful complete validation means those integration tests actually ran. The `validation.yml` workflow reuses this script. Container smoke tests and vulnerability scanning remain in the CI container job because they require Docker and GitHub Actions services.
 
 Run focused tests during development, then run the complete validation before delivery. Report skipped tests and environmental limitations explicitly.
 

--- a/docs/ai/issue-workflow.md
+++ b/docs/ai/issue-workflow.md
@@ -6,29 +6,45 @@ This document is the detailed workflow routed by `AGENTS.md`. It is intentionall
 
 ```text
 Read the issue
-    ↓
+    |
+Create or switch to a feature branch
+    |
 Preflight and baseline
-    ↓
+    |
 Investigation
-    ↓
+    |
 Plan
-    ↓
+    |
 Tests
-    ↓
+    |
 Incremental implementation
-    ↓
+    |
 Atomic commits
-    ↓
+    |
 Complete validation
-    ↓
+    |
 Self-review
-    ↓
+    |
 Delivery
 ```
 
 ## 1. Read the issue
 
 Confirm the repository, issue number, acceptance criteria, constraints, and out-of-scope items. Record the issue URL and a short interpretation in the local run directory. Do not infer additional product scope from nearby issues.
+
+## 2. Branch setup
+
+Resolve the current checkout and working tree before editing. Issue work must not be performed directly on `main` or `master`.
+
+Create or switch to a dedicated branch before preflight:
+
+```bash
+git switch -c feature/<issue-number>-<short-slug>
+```
+
+Use an existing issue branch when one is already present. If the working tree contains changes, preserve them and identify which files are unrelated; never stage or commit those files. If the existing changes belong to the issue, the new branch may carry them so they can be committed atomically.
+
+## 3. Preflight and baseline
 
 Start a run from the repository root:
 
@@ -38,42 +54,49 @@ bash scripts/ai/preflight.sh --repository Luca5Eckert/Kairos --issue 123
 
 The script stores temporary evidence in `.ai-runs/`. It uses the GitHub CLI when available and falls back to the public GitHub API. A clean tree is recommended; use `--require-clean` when a clean checkout is a prerequisite.
 
-## 2. Preflight and baseline
-
 Inspect the current branch, working tree, recent commits, build configuration, CI, and relevant tests before editing. Treat existing uncommitted files as user-owned unless the issue explicitly includes them. The preflight records this context and runs the current validation baseline unless `--skip-baseline` is supplied.
 
 The baseline is evidence, not permission to delete or reset local changes. If it fails, capture the failure and distinguish a pre-existing failure from a regression.
 
-## 3. Investigation
+## 4. Investigation
 
 Trace the affected behavior through the smallest relevant set of modules, configuration, migrations, tests, and documentation. Prefer repository code, Git history, and existing CI configuration over assumptions. Identify integration boundaries and compatibility constraints before choosing an implementation.
 
-## 4. Plan
+## 5. Plan
 
 Write a short, concrete plan before modifying code. It should identify:
 
 - the files or components to change;
 - the behavior and acceptance criterion each change addresses;
 - the focused test strategy;
-- validation commands and likely risks.
+- validation commands and likely risks;
+- the intended atomic commit boundaries.
 
 Keep the plan in the task conversation or in the local `.ai-runs/` evidence; do not add a planning document to the repository unless the issue requires one.
 
-## 5. Tests
+## 6. Tests
 
 Add or adjust a focused test before or alongside the implementation when behavior changes. Follow the existing JUnit and Mockito/Testcontainers conventions. For documentation and workflow changes, use `scripts/ai/test.sh` as the structural smoke test and run the affected scripts with `bash -n` where appropriate.
 
 Tests must verify observable behavior, not merely implementation details. Keep integration tests explicit about their Docker requirement and do not make local development depend on unavailable services unless the existing project convention already does so.
 
-## 6. Incremental implementation
+## 7. Incremental implementation
 
 Make the smallest coherent change that satisfies one part of the plan. After each meaningful increment, run the narrowest relevant test and inspect the diff. Avoid unrelated formatting, dependency upgrades, generated files, and drive-by refactors.
 
-## 7. Atomic commits
+## 8. Atomic commits (required)
 
-When commits are requested or part of the delivery workflow, group changes by intent: implementation and tests together when they form one behavior, documentation separately when it has independent value, and CI or tooling changes by concern. Use the repository's existing conventional style, include the issue reference when appropriate, and do not stage unrelated user files.
+Commit issue work throughout implementation; do not wait until the end for one large commit. Each commit must be independently understandable and limited to one intent:
 
-## 8. Complete validation
+- implementation plus its focused tests when they form one behavior;
+- documentation updates in a separate commit when independently reviewable;
+- CI or tooling changes in their own commit.
+
+Use explicit staging paths and verify `git diff --cached` before every commit. Never stage unrelated user-owned files or use broad staging when the tree contains unrelated changes. Follow the repository's existing conventional format, include `#<issue-number>` when appropriate, and use imperative summaries. Run the focused test for the commit before creating it.
+
+Before delivery, confirm that all issue files are committed, the branch is correct, and only explicitly identified unrelated files remain uncommitted. Pushing the branch requires user authorization.
+
+## 9. Complete validation
 
 Run the canonical validation from the repository root:
 
@@ -85,20 +108,22 @@ This prepares the pinned model and runs `./mvnw --batch-mode --no-transfer-progr
 
 Run focused tests during development, then run the complete validation before delivery. Report skipped tests and environmental limitations explicitly.
 
-## 9. Self-review
+## 10. Self-review
 
 Review the final diff and status for scope, security, error handling, backward compatibility, tests, documentation, and accidental secrets or generated artifacts. Confirm `.ai-runs/` and local Vault configuration are ignored. Re-run the structural smoke test if workflow files changed.
 
-## 10. Delivery
+## 11. Delivery
 
 The final report must be independently verifiable and contain:
 
 1. issue URL and concise outcome;
-2. implementation and test files changed;
-3. focused and complete validation commands with results;
-4. documentation and Obsidian decision;
-5. known risks, skips, or pre-existing failures;
-6. commit hashes, if commits were created.
+2. branch name;
+3. implementation and test files changed;
+4. focused and complete validation commands with results;
+5. documentation and Obsidian decision;
+6. known risks, skips, or pre-existing failures;
+7. commit hashes, with one-line intent for each commit;
+8. unrelated user-owned files left uncommitted, if any.
 
 ## Context boundaries
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,9 @@ spring:
 
 ```yaml
 kairos:
+  history:
+    default-page-size: ${KAIROS_HISTORY_DEFAULT_PAGE_SIZE:20}
+    max-page-size: ${KAIROS_HISTORY_MAX_PAGE_SIZE:100}
   retrieval:
     semantic-anchor-limit: ${KAIROS_SEMANTIC_ANCHOR_LIMIT:10}
     graph-passage-limit: ${KAIROS_GRAPH_PASSAGE_LIMIT:20}
@@ -86,6 +89,8 @@ kairos:
 | `KAIROS_GRAPH_PASSAGE_LIMIT` | `20` | Maximum graph-ranked passages returned |
 | `KAIROS_SEED_MIN_SCORE` | `0.45` | Minimum score required for a seed |
 | `KAIROS_SEED_RELATIVE_THRESHOLD` | `0.85` | Seed must be within this fraction of the best score |
+| `KAIROS_HISTORY_DEFAULT_PAGE_SIZE` | `20` | Default page size for history endpoints |
+| `KAIROS_HISTORY_MAX_PAGE_SIZE` | `100` | Maximum accepted page size for history endpoints |
 
 ## Graph Search
 

--- a/docs/postman/Kairos.postman_collection.json
+++ b/docs/postman/Kairos.postman_collection.json
@@ -16,7 +16,9 @@
     { "key": "confirmationCode", "value": "", "type": "string" },
     { "key": "sourceTitle", "value": "RAG e grafos de conhecimento", "type": "string" },
     { "key": "sourceContent", "value": "Retrieval augmented generation combina um recuperador com um modelo de linguagem. Grafos de conhecimento representam entidades e relacionamentos explicitamente. Personalized PageRank propaga relevância através de conceitos conectados.", "type": "string" },
-    { "key": "searchQuery", "value": "Como um grafo de conhecimento melhora retrieval augmented generation?", "type": "string" }
+    { "key": "searchQuery", "value": "Como um grafo de conhecimento melhora retrieval augmented generation?", "type": "string" },
+    { "key": "questionId", "value": "", "type": "string" },
+    { "key": "answerId", "value": "", "type": "string" }
   ],
   "event": [
     {
@@ -118,6 +120,35 @@
       ]
     },
     {
+      "name": "History (authenticated)",
+      "auth": { "type": "bearer", "bearer": [{ "key": "token", "value": "{{accessToken}}", "type": "string" }] },
+      "item": [
+        {
+          "name": "List questions",
+          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/history/questions?page=0&size=20", "description": "Lista perguntas persistidas do usuário autenticado em ordem decrescente de criação." },
+          "event": [{ "listen": "test", "script": { "type": "text/javascript", "exec": ["pm.test('Retorna 200', () => pm.response.to.have.status(200));", "const body = pm.response.json();", "pm.test('Retorna página de histórico', () => { pm.expect(body.content).to.be.an('array'); pm.expect(body).to.include.all.keys('page', 'size', 'totalElements', 'totalPages', 'first', 'last'); });", "if (body.content.length) pm.collectionVariables.set('questionId', body.content[0].questionId);"] } }]
+        },
+        {
+          "name": "Get question metadata",
+          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/history/questions/{{questionId}}", "description": "Abre uma pergunta sem carregar automaticamente seus snapshots." },
+          "event": [{ "listen": "test", "script": { "type": "text/javascript", "exec": ["pm.test('Retorna 200', () => pm.response.to.have.status(200));", "pm.expect(pm.response.json()).to.have.all.keys('questionId', 'text', 'createdAt', 'answerCount', 'latestExecutionAt');"] } }]
+        },
+        {
+          "name": "List question answers",
+          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/history/questions/{{questionId}}/answers?page=0&size=20", "description": "Lista os resumos das execuções persistidas da pergunta." },
+          "event": [{ "listen": "test", "script": { "type": "text/javascript", "exec": ["pm.test('Retorna 200', () => pm.response.to.have.status(200));", "const body = pm.response.json();", "pm.expect(body.content).to.be.an('array');", "if (body.content.length) pm.collectionVariables.set('answerId', body.content[0].answerId);"] } }]
+        },
+        {
+          "name": "Get answer snapshot",
+          "request": { "method": "GET", "header": [], "url": "{{baseUrl}}/history/answers/{{answerId}}", "description": "Recupera o snapshot completo e imutável armazenado em JSONB." },
+          "event": [{ "listen": "test", "script": { "type": "text/javascript", "exec": ["pm.test('Retorna 200', () => pm.response.to.have.status(200));", "const body = pm.response.json();", "pm.expect(body).to.include.all.keys('answerId', 'questionId', 'schemaVersion', 'createdAt', 'snapshot');", "pm.expect(body.snapshot).to.include.all.keys('retrievalVersion', 'parameters', 'seeds', 'rankedPassages', 'activatedTriples');"] } }]
+        },
+        {
+          "name": "Re-execute existing question",
+          "request": { "method": "POST", "header": [{ "key": "Content-Type", "value": "application/json" }], "body": { "mode": "raw", "raw": "{\n  \"termQuery\": \"{{searchQuery}}\",\n  \"questionId\": \"{{questionId}}\"\n}", "options": { "raw": { "language": "json" } } }, "url": "{{baseUrl}}/sources/search", "description": "Executa novamente uma pergunta existente e anexa um novo answer sem sobrescrever snapshots anteriores." }
+        }
+      ]
+    },    {
       "name": "Security (negative)",
       "item": [
         {

--- a/scripts/ai/test.sh
+++ b/scripts/ai/test.sh
@@ -33,6 +33,7 @@ done
 grep -Fq 'docs/ai/issue-workflow.md' AGENTS.md || fail 'AGENTS.md does not route to the issue workflow'
 grep -Fq 'docs/ai/documentation-policy.md' AGENTS.md || fail 'AGENTS.md does not route to the documentation policy'
 grep -Fq 'scripts/ai/validate.sh' .github/workflows/validation.yml || fail 'CI does not reuse validate.sh'
+grep -Fq 'disabledWithoutDocker is true' scripts/ai/validate.sh || fail 'validate.sh does not reject skipped Docker tests'
 grep -Fq '.ai-runs/' .gitignore || fail '.ai-runs/ is not ignored'
 grep -Fq 'issue' .github/pull_request_template.md || fail 'PR template does not request issue evidence'
 grep -Fq 'validation' docs/ai/issue-workflow.md || fail 'issue workflow does not describe complete validation'

--- a/scripts/ai/validate.sh
+++ b/scripts/ai/validate.sh
@@ -11,4 +11,19 @@ bash infra/scripts/prepare-model.sh
 echo "[2/2] Running Maven compile, tests, packaging, and coverage checks"
 ./mvnw --batch-mode --no-transfer-progress clean verify "$@"
 
+skipped_docker_tests=false
+for report_dir in target/surefire-reports target/failsafe-reports; do
+  [[ -d "${report_dir}" ]] || continue
+  while IFS= read -r -d '' report; do
+    if grep -Fq 'disabledWithoutDocker is true' "${report}" && grep -Fq 'Docker is not available' "${report}"; then
+      echo "[FAIL] Docker-backed tests were skipped in ${report}. Start Docker and rerun validation." >&2
+      skipped_docker_tests=true
+    fi
+  done < <(find "${report_dir}" -type f -name '*.xml' -print0)
+done
+
+if [[ "${skipped_docker_tests}" == true ]]; then
+  exit 1
+fi
+
 echo "Validation completed successfully."

--- a/src/main/java/com/kairos/module/context_engine/application/use_case/GetHistoryAnswerUseCase.java
+++ b/src/main/java/com/kairos/module/context_engine/application/use_case/GetHistoryAnswerUseCase.java
@@ -1,0 +1,25 @@
+package com.kairos.module.context_engine.application.use_case;
+
+import com.kairos.module.context_engine.domain.model.history.Answer;
+import com.kairos.module.context_engine.domain.port.repository.HistoryRepository;
+import com.kairos.share.security.context.RequestContextProvider;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class GetHistoryAnswerUseCase {
+    private static final String NOT_FOUND_MESSAGE = "History resource not found";
+
+    private final HistoryRepository historyRepository;
+    private final RequestContextProvider requestContextProvider;
+
+    public Answer execute(UUID answerId) {
+        UUID userId = requestContextProvider.getRequestContext().userId();
+        return historyRepository.findAnswerByIdAndUserId(answerId, userId)
+                .orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_MESSAGE));
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/application/use_case/GetHistoryQuestionUseCase.java
+++ b/src/main/java/com/kairos/module/context_engine/application/use_case/GetHistoryQuestionUseCase.java
@@ -1,0 +1,25 @@
+package com.kairos.module.context_engine.application.use_case;
+
+import com.kairos.module.context_engine.domain.model.history.QuestionHistory;
+import com.kairos.module.context_engine.domain.port.repository.HistoryRepository;
+import com.kairos.share.security.context.RequestContextProvider;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class GetHistoryQuestionUseCase {
+    private static final String NOT_FOUND_MESSAGE = "History resource not found";
+
+    private final HistoryRepository historyRepository;
+    private final RequestContextProvider requestContextProvider;
+
+    public QuestionHistory execute(UUID questionId) {
+        UUID userId = requestContextProvider.getRequestContext().userId();
+        return historyRepository.findQuestionHistoryByIdAndUserId(questionId, userId)
+                .orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_MESSAGE));
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/application/use_case/ListHistoryAnswersUseCase.java
+++ b/src/main/java/com/kairos/module/context_engine/application/use_case/ListHistoryAnswersUseCase.java
@@ -1,0 +1,38 @@
+package com.kairos.module.context_engine.application.use_case;
+
+import com.kairos.module.context_engine.domain.model.history.Answer;
+import com.kairos.module.context_engine.domain.model.history.HistoryPage;
+import com.kairos.module.context_engine.domain.model.history.HistoryPageRequest;
+import com.kairos.module.context_engine.domain.port.repository.HistoryRepository;
+import com.kairos.module.context_engine.infrastructure.config.HistoryProperties;
+import com.kairos.share.security.context.RequestContextProvider;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class ListHistoryAnswersUseCase {
+    private static final String NOT_FOUND_MESSAGE = "History resource not found";
+
+    private final HistoryRepository historyRepository;
+    private final RequestContextProvider requestContextProvider;
+    private final HistoryProperties historyProperties;
+
+    public HistoryPage<Answer> execute(UUID questionId, Integer page, Integer size) {
+        UUID userId = requestContextProvider.getRequestContext().userId();
+        if (historyRepository.findQuestionByIdAndUserId(questionId, userId).isEmpty()) {
+            throw new EntityNotFoundException(NOT_FOUND_MESSAGE);
+        }
+
+        int resolvedPage = page == null ? 0 : page;
+        int resolvedSize = size == null ? historyProperties.defaultPageSize() : size;
+        if (resolvedSize > historyProperties.maxPageSize()) {
+            throw new IllegalArgumentException("Page size cannot exceed " + historyProperties.maxPageSize());
+        }
+        return historyRepository.findAnswersByQuestionIdAndUserId(questionId, userId,
+                new HistoryPageRequest(resolvedPage, resolvedSize));
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/application/use_case/ListHistoryQuestionsUseCase.java
+++ b/src/main/java/com/kairos/module/context_engine/application/use_case/ListHistoryQuestionsUseCase.java
@@ -1,0 +1,33 @@
+package com.kairos.module.context_engine.application.use_case;
+
+import com.kairos.module.context_engine.domain.model.history.HistoryPage;
+import com.kairos.module.context_engine.domain.model.history.HistoryPageRequest;
+import com.kairos.module.context_engine.domain.model.history.QuestionHistory;
+import com.kairos.module.context_engine.domain.port.repository.HistoryRepository;
+import com.kairos.module.context_engine.infrastructure.config.HistoryProperties;
+import com.kairos.share.security.context.RequestContextProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ListHistoryQuestionsUseCase {
+    private final HistoryRepository historyRepository;
+    private final RequestContextProvider requestContextProvider;
+    private final HistoryProperties historyProperties;
+
+    public HistoryPage<QuestionHistory> execute(Integer page, Integer size) {
+        HistoryPageRequest pageRequest = pageRequest(page, size);
+        return historyRepository.findQuestionsByUserId(
+                requestContextProvider.getRequestContext().userId(), pageRequest);
+    }
+
+    private HistoryPageRequest pageRequest(Integer page, Integer size) {
+        int resolvedPage = page == null ? 0 : page;
+        int resolvedSize = size == null ? historyProperties.defaultPageSize() : size;
+        if (resolvedSize > historyProperties.maxPageSize()) {
+            throw new IllegalArgumentException("Page size cannot exceed " + historyProperties.maxPageSize());
+        }
+        return new HistoryPageRequest(resolvedPage, resolvedSize);
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/application/use_case/SearchSourceUseCase.java
+++ b/src/main/java/com/kairos/module/context_engine/application/use_case/SearchSourceUseCase.java
@@ -19,6 +19,7 @@ import com.kairos.module.context_engine.domain.port.recognition.RecognitionMemor
 import com.kairos.module.context_engine.domain.port.semantic.SemanticSearch;
 import com.kairos.module.context_engine.infrastructure.config.RetrievalProperties;
 import com.kairos.share.security.context.RequestContextProvider;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -107,7 +108,7 @@ public class SearchSourceUseCase {
     private Question questionFor(SearchSourceQuery query, UUID userId) {
         if (query.questionId() != null) {
             return historyRepository.findQuestionByIdAndUserId(query.questionId(), userId)
-                    .orElseThrow(() -> new IllegalArgumentException("Question does not belong to the authenticated user"));
+                    .orElseThrow(() -> new EntityNotFoundException("History resource not found"));
         }
 
         Question question = Question.create(userId, query.searchTerm());

--- a/src/main/java/com/kairos/module/context_engine/domain/model/history/HistoryPage.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/model/history/HistoryPage.java
@@ -1,0 +1,29 @@
+package com.kairos.module.context_engine.domain.model.history;
+
+import java.util.List;
+
+public record HistoryPage<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements
+) {
+    public HistoryPage {
+        if (content == null || page < 0 || size <= 0 || totalElements < 0) {
+            throw new IllegalArgumentException("History page fields are invalid");
+        }
+        content = List.copyOf(content);
+    }
+
+    public int totalPages() {
+        return totalElements == 0 ? 0 : (int) Math.ceil((double) totalElements / size);
+    }
+
+    public boolean first() {
+        return page == 0;
+    }
+
+    public boolean last() {
+        return totalPages() == 0 || page >= totalPages() - 1;
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/domain/model/history/HistoryPageRequest.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/model/history/HistoryPageRequest.java
@@ -1,0 +1,12 @@
+package com.kairos.module.context_engine.domain.model.history;
+
+public record HistoryPageRequest(int page, int size) {
+    public HistoryPageRequest {
+        if (page < 0) {
+            throw new IllegalArgumentException("Page must be greater than or equal to zero");
+        }
+        if (size <= 0) {
+            throw new IllegalArgumentException("Page size must be greater than zero");
+        }
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/domain/model/history/QuestionHistory.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/model/history/QuestionHistory.java
@@ -1,0 +1,26 @@
+package com.kairos.module.context_engine.domain.model.history;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record QuestionHistory(
+        UUID id,
+        UUID userId,
+        String text,
+        Instant createdAt,
+        long answerCount,
+        Instant latestAnswerAt
+) {
+    public QuestionHistory {
+        if (id == null || userId == null || text == null || text.isBlank() || createdAt == null
+                || answerCount < 0) {
+            throw new IllegalArgumentException("Question history fields are invalid");
+        }
+        text = text.trim();
+    }
+
+    public static QuestionHistory from(Question question, long answerCount, Instant latestAnswerAt) {
+        return new QuestionHistory(question.id(), question.userId(), question.text(), question.createdAt(),
+                answerCount, latestAnswerAt);
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/domain/port/repository/HistoryRepository.java
+++ b/src/main/java/com/kairos/module/context_engine/domain/port/repository/HistoryRepository.java
@@ -1,7 +1,10 @@
 package com.kairos.module.context_engine.domain.port.repository;
 
 import com.kairos.module.context_engine.domain.model.history.Answer;
+import com.kairos.module.context_engine.domain.model.history.HistoryPage;
+import com.kairos.module.context_engine.domain.model.history.HistoryPageRequest;
 import com.kairos.module.context_engine.domain.model.history.Question;
+import com.kairos.module.context_engine.domain.model.history.QuestionHistory;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +16,8 @@ public interface HistoryRepository {
     Optional<Question> findQuestionByIdAndUserId(UUID questionId, UUID userId);
     Optional<Answer> findAnswerByIdAndUserId(UUID answerId, UUID userId);
     List<Answer> findAnswersByQuestionIdAndUserId(UUID questionId, UUID userId);
+    HistoryPage<QuestionHistory> findQuestionsByUserId(UUID userId, HistoryPageRequest pageRequest);
+    Optional<QuestionHistory> findQuestionHistoryByIdAndUserId(UUID questionId, UUID userId);
+    HistoryPage<Answer> findAnswersByQuestionIdAndUserId(UUID questionId, UUID userId,
+                                                          HistoryPageRequest pageRequest);
 }

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/config/HistoryProperties.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/config/HistoryProperties.java
@@ -1,0 +1,18 @@
+package com.kairos.module.context_engine.infrastructure.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "kairos.history")
+public record HistoryProperties(int defaultPageSize, int maxPageSize) {
+    public HistoryProperties {
+        defaultPageSize = positiveOrDefault(defaultPageSize, 20);
+        maxPageSize = positiveOrDefault(maxPageSize, 100);
+        if (defaultPageSize > maxPageSize) {
+            defaultPageSize = maxPageSize;
+        }
+    }
+
+    private static int positiveOrDefault(int value, int defaultValue) {
+        return value > 0 ? value : defaultValue;
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/config/RetrievalConfiguration.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/config/RetrievalConfiguration.java
@@ -4,6 +4,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(RetrievalProperties.class)
+@EnableConfigurationProperties({RetrievalProperties.class, HistoryProperties.class})
 public class RetrievalConfiguration {
 }

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/projection/QuestionHistoryProjection.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/projection/QuestionHistoryProjection.java
@@ -1,0 +1,13 @@
+package com.kairos.module.context_engine.infrastructure.relational.projection;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public interface QuestionHistoryProjection {
+    UUID getId();
+    UUID getUserId();
+    String getText();
+    Instant getCreatedAt();
+    Long getAnswerCount();
+    Instant getLatestAnswerAt();
+}

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/history/JpaAnswerRepository.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/history/JpaAnswerRepository.java
@@ -1,6 +1,8 @@
 package com.kairos.module.context_engine.infrastructure.relational.repository.history;
 
 import com.kairos.module.context_engine.infrastructure.relational.entity.AnswerEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -11,6 +13,18 @@ import java.util.UUID;
 public interface JpaAnswerRepository extends JpaRepository<AnswerEntity, UUID> {
     @Query("select a from AnswerEntity a, QuestionEntity q where a.questionId = q.id and a.id = :answerId and q.userId = :userId")
     Optional<AnswerEntity> findByIdAndUserId(UUID answerId, UUID userId);
+
     @Query("select a from AnswerEntity a, QuestionEntity q where a.questionId = q.id and a.questionId = :questionId and q.userId = :userId order by a.createdAt")
     List<AnswerEntity> findAllByQuestionIdAndUserId(UUID questionId, UUID userId);
+
+    @Query(value = """
+            select a from AnswerEntity a, QuestionEntity q
+            where a.questionId = q.id and a.questionId = :questionId and q.userId = :userId
+            order by a.createdAt desc, a.id desc
+            """,
+            countQuery = """
+            select count(a) from AnswerEntity a, QuestionEntity q
+            where a.questionId = q.id and a.questionId = :questionId and q.userId = :userId
+            """)
+    Page<AnswerEntity> findPageByQuestionIdAndUserId(UUID questionId, UUID userId, Pageable pageable);
 }

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/history/JpaQuestionRepository.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/history/JpaQuestionRepository.java
@@ -1,11 +1,35 @@
 package com.kairos.module.context_engine.infrastructure.relational.repository.history;
 
 import com.kairos.module.context_engine.infrastructure.relational.entity.QuestionEntity;
+import com.kairos.module.context_engine.infrastructure.relational.projection.QuestionHistoryProjection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 import java.util.UUID;
 
 public interface JpaQuestionRepository extends JpaRepository<QuestionEntity, UUID> {
     Optional<QuestionEntity> findByIdAndUserId(UUID id, UUID userId);
+
+    @Query(value = """
+            select q.id as id, q.userId as userId, q.text as text, q.createdAt as createdAt,
+                   count(a.id) as answerCount, max(a.createdAt) as latestAnswerAt
+            from QuestionEntity q left join AnswerEntity a on a.questionId = q.id
+            where q.userId = :userId
+            group by q.id, q.userId, q.text, q.createdAt
+            order by q.createdAt desc, q.id desc
+            """,
+            countQuery = "select count(q) from QuestionEntity q where q.userId = :userId")
+    Page<QuestionHistoryProjection> findHistoryByUserId(UUID userId, Pageable pageable);
+
+    @Query("""
+            select q.id as id, q.userId as userId, q.text as text, q.createdAt as createdAt,
+                   count(a.id) as answerCount, max(a.createdAt) as latestAnswerAt
+            from QuestionEntity q left join AnswerEntity a on a.questionId = q.id
+            where q.id = :questionId and q.userId = :userId
+            group by q.id, q.userId, q.text, q.createdAt
+            """)
+    Optional<QuestionHistoryProjection> findHistoryByIdAndUserId(UUID questionId, UUID userId);
 }

--- a/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/history/SpringHistoryRepositoryAdapter.java
+++ b/src/main/java/com/kairos/module/context_engine/infrastructure/relational/repository/history/SpringHistoryRepositoryAdapter.java
@@ -1,10 +1,15 @@
 package com.kairos.module.context_engine.infrastructure.relational.repository.history;
 
 import com.kairos.module.context_engine.domain.model.history.Answer;
+import com.kairos.module.context_engine.domain.model.history.HistoryPage;
+import com.kairos.module.context_engine.domain.model.history.HistoryPageRequest;
 import com.kairos.module.context_engine.domain.model.history.Question;
+import com.kairos.module.context_engine.domain.model.history.QuestionHistory;
 import com.kairos.module.context_engine.domain.port.repository.HistoryRepository;
 import com.kairos.module.context_engine.infrastructure.relational.entity.AnswerEntity;
 import com.kairos.module.context_engine.infrastructure.relational.entity.QuestionEntity;
+import com.kairos.module.context_engine.infrastructure.relational.projection.QuestionHistoryProjection;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -15,10 +20,50 @@ import java.util.UUID;
 public class SpringHistoryRepositoryAdapter implements HistoryRepository {
     private final JpaQuestionRepository questions;
     private final JpaAnswerRepository answers;
-    public SpringHistoryRepositoryAdapter(JpaQuestionRepository questions, JpaAnswerRepository answers) { this.questions = questions; this.answers = answers; }
+
+    public SpringHistoryRepositoryAdapter(JpaQuestionRepository questions, JpaAnswerRepository answers) {
+        this.questions = questions;
+        this.answers = answers;
+    }
+
     public void saveQuestion(Question question) { questions.save(QuestionEntity.of(question)); }
+
     public void saveAnswer(Answer answer) { answers.save(AnswerEntity.of(answer)); }
-    public Optional<Question> findQuestionByIdAndUserId(UUID questionId, UUID userId) { return questions.findByIdAndUserId(questionId, userId).map(QuestionEntity::toDomain); }
-    public Optional<Answer> findAnswerByIdAndUserId(UUID answerId, UUID userId) { return answers.findByIdAndUserId(answerId, userId).map(AnswerEntity::toDomain); }
-    public List<Answer> findAnswersByQuestionIdAndUserId(UUID questionId, UUID userId) { return answers.findAllByQuestionIdAndUserId(questionId, userId).stream().map(AnswerEntity::toDomain).toList(); }
+
+    public Optional<Question> findQuestionByIdAndUserId(UUID questionId, UUID userId) {
+        return questions.findByIdAndUserId(questionId, userId).map(QuestionEntity::toDomain);
+    }
+
+    public Optional<Answer> findAnswerByIdAndUserId(UUID answerId, UUID userId) {
+        return answers.findByIdAndUserId(answerId, userId).map(AnswerEntity::toDomain);
+    }
+
+    public List<Answer> findAnswersByQuestionIdAndUserId(UUID questionId, UUID userId) {
+        return answers.findAllByQuestionIdAndUserId(questionId, userId).stream()
+                .map(AnswerEntity::toDomain)
+                .toList();
+    }
+
+    public HistoryPage<QuestionHistory> findQuestionsByUserId(UUID userId, HistoryPageRequest pageRequest) {
+        var page = questions.findHistoryByUserId(userId, PageRequest.of(pageRequest.page(), pageRequest.size()));
+        return new HistoryPage<>(page.getContent().stream().map(this::toQuestionHistory).toList(),
+                page.getNumber(), page.getSize(), page.getTotalElements());
+    }
+
+    public Optional<QuestionHistory> findQuestionHistoryByIdAndUserId(UUID questionId, UUID userId) {
+        return questions.findHistoryByIdAndUserId(questionId, userId).map(this::toQuestionHistory);
+    }
+
+    public HistoryPage<Answer> findAnswersByQuestionIdAndUserId(UUID questionId, UUID userId,
+                                                                  HistoryPageRequest pageRequest) {
+        var page = answers.findPageByQuestionIdAndUserId(questionId, userId,
+                PageRequest.of(pageRequest.page(), pageRequest.size()));
+        return new HistoryPage<>(page.getContent().stream().map(AnswerEntity::toDomain).toList(),
+                page.getNumber(), page.getSize(), page.getTotalElements());
+    }
+
+    private QuestionHistory toQuestionHistory(QuestionHistoryProjection projection) {
+        return new QuestionHistory(projection.getId(), projection.getUserId(), projection.getText(),
+                projection.getCreatedAt(), projection.getAnswerCount(), projection.getLatestAnswerAt());
+    }
 }

--- a/src/main/java/com/kairos/module/context_engine/presentation/controller/HistoryController.java
+++ b/src/main/java/com/kairos/module/context_engine/presentation/controller/HistoryController.java
@@ -1,0 +1,58 @@
+package com.kairos.module.context_engine.presentation.controller;
+
+import com.kairos.module.context_engine.application.use_case.GetHistoryAnswerUseCase;
+import com.kairos.module.context_engine.application.use_case.GetHistoryQuestionUseCase;
+import com.kairos.module.context_engine.application.use_case.ListHistoryAnswersUseCase;
+import com.kairos.module.context_engine.application.use_case.ListHistoryQuestionsUseCase;
+import com.kairos.module.context_engine.presentation.dto.response.AnswerHistoryResponse;
+import com.kairos.module.context_engine.presentation.dto.response.AnswerHistorySummaryResponse;
+import com.kairos.module.context_engine.presentation.dto.response.HistoryPageResponse;
+import com.kairos.module.context_engine.presentation.dto.response.QuestionHistoryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/history")
+@RequiredArgsConstructor
+public class HistoryController {
+    private final ListHistoryQuestionsUseCase listHistoryQuestionsUseCase;
+    private final GetHistoryQuestionUseCase getHistoryQuestionUseCase;
+    private final ListHistoryAnswersUseCase listHistoryAnswersUseCase;
+    private final GetHistoryAnswerUseCase getHistoryAnswerUseCase;
+
+    @GetMapping("/questions")
+    public ResponseEntity<HistoryPageResponse<QuestionHistoryResponse>> listQuestions(
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer size
+    ) {
+        var result = listHistoryQuestionsUseCase.execute(page, size);
+        return ResponseEntity.ok(HistoryPageResponse.of(result, QuestionHistoryResponse::of));
+    }
+
+    @GetMapping("/questions/{questionId}")
+    public ResponseEntity<QuestionHistoryResponse> getQuestion(@PathVariable UUID questionId) {
+        return ResponseEntity.ok(QuestionHistoryResponse.of(getHistoryQuestionUseCase.execute(questionId)));
+    }
+
+    @GetMapping("/questions/{questionId}/answers")
+    public ResponseEntity<HistoryPageResponse<AnswerHistorySummaryResponse>> listAnswers(
+            @PathVariable UUID questionId,
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer size
+    ) {
+        var result = listHistoryAnswersUseCase.execute(questionId, page, size);
+        return ResponseEntity.ok(HistoryPageResponse.of(result, AnswerHistorySummaryResponse::of));
+    }
+
+    @GetMapping("/answers/{answerId}")
+    public ResponseEntity<AnswerHistoryResponse> getAnswer(@PathVariable UUID answerId) {
+        return ResponseEntity.ok(AnswerHistoryResponse.of(getHistoryAnswerUseCase.execute(answerId)));
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/presentation/controller/SourceController.java
+++ b/src/main/java/com/kairos/module/context_engine/presentation/controller/SourceController.java
@@ -56,7 +56,7 @@ public class SourceController {
     public ResponseEntity<ContextResponse> searchSourceContext(
             @RequestBody @Valid GenerateSourceContextRequest request
     ) {
-        var query = SearchSourceQuery.of(request.termQuery());
+        var query = new SearchSourceQuery(request.termQuery(), request.questionId());
         var result = searchSourceUseCase.execute(query);
 
         return ResponseEntity.ok(mapper.toContextResponse(result));

--- a/src/main/java/com/kairos/module/context_engine/presentation/dto/request/GenerateSourceContextRequest.java
+++ b/src/main/java/com/kairos/module/context_engine/presentation/dto/request/GenerateSourceContextRequest.java
@@ -2,7 +2,10 @@ package com.kairos.module.context_engine.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 
+import java.util.UUID;
+
 public record GenerateSourceContextRequest(
-        @NotBlank String termQuery
+        @NotBlank String termQuery,
+        UUID questionId
 ) {
 }

--- a/src/main/java/com/kairos/module/context_engine/presentation/dto/response/AnswerHistoryResponse.java
+++ b/src/main/java/com/kairos/module/context_engine/presentation/dto/response/AnswerHistoryResponse.java
@@ -1,0 +1,89 @@
+package com.kairos.module.context_engine.presentation.dto.response;
+
+import com.kairos.module.context_engine.domain.model.history.Answer;
+import com.kairos.module.context_engine.domain.model.history.AnswerSnapshot;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record AnswerHistoryResponse(
+        UUID answerId,
+        UUID questionId,
+        int schemaVersion,
+        Instant createdAt,
+        AnswerSnapshotResponse snapshot
+) {
+    public static AnswerHistoryResponse of(Answer answer) {
+        return new AnswerHistoryResponse(answer.id(), answer.questionId(), answer.schemaVersion(), answer.createdAt(),
+                AnswerSnapshotResponse.of(answer.snapshot()));
+    }
+
+    public record AnswerSnapshotResponse(
+            String retrievalVersion,
+            RetrievalParametersResponse parameters,
+            List<GraphSeedResponse> seeds,
+            List<RankedPassageResponse> rankedPassages,
+            List<ActivatedTripleResponse> activatedTriples
+    ) {
+        static AnswerSnapshotResponse of(AnswerSnapshot snapshot) {
+            return new AnswerSnapshotResponse(snapshot.retrievalVersion(), RetrievalParametersResponse.of(snapshot.parameters()),
+                    snapshot.seeds().stream().map(GraphSeedResponse::of).toList(),
+                    snapshot.rankedPassages().stream().map(RankedPassageResponse::of).toList(),
+                    snapshot.activatedTriples().stream().map(ActivatedTripleResponse::of).toList());
+        }
+    }
+
+    public record RetrievalParametersResponse(
+            int semanticAnchorLimit,
+            int tripleCandidateLimit,
+            int recognitionSeedLimit,
+            int graphPassageLimit,
+            double seedMinScore,
+            double seedRelativeThreshold
+    ) {
+        static RetrievalParametersResponse of(AnswerSnapshot.RetrievalParameters parameters) {
+            return new RetrievalParametersResponse(parameters.semanticAnchorLimit(), parameters.tripleCandidateLimit(),
+                    parameters.recognitionSeedLimit(), parameters.graphPassageLimit(), parameters.seedMinScore(),
+                    parameters.seedRelativeThreshold());
+        }
+    }
+
+    public record GraphSeedResponse(String type, UUID chunkId, String concept, double weight, int order) {
+        static GraphSeedResponse of(AnswerSnapshot.GraphSeedSnapshot seed) {
+            return new GraphSeedResponse(seed.type(), seed.chunkId(), seed.concept(), seed.weight(), seed.order());
+        }
+    }
+
+    public record RankedPassageResponse(
+            UUID chunkId,
+            UUID sourceId,
+            String content,
+            int rank,
+            double finalScore,
+            Double denseScore,
+            double graphScore,
+            String retrievalSource
+    ) {
+        static RankedPassageResponse of(AnswerSnapshot.RankedPassageSnapshot passage) {
+            return new RankedPassageResponse(passage.chunkId(), passage.sourceId(), passage.content(), passage.rank(),
+                    passage.finalScore(), passage.denseScore(), passage.graphScore(), passage.retrievalSource());
+        }
+    }
+
+    public record ActivatedTripleResponse(
+            String tripleKey,
+            UUID chunkId,
+            String subject,
+            String predicate,
+            String object,
+            Double activationScore,
+            double structuralWeight,
+            int order
+    ) {
+        static ActivatedTripleResponse of(AnswerSnapshot.ActivatedTripleSnapshot triple) {
+            return new ActivatedTripleResponse(triple.tripleKey(), triple.chunkId(), triple.subject(), triple.predicate(),
+                    triple.object(), triple.activationScore(), triple.structuralWeight(), triple.order());
+        }
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/presentation/dto/response/AnswerHistorySummaryResponse.java
+++ b/src/main/java/com/kairos/module/context_engine/presentation/dto/response/AnswerHistorySummaryResponse.java
@@ -1,0 +1,23 @@
+package com.kairos.module.context_engine.presentation.dto.response;
+
+import com.kairos.module.context_engine.domain.model.history.Answer;
+import java.time.Instant;
+import java.util.UUID;
+
+public record AnswerHistorySummaryResponse(
+        UUID answerId,
+        int schemaVersion,
+        Instant createdAt,
+        String retrievalVersion,
+        AnswerHistoryResponse.RetrievalParametersResponse parameters,
+        int seedsCount,
+        int passagesCount,
+        int triplesCount
+) {
+    public static AnswerHistorySummaryResponse of(Answer answer) {
+        var snapshot = answer.snapshot();
+        return new AnswerHistorySummaryResponse(answer.id(), answer.schemaVersion(), answer.createdAt(),
+                snapshot.retrievalVersion(), AnswerHistoryResponse.RetrievalParametersResponse.of(snapshot.parameters()), snapshot.seeds().size(),
+                snapshot.rankedPassages().size(), snapshot.activatedTriples().size());
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/presentation/dto/response/HistoryPageResponse.java
+++ b/src/main/java/com/kairos/module/context_engine/presentation/dto/response/HistoryPageResponse.java
@@ -1,0 +1,21 @@
+package com.kairos.module.context_engine.presentation.dto.response;
+
+import com.kairos.module.context_engine.domain.model.history.HistoryPage;
+
+import java.util.List;
+import java.util.function.Function;
+
+public record HistoryPageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean first,
+        boolean last
+) {
+    public static <D, T> HistoryPageResponse<T> of(HistoryPage<D> page, Function<D, T> mapper) {
+        return new HistoryPageResponse<>(page.content().stream().map(mapper).toList(), page.page(), page.size(),
+                page.totalElements(), page.totalPages(), page.first(), page.last());
+    }
+}

--- a/src/main/java/com/kairos/module/context_engine/presentation/dto/response/QuestionHistoryResponse.java
+++ b/src/main/java/com/kairos/module/context_engine/presentation/dto/response/QuestionHistoryResponse.java
@@ -1,0 +1,19 @@
+package com.kairos.module.context_engine.presentation.dto.response;
+
+import com.kairos.module.context_engine.domain.model.history.QuestionHistory;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record QuestionHistoryResponse(
+        UUID questionId,
+        String text,
+        Instant createdAt,
+        long answerCount,
+        Instant latestExecutionAt
+) {
+    public static QuestionHistoryResponse of(QuestionHistory question) {
+        return new QuestionHistoryResponse(question.id(), question.text(), question.createdAt(),
+                question.answerCount(), question.latestAnswerAt());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,6 +73,9 @@ logging:
 kairos:
   mail:
     from: ${MAIL_FROM:no-reply@kairos.local}
+  history:
+    default-page-size: ${KAIROS_HISTORY_DEFAULT_PAGE_SIZE:20}
+    max-page-size: ${KAIROS_HISTORY_MAX_PAGE_SIZE:100}
   retrieval:
     semantic-anchor-limit: ${KAIROS_SEMANTIC_ANCHOR_LIMIT:10}
     graph-passage-limit: ${KAIROS_GRAPH_PASSAGE_LIMIT:20}

--- a/src/test/java/com/kairos/module/context_engine/integration/HistoryPersistenceIntegrationTest.java
+++ b/src/test/java/com/kairos/module/context_engine/integration/HistoryPersistenceIntegrationTest.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -36,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         properties = "spring.jpa.hibernate.ddl-auto=validate")
 @Import(SpringHistoryRepositoryAdapter.class)
 @Testcontainers(disabledWithoutDocker = true)
+@Transactional
 class HistoryPersistenceIntegrationTest {
     @Container
     static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("pgvector/pgvector:pg16")

--- a/src/test/java/com/kairos/module/context_engine/integration/HistoryPersistenceIntegrationTest.java
+++ b/src/test/java/com/kairos/module/context_engine/integration/HistoryPersistenceIntegrationTest.java
@@ -1,0 +1,99 @@
+package com.kairos.module.context_engine.integration;
+
+import com.kairos.module.context_engine.domain.model.history.Answer;
+import com.kairos.module.context_engine.domain.model.history.AnswerSnapshot;
+import com.kairos.module.context_engine.domain.model.history.HistoryPageRequest;
+import com.kairos.module.context_engine.domain.model.history.Question;
+import com.kairos.module.context_engine.domain.port.repository.HistoryRepository;
+import com.kairos.module.context_engine.infrastructure.relational.entity.AnswerEntity;
+import com.kairos.module.context_engine.infrastructure.relational.entity.QuestionEntity;
+import com.kairos.module.context_engine.infrastructure.relational.repository.history.JpaAnswerRepository;
+import com.kairos.module.context_engine.infrastructure.relational.repository.history.JpaQuestionRepository;
+import com.kairos.module.context_engine.infrastructure.relational.repository.history.SpringHistoryRepositoryAdapter;
+import jakarta.persistence.EntityManager;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = HistoryPersistenceIntegrationTest.IntegrationApplication.class,
+        properties = "spring.jpa.hibernate.ddl-auto=validate")
+@Import(SpringHistoryRepositoryAdapter.class)
+@Testcontainers(disabledWithoutDocker = true)
+class HistoryPersistenceIntegrationTest {
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("pgvector/pgvector:pg16")
+            .withDatabaseName("kairos")
+            .withUsername("kairos")
+            .withPassword("kairos");
+
+    @Autowired private Flyway flyway;
+    @Autowired private HistoryRepository historyRepository;
+    @Autowired private EntityManager entityManager;
+
+    @DynamicPropertySource
+    static void postgresProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+    }
+
+    @Test
+    void pagesQuestionsAndAnswersWithUserScopeAndDeterministicDescendingOrder() {
+        UUID userId = UUID.randomUUID();
+        UUID otherUserId = UUID.randomUUID();
+        Instant older = Instant.parse("2026-01-01T00:00:00Z");
+        Instant newer = Instant.parse("2026-01-02T00:00:00Z");
+        Question first = new Question(UUID.randomUUID(), userId, "older", older);
+        Question second = new Question(UUID.randomUUID(), userId, "newer", newer);
+        Question foreign = new Question(UUID.randomUUID(), otherUserId, "foreign", newer);
+        historyRepository.saveQuestion(first);
+        historyRepository.saveQuestion(second);
+        historyRepository.saveQuestion(foreign);
+
+        AnswerSnapshot snapshot = new AnswerSnapshot("hipporag-2",
+                new AnswerSnapshot.RetrievalParameters(10, 30, 10, 20, 0.45, 0.85), List.of(), List.of(), List.of());
+        Answer olderAnswer = new Answer(UUID.randomUUID(), second.id(), 1, snapshot, older);
+        Answer newerAnswer = new Answer(UUID.randomUUID(), second.id(), 1, snapshot, newer);
+        historyRepository.saveAnswer(olderAnswer);
+        historyRepository.saveAnswer(newerAnswer);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("3");
+        assertThat(historyRepository.findQuestionsByUserId(userId, new HistoryPageRequest(0, 20)).content())
+                .extracting(question -> question.id())
+                .containsExactly(second.id(), first.id());
+        assertThat(historyRepository.findAnswersByQuestionIdAndUserId(second.id(), userId,
+                new HistoryPageRequest(0, 1)))
+                .satisfies(page -> {
+                    assertThat(page.content()).extracting(Answer::id).containsExactly(newerAnswer.id());
+                    assertThat(page.totalElements()).isEqualTo(2);
+                });
+        assertThat(historyRepository.findAnswersByQuestionIdAndUserId(second.id(), otherUserId,
+                new HistoryPageRequest(0, 20)).content()).isEmpty();
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    @EntityScan(basePackageClasses = {QuestionEntity.class, AnswerEntity.class})
+    @EnableJpaRepositories(basePackageClasses = {JpaQuestionRepository.class, JpaAnswerRepository.class})
+    static class IntegrationApplication {
+    }
+}

--- a/src/test/java/com/kairos/module/context_engine/presentation/controller/HistoryControllerTest.java
+++ b/src/test/java/com/kairos/module/context_engine/presentation/controller/HistoryControllerTest.java
@@ -1,0 +1,89 @@
+package com.kairos.module.context_engine.presentation.controller;
+
+import com.kairos.module.context_engine.application.use_case.GetHistoryAnswerUseCase;
+import com.kairos.module.context_engine.application.use_case.GetHistoryQuestionUseCase;
+import com.kairos.module.context_engine.application.use_case.ListHistoryAnswersUseCase;
+import com.kairos.module.context_engine.application.use_case.ListHistoryQuestionsUseCase;
+import com.kairos.module.context_engine.domain.model.history.Answer;
+import com.kairos.module.context_engine.domain.model.history.AnswerSnapshot;
+import com.kairos.module.context_engine.domain.model.history.HistoryPage;
+import com.kairos.module.context_engine.domain.model.history.QuestionHistory;
+import com.kairos.share.exception.GlobalHandlerException;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+@ExtendWith(MockitoExtension.class)
+class HistoryControllerTest {
+    @Mock private ListHistoryQuestionsUseCase listQuestions;
+    @Mock private GetHistoryQuestionUseCase getQuestion;
+    @Mock private ListHistoryAnswersUseCase listAnswers;
+    @Mock private GetHistoryAnswerUseCase getAnswer;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = standaloneSetup(new HistoryController(listQuestions, getQuestion, listAnswers, getAnswer))
+                .setControllerAdvice(new GlobalHandlerException())
+                .build();
+    }
+
+    @Test
+    void listsQuestionsWithPaginationMetadata() throws Exception {
+        UUID questionId = UUID.randomUUID();
+        var question = new QuestionHistory(questionId, UUID.randomUUID(), "How?", Instant.parse("2026-01-01T00:00:00Z"), 2, Instant.parse("2026-01-02T00:00:00Z"));
+        when(listQuestions.execute(0, 20)).thenReturn(new HistoryPage<>(List.of(question), 0, 20, 21));
+
+        mockMvc.perform(get("/history/questions").param("page", "0").param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].questionId").value(questionId.toString()))
+                .andExpect(jsonPath("$.content[0].answerCount").value(2))
+                .andExpect(jsonPath("$.totalElements").value(21))
+                .andExpect(jsonPath("$.totalPages").value(2))
+                .andExpect(jsonPath("$.first").value(true))
+                .andExpect(jsonPath("$.last").value(false));
+    }
+
+    @Test
+    void returnsCompleteAnswerSnapshotFromDedicatedEndpoint() throws Exception {
+        UUID answerId = UUID.randomUUID();
+        var snapshot = new AnswerSnapshot("hipporag-2",
+                new AnswerSnapshot.RetrievalParameters(10, 30, 10, 20, 0.45, 0.85), List.of(), List.of(), List.of());
+        when(getAnswer.execute(answerId)).thenReturn(new Answer(answerId, UUID.randomUUID(), 1, snapshot,
+                Instant.parse("2026-01-02T00:00:00Z")));
+
+        mockMvc.perform(get("/history/answers/{answerId}", answerId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.answerId").value(answerId.toString()))
+                .andExpect(jsonPath("$.schemaVersion").value(1))
+                .andExpect(jsonPath("$.snapshot.retrievalVersion").value("hipporag-2"))
+                .andExpect(jsonPath("$.snapshot.parameters.graphPassageLimit").value(20));
+    }
+
+    @Test
+    void mapsMissingHistoryToNotFound() throws Exception {
+        UUID questionId = UUID.randomUUID();
+        when(getQuestion.execute(questionId)).thenThrow(new EntityNotFoundException("History resource not found"));
+
+        mockMvc.perform(get("/history/questions/{questionId}", questionId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(404))
+                .andExpect(jsonPath("$.path").value("/history/questions/" + questionId));
+    }
+}

--- a/src/test/java/com/kairos/module/context_engine/presentation/controller/SourceControllerTest.java
+++ b/src/test/java/com/kairos/module/context_engine/presentation/controller/SourceControllerTest.java
@@ -247,4 +247,26 @@ class SourceControllerTest {
                 .andExpect(jsonPath("$.code").value(409))
                 .andExpect(jsonPath("$.message").value("Source retry conflict"));
     }
+    @Test
+    void searchSourceContext_passesExistingQuestionId() throws Exception {
+        UUID questionId = UUID.randomUUID();
+        SearchResult result = SearchResult.empty();
+        ContextResponse response = new ContextResponse(List.of(), List.of());
+        when(searchSourceUseCase.execute(argThat(query ->
+                query.searchTerm().equals("Repeat this question") && questionId.equals(query.questionId())
+        ))).thenReturn(result);
+        when(mapper.toContextResponse(result)).thenReturn(response);
+
+        mockMvc.perform(post("/sources/search")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "termQuery": "Repeat this question",
+                                  "questionId": "%s"
+                                }
+                                """.formatted(questionId)))
+                .andExpect(status().isOk());
+
+        verify(searchSourceUseCase).execute(argThat(query -> questionId.equals(query.questionId())));
+    }
 }

--- a/src/test/java/com/kairos/module/context_engine/use_case/HistoryUseCaseTest.java
+++ b/src/test/java/com/kairos/module/context_engine/use_case/HistoryUseCaseTest.java
@@ -1,0 +1,59 @@
+package com.kairos.module.context_engine.use_case;
+
+import com.kairos.module.context_engine.application.use_case.ListHistoryAnswersUseCase;
+import com.kairos.module.context_engine.application.use_case.ListHistoryQuestionsUseCase;
+
+import com.kairos.module.context_engine.domain.model.history.Answer;
+import com.kairos.module.context_engine.domain.model.history.AnswerSnapshot;
+import com.kairos.module.context_engine.domain.model.history.HistoryPage;
+import com.kairos.module.context_engine.domain.model.history.HistoryPageRequest;
+import com.kairos.module.context_engine.domain.model.history.Question;
+import com.kairos.module.context_engine.domain.model.history.QuestionHistory;
+import com.kairos.module.context_engine.domain.port.repository.HistoryRepository;
+import com.kairos.module.context_engine.infrastructure.config.HistoryProperties;
+import com.kairos.share.security.context.RequestContext;
+import com.kairos.share.security.context.RequestContextProvider;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HistoryUseCaseTest {
+    @Mock private HistoryRepository historyRepository;
+    @Mock private RequestContextProvider requestContextProvider;
+
+    @Test
+    void listsQuestionsForTheAuthenticatedUserAndRejectsOversizedPages() {
+        UUID userId = UUID.randomUUID();
+        when(requestContextProvider.getRequestContext()).thenReturn(new RequestContext(userId, "user@example.com", List.of()));
+        var useCase = new ListHistoryQuestionsUseCase(historyRepository, requestContextProvider, new HistoryProperties(20, 50));
+        when(historyRepository.findQuestionsByUserId(userId, new HistoryPageRequest(1, 20)))
+                .thenReturn(new HistoryPage<>(List.of(), 1, 20, 0));
+
+        useCase.execute(1, 20);
+        verify(historyRepository).findQuestionsByUserId(userId, new HistoryPageRequest(1, 20));
+        assertThatThrownBy(() -> useCase.execute(0, 51)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void doesNotListAnswersForAQuestionOwnedByAnotherUser() {
+        UUID userId = UUID.randomUUID();
+        UUID questionId = UUID.randomUUID();
+        when(requestContextProvider.getRequestContext()).thenReturn(new RequestContext(userId, "user@example.com", List.of()));
+        when(historyRepository.findQuestionByIdAndUserId(questionId, userId)).thenReturn(java.util.Optional.empty());
+        var useCase = new ListHistoryAnswersUseCase(historyRepository, requestContextProvider, new HistoryProperties(20, 50));
+
+        assertThatThrownBy(() -> useCase.execute(questionId, 0, 20)).isInstanceOf(EntityNotFoundException.class);
+    }
+}


### PR DESCRIPTION
This pull request introduces a complete, user-scoped API for reading persisted question and answer history, along with significant improvements to workflow documentation and configuration. The main changes include new endpoints for listing and retrieving historical questions and answers, updates to documentation and Postman collections, and new configuration options for history pagination.

**History API implementation and documentation:**

* Added new endpoints under `/history/**` for listing questions, retrieving question metadata, listing answers for a question, and fetching immutable answer snapshots. These endpoints are user-scoped and require JWT authentication. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L251-R265) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R236-R239) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L302-R312) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L293-R299); `docs/postman/Kairos.postman_collection.json` [[5]](diffhunk://#diff-f954d424aa1bb142aef08d146b2becc7e24e92f8787de7d878e45e9f4fda0c6bR123-R151) [[6]](diffhunk://#diff-f954d424aa1bb142aef08d146b2becc7e24e92f8787de7d878e45e9f4fda0c6bL19-R21)
* Implemented `GetHistoryQuestionUseCase` and `GetHistoryAnswerUseCase` application services to enforce user scoping and encapsulate retrieval logic. [[1]](diffhunk://#diff-b72ac415a44b547626ed9c76d46997f5a2e4d86285fabf3e3b61bec3d2d01e70R1-R25) [[2]](diffhunk://#diff-37ee7fd0d04a13c3057b104d3a50ebd979c7330986e02f081f21261d9aed6c58R1-R25)

**Configuration and settings:**

* Introduced configuration properties for history pagination: `history.default-page-size` and `history.max-page-size`, with corresponding environment variables. (`docs/configuration.md` [[1]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R70-R72) [[2]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R92-R93); `README.md` [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R236-R239)

**Workflow and process documentation:**

* Updated `AGENTS.md` and `docs/ai/issue-workflow.md` to require disciplined branch and commit practices, including explicit instructions for branch creation, atomic commits, and reporting of uncommitted files. The workflow now mandates working on feature branches and provides detailed steps for preflight, validation, and delivery. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R5-R15) [[2]](diffhunk://#diff-786ac7146d9f7f07e1f8427a76d587a5a10b45f30843810678d5bd75fc0b802dL9-R48) [[3]](diffhunk://#diff-786ac7146d9f7f07e1f8427a76d587a5a10b45f30843810678d5bd75fc0b802dL41-R99) [[4]](diffhunk://#diff-786ac7146d9f7f07e1f8427a76d587a5a10b45f30843810678d5bd75fc0b802dL88-R126)

**API and Postman collection updates:**

* Extended the Postman collection to include history endpoints, parameterization for `questionId` and `answerId`, and new tests for history retrieval. [[1]](diffhunk://#diff-f954d424aa1bb142aef08d146b2becc7e24e92f8787de7d878e45e9f4fda0c6bL19-R21) [[2]](diffhunk://#diff-f954d424aa1bb142aef08d146b2becc7e24e92f8787de7d878e45e9f4fda0c6bR123-R151)

**Other documentation improvements:**

* Updated the API and README to clarify the behavior of `/sources/search` with `questionId`, and removed the history API from the "remaining gaps" section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L210-R210) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L456)

These changes together provide a robust, user-friendly way to access and manage historical retrieval data, while ensuring disciplined engineering workflow and clear configuration.